### PR TITLE
Display headers on receiving 429 response

### DIFF
--- a/lib/tesla_api/vehicle.ex
+++ b/lib/tesla_api/vehicle.ex
@@ -102,6 +102,11 @@ defmodule TeslaApi.Vehicle do
       %Tesla.Env{status: 408, body: %{"error" => "vehicle unavailable:" <> _}} = env ->
         {:error, %Error{reason: :vehicle_unavailable, env: env}}
 
+      %Tesla.Env{status: 429, headers: headers} = env ->
+        IO.inspect(headers)
+        IO.inspect(headers["Retry-After"])
+        {:error, %Error{reason: :unknown, env: env}}
+
       %Tesla.Env{status: 504} = env ->
         {:error, %Error{reason: :timeout, env: env}}
 


### PR DESCRIPTION
Basic code to try to see what the headers are when we get a 429 (rate limited) response from Tesla.

Not tested;  I am not getting 429 responses at present.

I imagine that for a working version we will need to convert the "Retry-After" value from a string into an integer.