### PR TITLE
WIP: CI Build PR images on GHCR

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -1,0 +1,70 @@
+name: "Build"
+description: "Build images"
+inputs:
+  docker_password:
+    description: "Docker password"
+    required: true
+  repository_owner:
+    description: "Repository owner"
+    required: true
+    default: "teslamate-org"
+  repository:
+    description: "Repo owner and name (repo_owner/repo_name)"
+    required: true
+    default: "teslamate"
+  github_token:
+    description: "GitHub Token"
+    required: true
+  labels:
+    description: "Labels added on metadata"
+    required: false
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY_IMAGE }}
+        labels: |
+          {{ inputs.labels }}
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker Hub
+      if: inputs.docker_password != ''
+      uses: docker/login-action@v3.0.0
+      with:
+        username: teslamate
+        password: ${{ inputs.docker_password }}
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3.0.0
+      with:
+        registry: ghcr.io
+        username: ${{ inputs.repository_owner }}
+        password: ${{ inputs.github_token }}
+    - name: Build and push by digest
+      id: build
+      uses: docker/build-push-action@v5.0.0
+      with:
+        context: .
+        platforms: ${{ matrix.platform }}
+        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        cache-from: type=registry,ref=ghcr.io/${{ inputs.repository }}:buildcache-${{ matrix.cache_id }}
+        cache-to: type=registry,ref=ghcr.io/${{ inputs.repository }}:buildcache-${{ matrix.cache_id }},mode=max
+        outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+    - name: Export digest
+      shell: bash
+      run: |
+        mkdir -p /tmp/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "/tmp/digests/${digest#sha256:}"
+        ls -l /tmp/digests/
+    - name: Upload digest
+      uses: actions/upload-artifact@v3
+      with:
+        name: digests
+        path: /tmp/digests/*
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/actions/grafana/action.yml
+++ b/.github/actions/grafana/action.yml
@@ -1,0 +1,37 @@
+name: "Grafana"
+description: "Grafana images"
+inputs:
+  tags:
+    description: "Tags"
+    required: false
+    default: ""
+  labels:
+    description: "Labels"
+    required: true
+  image:
+    description: "Image target"
+    required: true
+    default: "teslamate/grafana"
+runs:
+  using: "composite"
+  steps:
+    - name: Docker meta
+      id: docker_meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.image }}
+        tags: ${{ inputs.tags }}
+        labels: ${{ inputs.labels }}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build and push
+      uses: docker/build-push-action@v5.0.0
+      with:
+        context: grafana
+        push: true
+        platforms: linux/amd64,linux/arm/v7,linux/arm64
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/actions/merge/action.yml
+++ b/.github/actions/merge/action.yml
@@ -1,0 +1,40 @@
+name: "Merge"
+description: "Merge images"
+inputs:
+  tags:
+    description: "Tags"
+    required: false
+    default: ""
+  image:
+    description: "Image target"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download digests
+      uses: actions/download-artifact@v3
+      with:
+        name: digests
+        path: /tmp/digests
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.image }}
+        tags: ${{ inputs.tags }}
+
+    - name: Create manifest list and push
+      working-directory: /tmp/digests
+      shell: bash
+      run: |
+        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+    - name: Inspect image
+      shell: bash
+      run: |
+        docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -31,118 +31,52 @@ jobs:
             cache_id: arm64
 
     runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
+      - name: Buildx
+        uses: ./.github/actions/build
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3.0.0
-        with:
-          username: teslamate
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v5.0.0
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          cache-from: type=registry,ref=ghcr.io/teslamate-org/teslamate:buildcache-${{ matrix.cache_id }}
-          cache-to: type=registry,ref=ghcr.io/teslamate-org/teslamate:buildcache-${{ matrix.cache_id }},mode=max
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-      - name: Upload digest
-        uses: actions/upload-artifact@v3
-        with:
-          name: digests
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
+          docker_password: ${{ secrets.DOCKER_PASSWORD }}
+          repository_owner: ${{ github.repository_owner }}
+          repository: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   teslamate_merge:
     runs-on: ubuntu-latest
     needs:
       - teslamate_build
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@v3
-        with:
-          name: digests
-          path: /tmp/digests
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-            type=schedule,pattern=edge
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=edge
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3.0.0
         with:
           username: teslamate
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
 
+      - uses: ./.github/actions/merge
+        with:
+          image: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=schedule,pattern=edge
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=edge
   grafana:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Docker meta
-        id: docker_meta
-        uses: docker/metadata-action@v5
+
+      - uses: ./.github/actions/grafana
         with:
-          images: teslamate/grafana
           tags: |
             type=edge
             type=schedule,pattern=edge
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
-        uses: docker/login-action@v3.0.0
-        with:
-          username: teslamate
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build and push
-        uses: docker/build-push-action@v5.0.0
-        with:
-          context: grafana
-          push: true
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,8 +2,14 @@ name: Elixir CI
 
 on:
   push:
+    paths:
+      - "**/*"
+      - "!.github/**" # Important: Exclude PRs related to .github from auto-run
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
+    paths:
+      - "**/*"
+      - "!.github/**" # Important: Exclude PRs related to .github from auto-run
 
 jobs:
   lint:
