### PR TITLE
added tire low pressure icon to teslamate web

### DIFF
--- a/lib/tesla_api/vehicle/state.ex
+++ b/lib/tesla_api/vehicle/state.ex
@@ -302,7 +302,11 @@ defmodule TeslaApi.Vehicle.State do
       :tpms_pressure_fl,
       :tpms_pressure_fr,
       :tpms_pressure_rl,
-      :tpms_pressure_rr
+      :tpms_pressure_rr,
+      :tpms_soft_warning_fl,
+      :tpms_soft_warning_fr,
+      :tpms_soft_warning_rl,
+      :tpms_soft_warning_rr
     ]
 
     defmodule SoftwareUpdate do
@@ -366,7 +370,11 @@ defmodule TeslaApi.Vehicle.State do
         tpms_pressure_fl: vehicle_state["tpms_pressure_fl"],
         tpms_pressure_fr: vehicle_state["tpms_pressure_fr"],
         tpms_pressure_rl: vehicle_state["tpms_pressure_rl"],
-        tpms_pressure_rr: vehicle_state["tpms_pressure_rr"]
+        tpms_pressure_rr: vehicle_state["tpms_pressure_rr"],
+        tpms_soft_warning_fl: vehicle_state["tpms_soft_warning_fl"],
+        tpms_soft_warning_fr: vehicle_state["tpms_soft_warning_fr"],
+        tpms_soft_warning_rl: vehicle_state["tpms_soft_warning_rl"],
+        tpms_soft_warning_rr: vehicle_state["tpms_soft_warning_rr"]
       }
     end
   end

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -14,6 +14,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     charger_actual_current charger_voltage version update_available update_version is_user_present geofence
     model trim_badging exterior_color wheel_type spoiler_type trunk_open frunk_open elevation power
     charge_current_request charge_current_request_max tpms_pressure_fl tpms_pressure_fr tpms_pressure_rl tpms_pressure_rr
+    tpms_soft_warning_fl tpms_soft_warning_fr tpms_soft_warning_rl tpms_soft_warning_rr
   )a
 
   def into(nil, %{state: :start, healthy?: healthy?, car: car}) do
@@ -122,7 +123,11 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       tpms_pressure_fl: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_fl]),
       tpms_pressure_fr: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_fr]),
       tpms_pressure_rl: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_rl]),
-      tpms_pressure_rr: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_rr])
+      tpms_pressure_rr: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_rr]),
+      tpms_soft_warning_fl: get_in_struct(vehicle, [:vehicle_state, :tpms_soft_warning_fl]),
+      tpms_soft_warning_fr: get_in_struct(vehicle, [:vehicle_state, :tpms_soft_warning_fr]),
+      tpms_soft_warning_rl: get_in_struct(vehicle, [:vehicle_state, :tpms_soft_warning_rl]),
+      tpms_soft_warning_rr: get_in_struct(vehicle, [:vehicle_state, :tpms_soft_warning_rr])
     }
   end
 

--- a/lib/teslamate_web/live/car_live/summary.html.heex
+++ b/lib/teslamate_web/live/car_live/summary.html.heex
@@ -84,6 +84,35 @@
           <span class="mdi mdi-gift-outline"></span>
         </span>
       <% end %>
+      <%= unless is_nil(@summary.tpms_soft_warning_fl) or is_nil(@summary.tpms_soft_warning_fr) or is_nil(@summary.tpms_soft_warning_rl) or is_nil(@summary.tpms_soft_warning_rr) do %>
+        <%= if @summary.tpms_soft_warning_fl or @summary.tpms_soft_warning_fr or @summary.tpms_soft_warning_rl or @summary.tpms_soft_warning_rr do %>
+            <span class="icon has-text-grey-dark has-tooltip-top has-tooltip-left-mobile"
+                  data-tooltip={
+                    gettext(
+                      "Low tire pressure, check (%{tire_low}) tire",
+                      %{tire_low:
+                        Enum.filter([
+                          {:fl, @summary.tpms_soft_warning_fl},
+                          {:fr, @summary.tpms_soft_warning_fr},
+                          {:rl, @summary.tpms_soft_warning_rl},
+                          {:rr, @summary.tpms_soft_warning_rr}
+                        ], fn {_tire, pressure} -> pressure end)
+                        |> Enum.map(fn
+                          {:fl, true} -> "Front left"
+                          {:fr, true} -> "Front right"
+                          {:rl, true} -> "Rear left"
+                          {:rr, true} -> "Rear right"
+                          _ -> nil
+                        end)
+                        |> Enum.filter(&(&1 != nil))
+                        |> Enum.join(", ")
+                      }
+                    )
+                  }>
+              <span class="mdi mdi-car-tire-alert"></span>
+            </span>
+        <% end %>
+      <% end %>
       <%= if @summary.healthy == false do %>
         <span class="icon has-text-danger has-tooltip-top has-tooltip-left-mobile" data-tooltip={gettext "Health check failed"}>
           <span class="mdi mdi-alert-box"></span>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -10,22 +10,22 @@
 msgid ""
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:104
+#: lib/teslamate_web/live/car_live/summary.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:237
+#: lib/teslamate_web/live/car_live/summary.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "Speed"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:229
+#: lib/teslamate_web/live/car_live/summary.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "State of Charge"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:165
+#: lib/teslamate_web/live/car_live/summary.html.heex:194
 #, elixir-autogen, elixir-format
 msgid "Charged"
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:180
+#: lib/teslamate_web/live/car_live/summary.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Scheduled Charging"
 msgstr ""
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Plugged In"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:189
+#: lib/teslamate_web/live/car_live/summary.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Charge Limit"
 msgstr ""
