### PR TITLE
Switch to alexandra-trackmap plugin

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -4,7 +4,7 @@ ENV GF_ANALYTICS_REPORTING_ENABLED=FALSE \
     GF_AUTH_ANONYMOUS_ENABLED=false \
     GF_AUTH_BASIC_ENABLED=false \
     GF_PATHS_PLUGINS="/var/lib/grafana-plugins" \
-    GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel,natel-plotly-panel \
+    GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=natel-discrete-panel,alexandra-trackmap-panel,panodata-map-panel,natel-plotly-panel \
     GF_SECURITY_ADMIN_PASSWORD=admin \
     GF_SECURITY_ADMIN_USER=admin \
     GF_SECURITY_ALLOW_EMBEDDING=true \
@@ -20,7 +20,7 @@ RUN mkdir -p "$GF_PATHS_PLUGINS" && \
 
 USER grafana
 
-RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install pr0ps-trackmap-panel 2.1.4 && \
+RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/alexandrainst/alexandra-trackmap-panel/archive/b0582bd5722191dae1a3dede9cd0acfe599bf84d.zip plugins install alexandra-trackmap-panel \
     grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install natel-plotly-panel 0.0.7 && \
     grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/panodata/panodata-map-panel/releases/download/0.16.0/panodata-map-panel-0.16.0.zip plugins install grafana-worldmap-panel-ng
 

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p "$GF_PATHS_PLUGINS" && \
 
 USER grafana
 
-RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/alexandrainst/alexandra-trackmap-panel/archive/b0582bd5722191dae1a3dede9cd0acfe599bf84d.zip plugins install alexandra-trackmap-panel \
+RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/alexandrainst/alexandra-trackmap-panel/archive/refs/tags/v2.5.0.zip plugins install alexandra-trackmap-panel \
     grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install natel-plotly-panel 0.0.7 && \
     grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/panodata/panodata-map-panel/releases/download/0.16.0/panodata-map-panel-0.16.0.zip plugins install grafana-worldmap-panel-ng
 

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p "$GF_PATHS_PLUGINS" && \
 
 USER grafana
 
-RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/alexandrainst/alexandra-trackmap-panel/archive/refs/tags/v2.5.0.zip plugins install alexandra-trackmap-panel \
+RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/alexandrainst/alexandra-trackmap-panel/releases/download/v2.5.1/alexandra-trackmap-panel-v2.5.1.zip plugins install alexandra-trackmap-panel \
     grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install natel-plotly-panel 0.0.7 && \
     grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/panodata/panodata-map-panel/releases/download/0.16.0/panodata-map-panel-0.16.0.zip plugins install grafana-worldmap-panel-ng
 