@@ -124,7 +130,7 @@ jobs:
     services:
       db:
         image: postgres:15
-        ports: [ "5432:5432" ]
+        ports: ["5432:5432"]
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/ghcr_build.yml
+++ b/.github/workflows/ghcr_build.yml
@@ -8,9 +8,9 @@ on:
       - "!.github/**"
   pull_request_target:
     branches: ["master"]
-    paths:
-      - "**/*"
-      - "!.github/**" # Important: Exclude PRs related to .github from auto-run
+#    paths:
+#      - "**/*"
+#      - "!.github/**" # Important: Exclude PRs related to .github from auto-run
 
 env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository }}

--- a/.github/workflows/ghcr_build.yml
+++ b/.github/workflows/ghcr_build.yml
@@ -1,0 +1,97 @@
+name: Build GHCR images
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "**/*"
+      - "!.github/**"
+  pull_request_target:
+    branches: ["master"]
+    paths:
+      - "**/*"
+      - "!.github/**" # Important: Exclude PRs related to .github from auto-run
+
+env:
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  teslamate_build:
+    name: Build images
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: "linux/amd64"
+            runs_on: "ubuntu-latest"
+            cache_id: amd64
+          - platform: "linux/amd64"
+            runs_on: "ubuntu-latest"
+            cache_id: amd64test            
+          - platform: "linux/amd64"
+            runs_on: "ubuntu-latest"
+            cache_id: amd64test2            
+#          - platform: "linux/arm/v7"
+#            runs_on: "buildjet-2vcpu-ubuntu-2204-arm"
+#            cache_id: arm
+#          - platform: "linux/arm64"
+#            runs_on: "buildjet-2vcpu-ubuntu-2204-arm"
+#            cache_id: arm64
+    runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Buildx
+        uses: ./.github/actions/build
+        with:
+          docker_password: ${{ secrets.DOCKER_PASSWORD }}
+          repository_owner: ${{ github.repository_owner }}
+          repository: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            org.opencontainers.image.version=${{ github.ref || github.ref_name }}
+
+  teslamate_merge:
+    name: Merge GHCR images
+    runs-on: ubuntu-latest
+    needs:
+      - teslamate_build
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge
+        id: merge
+        uses: ./.github/actions/merge
+        with:
+          image: ${{ env.REGISTRY_IMAGE }}
+
+  grafana:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/grafana
+        with:
+          image: ${{ env.REGISTRY_IMAGE }}/grafana
+          labels: |
+            org.opencontainers.image.version=${{ github.ref || github.ref_name }}

--- a/.github/workflows/ghcr_build.yml
+++ b/.github/workflows/ghcr_build.yml
@@ -7,7 +7,7 @@ on:
       - "**/*"
       - "!.github/**"
   pull_request_target:
-    branches: ["master"]
+#    branches: ["master"]
 #    paths:
 #      - "**/*"
 #      - "!.github/**" # Important: Exclude PRs related to .github from auto-run

--- a/.github/workflows/ghcr_purge.yml
+++ b/.github/workflows/ghcr_purge.yml
@@ -1,0 +1,35 @@
+name: Purge PR images
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  purge-pr-untagged:
+    name: Delete untagged images from ghcr.io
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/delete-package-versions@v4
+        with:
+          package-name: "teslamate"
+          package-type: "container"
+          min-versions-to-keep: 0
+          delete-only-untagged-versions: "true"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  purge-pr-package:
+    name: Delete image from ghcr.io
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: chipkent/action-cleanup-package@v1.0.1
+        with:
+          package-name: ${{ github.event.repository.name }}
+          tag: pr-${{ github.event.pull_request.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I modified the CI so that the PR images are build then pushed into the GitHub packages (GHCR).

This does not interfere with how current CI works with Docker Hub.

Functioning :
- When a PR is created or modified: the image is built on the GHCR from fork repo.
- When a branch is pushed: the image is built on the GHCR from main repo.
- When a PR is completed: the image is deleted in the fork repo. Additionally, untagged images are also deleted on this fork repo.

Once this PR is merged, each new / updated PR will trigger CI on the fork repo.
- Users will then see all these images on their fork. Eg: [https://github.com/jlestel/teslamate/pkgs/container/teslamate](https://github.com/jlestel/teslamate/pkgs/container/teslamate)


If necessary, anyone can then modify their docker-compose to use a PR image (eg: `ghcr.io/jlestel/teslamate:master`) for testing this PR instead of `teslamate/teslamate:latest`.