### PR TITLE
sync meta theme-color with header background color

### DIFF
--- a/lib/teslamate_web/templates/layout/root.html.heex
+++ b/lib/teslamate_web/templates/layout/root.html.heex
@@ -14,7 +14,7 @@
     <link rel="shortcut icon" href="/favicon.ico?v=5AB53N3ALo">
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#363636">
     <%= csrf_meta_tag() %>
     <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
   </head>


### PR DESCRIPTION
The theme-color meta tag suggests the color for the status bar in iOS.
REF: [MDN theme-color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color)
Before:
![before](https://user-images.githubusercontent.com/8411962/183444617-5450ca0c-1007-404c-be7b-edf8d1b2db8f.png)
After:
![after](https://user-images.githubusercontent.com/8411962/183444706-3c472499-8298-489b-a8f6-4f14678cab35.png)

