### PR TITLE
Grafana update to 10.1.2

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,3 +1,6 @@
+# Ensure selecting a tag that is available for ARMv7
+# https://hub.docker.com/r/grafana/grafana/tags
+# https://grafana.com/blog/2023/09/29/grafana-and-grafana-enterprise-updates-for-armv6-and-armv7-will-be-temporarily-paused/
 FROM grafana/grafana:10.1.2
 
 ENV GF_ANALYTICS_REPORTING_ENABLED=false \

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,28 +1,17 @@
-FROM grafana/grafana:9.5.10
+FROM grafana/grafana:10.1.2
 
-ENV GF_ANALYTICS_REPORTING_ENABLED=FALSE \
+ENV GF_ANALYTICS_REPORTING_ENABLED=false \
     GF_AUTH_ANONYMOUS_ENABLED=false \
     GF_AUTH_BASIC_ENABLED=false \
-    GF_PATHS_PLUGINS="/var/lib/grafana-plugins" \
-    GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel,natel-plotly-panel \
     GF_SECURITY_ADMIN_PASSWORD=admin \
     GF_SECURITY_ADMIN_USER=admin \
     GF_SECURITY_ALLOW_EMBEDDING=true \
     GF_SECURITY_DISABLE_GRAVATAR=true \
+    GF_SECURITY_ANGULAR_SUPPORT_ENABLED=false \
     GF_USERS_ALLOW_SIGN_UP=false \
-    GF_ANALYTICS_REPORTING_ENABLED=FALSE \
     DATABASE_PORT=5432
 
-USER root
-
-RUN mkdir -p "$GF_PATHS_PLUGINS" && \
-    chown -R grafana "$GF_PATHS_PLUGINS"
-
 USER grafana
-
-RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install pr0ps-trackmap-panel 2.1.4 && \
-    grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install natel-plotly-panel 0.0.7 && \
-    grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/panodata/panodata-map-panel/releases/download/0.16.0/panodata-map-panel-0.16.0.zip plugins install grafana-worldmap-panel-ng
 
 COPY logo.svg /usr/share/grafana/public/img/grafana_icon.svg
 COPY favicon.png /usr/share/grafana/public/img/fav32.png


### PR DESCRIPTION
- requires the following PRs to be merged first!
  - #3439
  - #3454

Updates Grafana and removes old Plugins - also disables Angular Support in Grafana, that way we can easily see if we're still using it somewhere