@@ -226,22 +226,22 @@ msgstr ""
 msgid "Driver present"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:307
+#: lib/teslamate_web/live/car_live/summary.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "cancel sleep attempt"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:302
+#: lib/teslamate_web/live/car_live/summary.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "try to sleep"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:152
+#: lib/teslamate_web/live/car_live/summary.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Range (est.)"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:107
+#: lib/teslamate_web/live/car_live/summary.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr ""
@@ -256,12 +256,12 @@ msgstr ""
 msgid "Vehicle must be locked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:133
+#: lib/teslamate_web/live/car_live/summary.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Range (rated)"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:171
+#: lib/teslamate_web/live/car_live/summary.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Charger Power"
 msgstr ""
@@ -286,7 +286,7 @@ msgstr ""
 msgid "rated"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:132
+#: lib/teslamate_web/live/car_live/summary.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "Range (ideal)"
 msgstr ""
@@ -311,23 +311,23 @@ msgstr ""
 msgid "Delete '%{geo_fence}'?"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:262
+#: lib/teslamate_web/live/car_live/summary.html.heex:291
 #, elixir-autogen, elixir-format
 msgid "Inside Temperature"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:250
+#: lib/teslamate_web/live/car_live/summary.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "Outside Temperature"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:287
+#: lib/teslamate_web/live/car_live/summary.html.heex:316
 #: lib/teslamate_web/live/settings_live/index.html.heex:283
 #, elixir-autogen, elixir-format
 msgid "Version"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:88
+#: lib/teslamate_web/live/car_live/summary.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Health check failed"
 msgstr ""
@@ -337,7 +337,7 @@ msgstr ""
 msgid "Unlocked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:119
+#: lib/teslamate_web/live/car_live/summary.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Remaining Time"
 msgstr ""
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Reduced Battery Range"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:222
+#: lib/teslamate_web/live/car_live/summary.html.heex:251
 #, elixir-autogen, elixir-format
 msgid "≈ %{range} at 100%"
 msgstr ""
@@ -523,7 +523,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:275
+#: lib/teslamate_web/live/car_live/summary.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Mileage"
 msgstr ""
@@ -633,4 +633,9 @@ msgstr ""
 #: lib/teslamate_web/live/settings_live/index.html.heex:228
 #, elixir-autogen, elixir-format
 msgid "Tire Pressure"
+msgstr ""
+
+#: lib/teslamate_web/live/car_live/summary.html.heex:91
+#, elixir-autogen, elixir-format
+msgid "Low tire pressure, check (%{tire_low}) tire"
 msgstr ""

--- a/website/docs/integrations/mqtt.md
+++ b/website/docs/integrations/mqtt.md
@@ -71,6 +71,10 @@ Vehicle data will be published to the following topics:
 | `teslamate/cars/$car_id/tpms_pressure_fr`              | 2.8                  | Tire pressure measure in BAR, front right tire                                        |
 | `teslamate/cars/$car_id/tpms_pressure_rl`              | 2.9                  | Tire pressure measure in BAR, rear left tire                                          |
 | `teslamate/cars/$car_id/tpms_pressure_rr`              | 2.8                  | Tire pressure measure in BAR, rear right tire                                         |
+| `teslamate/cars/$car_id/tpms_soft_warning_fl`          | true                 | Indicates if the Tire pressure measure is soft warning, front left tire               |
+| `teslamate/cars/$car_id/tpms_soft_warning_fr`          | false                | Indicates if the Tire pressure measure is soft warning, front right tire              |                          |
+| `teslamate/cars/$car_id/tpms_soft_warning_rl`          | false                | Indicates if the Tire pressure measure is soft warning, rear left tire                |                          |
+| `teslamate/cars/$car_id/tpms_soft_warning_rr`          | false                | Indicates if the Tire pressure measure is soft warning, rear right tire               |     
 
 :::note
 `$car_id` usually starts at 1


### PR DESCRIPTION
Added tire low pressure warnings to teslamate web.
It uses the warning from Tesla API. 

sync fork as failed 

For example:
<img width="254" alt="tesla_api" src="https://github.com/adriankumpf/teslamate/assets/45952578/605c5b7c-348f-4b8e-a55b-325fefd8193f">

teslamate web
<img width="436" alt="teslamate_web" src="https://github.com/adriankumpf/teslamate/assets/45952578/e6d75f87-a30b-4ec3-81b9-375372d73e42">

