### PR TITLE
Add `charge_rate` to MQTT broker

### DIFF
--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -45,7 +45,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
 
   @always_published ~w(charge_energy_added charger_actual_current charger_phases
                        charger_power charger_voltage scheduled_charging_start_time
-                       time_to_full_charge shift_state geofence trim_badging)a
+                       time_to_full_charge shift_state geofence trim_badging
+                       charge_rate)a
 
   def handle_info(%Summary{} = summary, state) do
     summary

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -9,7 +9,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     car display_name state since healthy latitude longitude heading battery_level usable_battery_level
     ideal_battery_range_km est_battery_range_km rated_battery_range_km charge_energy_added
     speed outside_temp inside_temp is_climate_on is_preconditioning locked sentry_mode
-    plugged_in scheduled_charging_start_time charge_limit_soc charger_power windows_open doors_open
+    plugged_in scheduled_charging_start_time charge_limit_soc charger_power charge_rate windows_open doors_open
     odometer shift_state charge_port_door_open time_to_full_charge charger_phases
     charger_actual_current charger_voltage version update_available update_version is_user_present geofence
     model trim_badging exterior_color wheel_type spoiler_type trunk_open frunk_open elevation power
@@ -87,6 +87,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       charge_current_request_max: charge(vehicle, :charge_current_request_max),
       charge_energy_added: charge(vehicle, :charge_energy_added),
       charge_limit_soc: charge(vehicle, :charge_limit_soc),
+      charge_rate: charge(vehicle, :charge_rate),
       charge_port_door_open: charge(vehicle, :charge_port_door_open),
       charger_actual_current: charge(vehicle, :charger_actual_current),
       charger_phases: charge(vehicle, :charger_phases),

--- a/website/docs/integrations/mqtt.md
+++ b/website/docs/integrations/mqtt.md
@@ -58,6 +58,7 @@ Vehicle data will be published to the following topics:
 | `teslamate/cars/$car_id/plugged_in`                    | true                 | If car is currently plugged into a charger                                            |
 | `teslamate/cars/$car_id/charge_energy_added`           | 5.06                 | Last added energy in kWh                                                              |
 | `teslamate/cars/$car_id/charge_limit_soc`              | 90                   | Charge Limit Configured in Percentage                                                 |
+| `teslamate/cars/$car_id/charge_rate`                   | 0.0                  | Charge rate in km per hour                                                           |
 | `teslamate/cars/$car_id/charge_port_door_open`         | true                 | Indicates if the charger door is open                                                 |
 | `teslamate/cars/$car_id/charger_actual_current`        | 2.05                 | Current amperage supplied by charger                                                  |
 | `teslamate/cars/$car_id/charger_phases`                | 3                    | Number of charger power phases (1-3)                                                  |


### PR DESCRIPTION
I'm switching from the Home Assistant Tesla integration to TeslaMate. I had a dashboard where I displayed the `charge_rate`. This was the only value I was missing in the mqtt topics from TeslaMate.

I was wondering if there was a reason why it was not exported? It is covered by the vehicle state api call:
https://github.com/adriankumpf/teslamate/blob/7a9c6b9ad1b2b03f424f46f652a53b831df73697/lib/tesla_api/vehicle/state.ex#L38

I'd love to see this added.