### PR TITLE
Correction of template error in home_assistant.md

### DIFF
--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -395,7 +395,7 @@ tesla_location:
       unit_of_measurement: ft
       icon_template: mdi:image-filter-hdr
       value_template: >
-       {{ (states('sensor.tesla_elevation') | float * 3.2808 ) | round(2) }}
+       {{ (states('sensor.tesla_elevation') | float * 3.2808) | round(2) }}
 ```
 
 ### binary_sensor.yaml (binary_sensor: section of configuration.yaml)


### PR DESCRIPTION
Template tesla_elevation_ft contained an extra space after 3.2808 which caused the value cannot be calculated correctly.