--- a/grafana/dashboards/internal/charge-details.json
+++ b/grafana/dashboards/internal/charge-details.json
@@ -21,7 +21,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "iteration": 1656106965302,
+  "iteration": 1691400000000,
   "links": [
     {
       "icon": "dashboard",
@@ -434,7 +434,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "format": "table",
@@ -525,7 +525,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "format": "table",
@@ -617,7 +617,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "format": "table",
@@ -651,9 +651,8 @@
       "type": "stat"
     },
     {
-      "autoZoom": true,
       "datasource": "TeslaMate",
-      "defaultLayer": "OpenStreetMap",
+      "description": "",
       "gridPos": {
         "h": 15,
         "w": 7,
@@ -661,12 +660,75 @@
         "y": 5
       },
       "id": 4,
-      "lineColor": "red",
       "links": [],
       "maxDataPoints": 500,
-      "pointColor": "royalblue",
-      "scrollWheelZoom": false,
-      "showLayerChanger": true,
+      "options": {
+        "ant": {
+          "color": "dark-red",
+          "colorOverridesByLabel": [],
+          "delay": 650,
+          "hardwareAccelerated": true,
+          "labelName": "",
+          "paused": false,
+          "pulseColor": "super-light-red",
+          "reverse": false,
+          "weight": 3
+        },
+        "coordinates": {
+          "customLatitudeColumnName": "",
+          "customLongitudeColumnName": ""
+        },
+        "discardZeroOrNull": true,
+        "displayHoverMarker": false,
+        "heat": {
+          "maxValue": 1
+        },
+        "hex": {
+          "colorRangeFrom": "#f7fbff",
+          "colorRangeTo": "#ff0000",
+          "opacity": 0.6,
+          "radiusRangeFrom": 5,
+          "radiusRangeTo": 12
+        },
+        "hoverMarker": {
+          "color": "white",
+          "fillColor": "royalblue",
+          "fillOpacity": 1,
+          "radius": 7,
+          "weight": 2
+        },
+        "map": {
+          "centerLatitude": 56.17203,
+          "centerLongitude": 10.1865203,
+          "centerMethod": "first",
+          "tileAttribution": "&copy <a href=\"http://osm.org/copyright\">OpenStreetMap</a> contributors",
+          "tileSubdomains": [
+            "a",
+            "b",
+            "c"
+          ],
+          "tileUrlSchema": "https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png",
+          "useBoundsInQuery": false,
+          "zoom": 10,
+          "zoomToDataBounds": true
+        },
+        "marker": {
+          "alwaysShowTooltips": false,
+          "defaultHtml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"25px\" height=\"25px\" viewBox=\"0 0 25 25\" version=\"1.1\"><g id=\"surface1\"><path style=\" stroke:none;fill-rule:nonzero;fill:rgb(100%,50%,50%);fill-opacity:0.8;\" d=\"M 12.515625 0 L 12.480469 0 C 8.164062 0 4.652344 3.511719 4.652344 7.828125 C 4.652344 10.65625 5.941406 14.386719 8.480469 18.921875 C 10.363281 22.285156 12.273438 24.859375 12.292969 24.882812 C 12.347656 24.957031 12.429688 24.996094 12.519531 24.996094 C 12.523438 24.996094 12.523438 24.996094 12.527344 24.996094 C 12.617188 24.996094 12.703125 24.949219 12.753906 24.871094 C 12.773438 24.84375 14.667969 21.980469 16.539062 18.476562 C 19.066406 13.75 20.347656 10.164062 20.347656 7.828125 C 20.347656 3.511719 16.832031 0 12.515625 0 Z M 16.128906 8.019531 C 16.128906 10.019531 14.5 11.648438 12.5 11.648438 C 10.496094 11.648438 8.867188 10.019531 8.867188 8.019531 C 8.867188 6.015625 10.496094 4.386719 12.5 4.386719 C 14.5 4.386719 16.128906 6.015625 16.128906 8.019531 Z M 16.128906 8.019531 \"/></g></svg>",
+          "iconOffset": "",
+          "labelName": "",
+          "markerHtmlByLabel": [],
+          "popupOffset": "",
+          "showOnlyLastMarker": false,
+          "size": 40,
+          "sizeLast": 40,
+          "tooltipOffset": "",
+          "useHTMLForMarkers": false,
+          "useSecondaryIconForAllMarkers": false,
+          "useSecondaryIconForLastMarker": false
+        },
+        "viewType": "marker"
+      },
       "targets": [
         {
           "alias": "",
@@ -675,37 +737,8 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\t$__time(date),\n\tunnest(ARRAY[latitude, latitude]) AS latitude\nFROM\n\tcharging_processes c\n\tJOIN positions p ON c.position_id = p.id\nWHERE\n\t$__timeFilter(date)\n\tAND c.car_id = $car_id;",
+          "rawSql": "SELECT\n\t$__time(date),\n\tlatitude,\n\tlongitude,\n\tcharge_energy_used AS intensity,\n\tcharge_energy_used AS tooltip\nFROM\n\tcharging_processes c\n\tJOIN positions p ON c.position_id = p.id\nWHERE\n\t$__timeFilter(date)\n\tAND c.car_id = $car_id;",
           "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "timeColumn": "time",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        },
-        {
-          "alias": "",
-          "datasource": "TeslaMate",
-          "format": "time_series",
-          "group": [],
-          "hide": false,
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n\t$__time(date),\n\tunnest(ARRAY[longitude, longitude]) AS longitude\nFROM\n\tcharging_processes c\n\tJOIN positions p ON c.position_id = p.id\nWHERE\n\t$__timeFilter(date)\n\tAND c.car_id = $car_id;",
-          "refId": "B",
           "select": [
             [
               {
@@ -726,7 +759,7 @@
           ]
         }
       ],
-      "type": "pr0ps-trackmap-panel"
+      "type": "alexandra-trackmap-panel"
     },
     {
       "datasource": "TeslaMate",
@@ -1098,6 +1131,6 @@
   "timezone": "",
   "title": "Charge Details",
   "uid": "BHhxFeZRz",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/grafana/dashboards/internal/drive-details.json
+++ b/grafana/dashboards/internal/drive-details.json
@@ -22,7 +22,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "iteration": 1658136653681,
+  "iteration": 1691400000000,
   "links": [
     {
       "icon": "dashboard",
@@ -334,7 +334,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "alias": "",
@@ -763,9 +763,7 @@
       "type": "stat"
     },
     {
-      "autoZoom": true,
       "datasource": "TeslaMate",
-      "defaultLayer": "OpenStreetMap",
       "gridPos": {
         "h": 27,
         "w": 12,
@@ -773,12 +771,77 @@
         "y": 4
       },
       "id": 4,
-      "lineColor": "red",
       "links": [],
       "maxDataPoints": 50000,
-      "pointColor": "royalblue",
-      "scrollWheelZoom": false,
-      "showLayerChanger": true,
+      "options": {
+        "ant": {
+          "color": "dark-red",
+          "colorOverridesByLabel": [],
+          "delay": 600,
+          "hardwareAccelerated": true,
+          "labelName": "",
+          "paused": false,
+          "pulseColor": "super-light-red",
+          "reverse": false,
+          "weight": 3
+        },
+        "coordinates": {
+          "customLatitudeColumnName": "",
+          "customLongitudeColumnName": ""
+        },
+        "discardZeroOrNull": true,
+        "displayHoverMarker": true,
+        "heat": {
+          "maxValue": 1
+        },
+        "hex": {
+          "colorRangeFrom": "#f7fbff",
+          "colorRangeTo": "#ff0000",
+          "opacity": 0.6,
+          "radiusRangeFrom": 5,
+          "radiusRangeTo": 12
+        },
+        "hoverMarker": {
+          "color": "white",
+          "fillColor": "royalblue",
+          "fillOpacity": 1,
+          "radius": 7,
+          "weight": 2
+        },
+        "map": {
+          "centerLatitude": 56.17203,
+          "centerLongitude": 10.1865203,
+          "centerMethod": "first",
+          "tileAttribution": "&copy <a href=\"http://osm.org/copyright\">OpenStreetMap</a> contributors",
+          "tileSubdomains": [
+            "a",
+            "b",
+            "c"
+          ],
+          "tileUrlSchema": "https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png",
+          "useBoundsInQuery": false,
+          "useCenterFromFirstPos": false,
+          "useCenterFromLastPos": false,
+          "zoom": 10,
+          "zoomToDataBounds": true
+        },
+        "marker": {
+          "alwaysShowTooltips": false,
+          "defaultHtml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"25px\" height=\"25px\" viewBox=\"0 0 25 25\" version=\"1.1\"><g id=\"surface1\"><path style=\" stroke:none;fill-rule:nonzero;fill:rgb(100%,50%,50%);fill-opacity:0.8;\" d=\"M 12.515625 0 L 12.480469 0 C 8.164062 0 4.652344 3.511719 4.652344 7.828125 C 4.652344 10.65625 5.941406 14.386719 8.480469 18.921875 C 10.363281 22.285156 12.273438 24.859375 12.292969 24.882812 C 12.347656 24.957031 12.429688 24.996094 12.519531 24.996094 C 12.523438 24.996094 12.523438 24.996094 12.527344 24.996094 C 12.617188 24.996094 12.703125 24.949219 12.753906 24.871094 C 12.773438 24.84375 14.667969 21.980469 16.539062 18.476562 C 19.066406 13.75 20.347656 10.164062 20.347656 7.828125 C 20.347656 3.511719 16.832031 0 12.515625 0 Z M 16.128906 8.019531 C 16.128906 10.019531 14.5 11.648438 12.5 11.648438 C 10.496094 11.648438 8.867188 10.019531 8.867188 8.019531 C 8.867188 6.015625 10.496094 4.386719 12.5 4.386719 C 14.5 4.386719 16.128906 6.015625 16.128906 8.019531 Z M 16.128906 8.019531 \"/></g></svg>",
+          "iconOffset": "",
+          "labelName": "",
+          "markerHtmlByLabel": [],
+          "popupOffset": "",
+          "showOnlyLastMarker": false,
+          "size": 25,
+          "sizeLast": 25,
+          "tooltipOffset": "",
+          "useHTMLForMarkers": false,
+          "useSecondaryIconForAllMarkers": false,
+          "useSecondaryIconForLastMarker": false
+        },
+        "viewType": "ant"
+      },
       "targets": [
         {
           "alias": "",
@@ -796,79 +859,8 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__time(date),\n   latitude\nFROM positions\nWHERE \n  car_id = $car_id AND \n  $__timeFilter(date)\nORDER BY \n  date ASC",
+          "rawSql": "SELECT\n  $__time(date),\n   latitude,\n   longitude,\n   power AS intensity\nFROM positions\nWHERE \n  car_id = $car_id AND \n  $__timeFilter(date)\nORDER BY \n  date ASC",
           "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "lat"
-                ],
-                "type": "column"
-              },
-              {
-                "params": [
-                  "avg"
-                ],
-                "type": "aggregate"
-              },
-              {
-                "params": [
-                  "lat"
-                ],
-                "type": "alias"
-              }
-            ],
-            [
-              {
-                "params": [
-                  "lng"
-                ],
-                "type": "column"
-              },
-              {
-                "params": [
-                  "avg"
-                ],
-                "type": "aggregate"
-              },
-              {
-                "params": [
-                  "lat"
-                ],
-                "type": "alias"
-              }
-            ]
-          ],
-          "table": "pos",
-          "timeColumn": "Datum",
-          "timeColumnType": "datetime",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        },
-        {
-          "alias": "",
-          "datasource": "TeslaMate",
-          "format": "time_series",
-          "group": [
-            {
-              "params": [
-                "$__interval",
-                "none"
-              ],
-              "type": "time"
-            }
-          ],
-          "hide": false,
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n  $__time(date),\n  longitude\nFROM positions\nWHERE \n  car_id = $car_id AND \n  $__timeFilter(date)\nORDER BY \n  date ASC",
-          "refId": "B",
           "select": [
             [
               {
@@ -924,7 +916,7 @@
         }
       ],
       "title": "Map",
-      "type": "pr0ps-trackmap-panel"
+      "type": "alexandra-trackmap-panel"
     },
     {
       "datasource": "TeslaMate",
@@ -1134,7 +1126,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "alias": "",
@@ -1288,7 +1280,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "datasource": "TeslaMate",
@@ -1548,7 +1540,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "datasource": "TeslaMate",
@@ -1998,6 +1990,6 @@
   "timezone": "",
   "title": "Drive Details",
   "uid": "zm7wN6Zgz",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/grafana/dashboards/trip.json
+++ b/grafana/dashboards/trip.json
@@ -22,7 +22,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "iteration": 1656104359102,
+  "iteration": 1691400000000,
   "links": [
     {
       "icon": "doc",
@@ -67,9 +67,7 @@
       "type": "row"
     },
     {
-      "autoZoom": true,
       "datasource": "TeslaMate",
-      "defaultLayer": "OpenStreetMap",
       "gridPos": {
         "h": 13,
         "w": 13,
@@ -77,11 +75,74 @@
         "y": 1
       },
       "id": 6,
-      "lineColor": "red",
       "maxDataPoints": 500,
-      "pointColor": "royalblue",
-      "scrollWheelZoom": false,
-      "showLayerChanger": true,
+      "options": {
+        "ant": {
+          "color": "dark-red",
+          "colorOverridesByLabel": [],
+          "delay": 650,
+          "hardwareAccelerated": true,
+          "labelName": "",
+          "paused": false,
+          "pulseColor": "super-light-red",
+          "reverse": false,
+          "weight": 3
+        },
+        "coordinates": {
+          "customLatitudeColumnName": "",
+          "customLongitudeColumnName": ""
+        },
+        "discardZeroOrNull": true,
+        "displayHoverMarker": false,
+        "heat": {
+          "maxValue": 1
+        },
+        "hex": {
+          "colorRangeFrom": "#f7fbff",
+          "colorRangeTo": "#ff0000",
+          "opacity": 0.6,
+          "radiusRangeFrom": 5,
+          "radiusRangeTo": 12
+        },
+        "hoverMarker": {
+          "color": "rgb(255, 255, 255)",
+          "fillColor": "rgb(65, 105, 225)",
+          "fillOpacity": 1,
+          "radius": 7,
+          "weight": 2
+        },
+        "map": {
+          "centerLatitude": 56.17203,
+          "centerLongitude": 10.1865203,
+          "centerMethod": "first",
+          "tileAttribution": "&copy <a href=\"http://osm.org/copyright\">OpenStreetMap</a> contributors",
+          "tileSubdomains": [
+            "a",
+            "b",
+            "c"
+          ],
+          "tileUrlSchema": "https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png",
+          "useBoundsInQuery": false,
+          "zoom": 10,
+          "zoomToDataBounds": true
+        },
+        "marker": {
+          "alwaysShowTooltips": false,
+          "defaultHtml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"25px\" height=\"25px\" viewBox=\"0 0 25 25\" version=\"1.1\"><g id=\"surface1\"><path style=\" stroke:none;fill-rule:nonzero;fill:rgb(100%,50%,50%);fill-opacity:0.8;\" d=\"M 12.515625 0 L 12.480469 0 C 8.164062 0 4.652344 3.511719 4.652344 7.828125 C 4.652344 10.65625 5.941406 14.386719 8.480469 18.921875 C 10.363281 22.285156 12.273438 24.859375 12.292969 24.882812 C 12.347656 24.957031 12.429688 24.996094 12.519531 24.996094 C 12.523438 24.996094 12.523438 24.996094 12.527344 24.996094 C 12.617188 24.996094 12.703125 24.949219 12.753906 24.871094 C 12.773438 24.84375 14.667969 21.980469 16.539062 18.476562 C 19.066406 13.75 20.347656 10.164062 20.347656 7.828125 C 20.347656 3.511719 16.832031 0 12.515625 0 Z M 16.128906 8.019531 C 16.128906 10.019531 14.5 11.648438 12.5 11.648438 C 10.496094 11.648438 8.867188 10.019531 8.867188 8.019531 C 8.867188 6.015625 10.496094 4.386719 12.5 4.386719 C 14.5 4.386719 16.128906 6.015625 16.128906 8.019531 Z M 16.128906 8.019531 \"/></g></svg>",
+          "iconOffset": "",
+          "labelName": "",
+          "markerHtmlByLabel": [],
+          "popupOffset": "",
+          "showOnlyLastMarker": false,
+          "size": 25,
+          "sizeLast": 25,
+          "tooltipOffset": "",
+          "useHTMLForMarkers": false,
+          "useSecondaryIconForAllMarkers": false,
+          "useSecondaryIconForLastMarker": false
+        },
+        "viewType": "ant"
+      },
       "targets": [
         {
           "datasource": "TeslaMate",
@@ -89,38 +150,8 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\t$__timeGroup(date, '5s') AS time,\n\tavg(latitude) AS lat\nFROM\n\tpositions\nWHERE\n  car_id = $car_id AND\n\t$__timeFilter(date)\nGROUP BY\n\t1\nORDER BY\n\t1 ASC",
+          "rawSql": "SELECT\n\t$__timeGroup(date, '5s') AS time,\n\tavg(latitude) AS lat,\n\tavg(longitude) as lon\nFROM\n\tpositions\nWHERE\n  car_id = $car_id AND\n\t$__timeFilter(date)\nGROUP BY\n\t1\nORDER BY\n\t1 ASC",
           "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "latitude"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "table": "addresses",
-          "timeColumn": "inserted_at",
-          "timeColumnType": "timestamp",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        },
-        {
-          "datasource": "TeslaMate",
-          "format": "time_series",
-          "group": [],
-          "hide": false,
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n\t$__timeGroup(date, '5s') AS time,\n\tavg(longitude) AS lng\nFROM\n\tpositions\nWHERE\n  car_id = $car_id AND\n\t$__timeFilter(date)\nGROUP BY\n\t1\nORDER BY\n\t1 ASC",
-          "refId": "B",
           "select": [
             [
               {
@@ -145,7 +176,7 @@
       ],
       "transformations": [],
       "transparent": true,
-      "type": "pr0ps-trackmap-panel"
+      "type": "alexandra-trackmap-panel"
     },
     {
       "datasource": "TeslaMate",
@@ -226,7 +257,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "format": "table",
@@ -510,7 +541,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "format": "table",
@@ -622,7 +653,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "format": "table",
@@ -737,7 +768,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "format": "table",
@@ -851,7 +882,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "format": "table",
@@ -942,7 +973,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "format": "table",
@@ -1026,7 +1057,7 @@
         },
         "showUnfilled": false
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "format": "table",
@@ -1551,7 +1582,7 @@
           }
         ]
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "alias": "",
@@ -2046,7 +2077,7 @@
           }
         ]
       },
-      "pluginVersion": "8.5.4",
+      "pluginVersion": "8.5.26",
       "targets": [
         {
           "datasource": "TeslaMate",
@@ -2627,6 +2658,6 @@
   "timezone": "",
   "title": "Trip",
   "uid": "FkUpJpQZk",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/grafana/dashboards/visited.json
+++ b/grafana/dashboards/visited.json
@@ -21,7 +21,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "iteration": 1642780400001,
+  "iteration": 1691400000000,
   "links": [
     {
       "icon": "dashboard",
@@ -59,9 +59,7 @@
       "type": "row"
     },
     {
-      "autoZoom": true,
       "datasource": "TeslaMate",
-      "defaultLayer": "OpenStreetMap",
       "gridPos": {
         "h": 21,
         "w": 24,
@@ -69,12 +67,75 @@
         "y": 1
       },
       "id": 2,
-      "lineColor": "red",
       "links": [],
       "maxDataPoints": 10000000,
-      "pointColor": "royalblue",
-      "scrollWheelZoom": false,
-      "showLayerChanger": true,
+      "options": {
+        "ant": {
+          "color": "dark-red",
+          "colorOverridesByLabel": [],
+          "delay": 650,
+          "hardwareAccelerated": true,
+          "labelName": "",
+          "paused": false,
+          "pulseColor": "super-light-red",
+          "reverse": false,
+          "weight": 3
+        },
+        "coordinates": {
+          "customLatitudeColumnName": "",
+          "customLongitudeColumnName": ""
+        },
+        "discardZeroOrNull": true,
+        "displayHoverMarker": false,
+        "heat": {
+          "maxValue": 1
+        },
+        "hex": {
+          "colorRangeFrom": "#ffeeee",
+          "colorRangeTo": "#bf0000",
+          "opacity": 0.5,
+          "radiusRangeFrom": 2,
+          "radiusRangeTo": 12
+        },
+        "hoverMarker": {
+          "color": "white",
+          "fillColor": "royalblue",
+          "fillOpacity": 1,
+          "radius": 7,
+          "weight": 2
+        },
+        "map": {
+          "centerLatitude": 56.17203,
+          "centerLongitude": 10.1865203,
+          "centerMethod": "first",
+          "tileAttribution": "&copy <a href=\"http://osm.org/copyright\">OpenStreetMap</a> contributors",
+          "tileSubdomains": [
+            "a",
+            "b",
+            "c"
+          ],
+          "tileUrlSchema": "https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png",
+          "useBoundsInQuery": false,
+          "zoom": 10,
+          "zoomToDataBounds": true
+        },
+        "marker": {
+          "alwaysShowTooltips": false,
+          "defaultHtml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"25px\" height=\"25px\" viewBox=\"0 0 25 25\" version=\"1.1\"><g id=\"surface1\"><path style=\" stroke:none;fill-rule:nonzero;fill:rgb(100%,50%,50%);fill-opacity:0.8;\" d=\"M 12.515625 0 L 12.480469 0 C 8.164062 0 4.652344 3.511719 4.652344 7.828125 C 4.652344 10.65625 5.941406 14.386719 8.480469 18.921875 C 10.363281 22.285156 12.273438 24.859375 12.292969 24.882812 C 12.347656 24.957031 12.429688 24.996094 12.519531 24.996094 C 12.523438 24.996094 12.523438 24.996094 12.527344 24.996094 C 12.617188 24.996094 12.703125 24.949219 12.753906 24.871094 C 12.773438 24.84375 14.667969 21.980469 16.539062 18.476562 C 19.066406 13.75 20.347656 10.164062 20.347656 7.828125 C 20.347656 3.511719 16.832031 0 12.515625 0 Z M 16.128906 8.019531 C 16.128906 10.019531 14.5 11.648438 12.5 11.648438 C 10.496094 11.648438 8.867188 10.019531 8.867188 8.019531 C 8.867188 6.015625 10.496094 4.386719 12.5 4.386719 C 14.5 4.386719 16.128906 6.015625 16.128906 8.019531 Z M 16.128906 8.019531 \"/></g></svg>",
+          "iconOffset": "",
+          "labelName": "",
+          "markerHtmlByLabel": [],
+          "popupOffset": "",
+          "showOnlyLastMarker": false,
+          "size": 25,
+          "sizeLast": 25,
+          "tooltipOffset": "",
+          "useHTMLForMarkers": false,
+          "useSecondaryIconForAllMarkers": false,
+          "useSecondaryIconForLastMarker": false
+        },
+        "viewType": "hex"
+      },
       "targets": [
         {
           "datasource": "TeslaMate",
@@ -82,38 +143,8 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tto_timestamp(floor((extract('epoch' FROM date) / 60)) * 60) AT TIME ZONE 'UTC' AS time,\n\tavg(latitude) AS lat\nFROM\n\tpositions\nWHERE\n  car_id = $car_id AND\n\t$__timeFilter(date)\nGROUP BY\n\t1\nORDER BY\n\t1 ASC",
+          "rawSql": "SELECT\n\tto_timestamp(floor((extract('epoch' FROM date) / 60)) * 60) AT TIME ZONE 'UTC' AS time,\n\tavg(latitude) AS lat,\n\tavg(longitude) AS lon\nFROM\n\tpositions\nWHERE\n  car_id = $car_id AND\n\t$__timeFilter(date)\nGROUP BY\n\t1\nORDER BY\n\t1 ASC",
           "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "id"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "table": "charging",
-          "timeColumn": "Datum",
-          "timeColumnType": "timestamp",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        },
-        {
-          "datasource": "TeslaMate",
-          "format": "time_series",
-          "group": [],
-          "hide": false,
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n\tto_timestamp(floor((extract('epoch' FROM date) / 60)) * 60) AT TIME ZONE 'UTC' AS time,\n\tavg(longitude) AS lng\nFROM\n\tpositions\nWHERE\n  car_id = $car_id AND\n\t$__timeFilter(date)\nGROUP BY\n\t1\nORDER BY\n\t1 ASC",
-          "refId": "B",
           "select": [
             [
               {
@@ -137,11 +168,11 @@
         }
       ],
       "title": "MAP",
-      "type": "pr0ps-trackmap-panel"
+      "type": "alexandra-trackmap-panel"
     }
   ],
   "refresh": false,
-  "schemaVersion": 34,
+  "schemaVersion": 36,
   "style": "dark",
   "tags": [
     "tesla"
@@ -231,6 +262,6 @@
   "datasource": "TeslaMate",
   "title": "Visited",
   "uid": "RG_DxSmgk",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/website/docs/installation/debian.md
+++ b/website/docs/installation/debian.md
@@ -54,7 +54,7 @@ Source: [grafana.com/docs/installation](https://grafana.com/docs/grafana/latest/
 Install the required Grafana plugins as well:
 
 ```bash
-sudo grafana-cli plugins install pr0ps-trackmap-panel 2.1.2
+sudo grafana-cli --pluginUrl https://github.com/alexandrainst/alexandra-trackmap-panel/archive/b0582bd5722191dae1a3dede9cd0acfe599bf84d.zip plugins install alexandra-trackmap-panel
 sudo grafana-cli plugins install natel-plotly-panel 0.0.7
 sudo grafana-cli --pluginUrl https://github.com/panodata/panodata-map-panel/releases/download/0.16.0/panodata-map-panel-0.16.0.zip plugins install grafana-worldmap-panel-ng
 sudo systemctl restart grafana-server


### PR DESCRIPTION
This PR switches away from the dated pr0ps-trackmap-panel to alexandra-trackmap-panel plugin. The pr0ps-trackmap-panel is written in AngularJS which is deprecated in later versions of grafana and will cease to work in the future. Alexandra-trackmap-panel has instead a more modern stack (Typescript & React) which is recommended to be used in Grafana.

Teslamate's Grafana Map panels in Drive details, Charge details, Trip and Visited dashboards are converted to alexandra-trackmap with "sensible settings" that look nice and have decent performance.

In this PR alexandra-trackmap is configured with dark raster map background which goes along nicely with the default dark grafana theme. Other graphical features (such as ant-path to show the direction of the drive) are included as well.

<img width="735" alt="Dark TrackMap" src="https://github.com/adriankumpf/teslamate/assets/9271441/a1133e85-3948-4f2c-bb4c-e2488156e669">

n.b. Plugin upstream has not tagged new releases for a while which is why this pull request links to a direct commit hash in the upstream repository.