### PR TITLE
Add cost per kwh and min support for charging stations.

### DIFF
--- a/lib/teslamate_web/live/charge_live/cost.html.heex
+++ b/lib/teslamate_web/live/charge_live/cost.html.heex
@@ -109,13 +109,13 @@
             <%= select f, :mode, [
                   {gettext("Total"), :total},
                   {gettext("Per kWh"), :per_kwh},
-                  {gettext("Per Minute"), :per_minute}
+                  {gettext("Per Minute"), :per_minute},
+                  {gettext("Per kWh/Minute (semicolon separated values"), :per_kwh_and_minute}
             ] %>
           </span>
         </p>
         <p class="control is-expanded">
           <%= text_input f, :cost, class: "input",
-                                   type: :number, inputmode: :decimal, step: 0.01,
                                    placeholder: gettext("Enter charge cost"), autofocus: true %>
         </p>
         <p class="help is-danger"><%= error_tag(f, :cost) %></p>

--- a/test/teslamate_web/live/charge_cost_live_test.exs
+++ b/test/teslamate_web/live/charge_cost_live_test.exs
@@ -310,6 +310,36 @@ defmodule TeslaMateWeb.ChargeLive.CostTest do
       assert ["1.50"] = html |> Floki.find("#charging_process_cost") |> Floki.attribute("value")
       assert %ChargingProcess{cost: decimal("1.50")} = Repo.get(ChargingProcess, id)
     end
+
+    test "allows to enter the cost per kWh Minute", %{conn: conn} do
+      %ChargingProcess{id: id} =
+        charging_process_fixture(car_fixture(), %{
+          cost: nil,
+          charge_energy_added: 7,
+          charge_energy_used: 10,
+          duration_min: 60
+        })
+
+      assert {:ok, view, html} = live(conn, "/charge-cost/#{id}")
+
+      assert [] =
+               html
+               |> Floki.parse_document!()
+               |> Floki.find("#charging_process_cost")
+               |> Floki.attribute("value")
+
+      html =
+        render_submit(view, :save, %{
+          charging_process: %{cost: "0.19;0.01", mode: "per_kwh_and_minute"}
+        })
+        |> Floki.parse_document!()
+
+      assert "Total" =
+               html |> Floki.find("#charging_process_mode option[selected]") |> Floki.text()
+
+      assert ["2.50"] = html |> Floki.find("#charging_process_cost") |> Floki.attribute("value")
+      assert %ChargingProcess{cost: decimal("2.50")} = Repo.get(ChargingProcess, id)
+    end
   end
 
   describe "back button" do


### PR DESCRIPTION
Some EMSP charges per kwh and per minutes for charging stations.
I added the ability to set the price per kwh and per minute when defining the cost.
I'm also adding the cost per kwh per minute in the geofence page configuration.