### PR TITLE
Run CI with PR sources

### DIFF
--- a/.github/workflows/ghcr_build.yml
+++ b/.github/workflows/ghcr_build.yml
@@ -8,7 +8,7 @@ on:
       - "!.github/**"
     branches: ["ci"]
   pull_request_target:
-    branches: ["master"]
+    branches: ["master", "ci"]
     paths:
       - "**/*"
       - "!.github/**" # Important: Exclude PRs related to .github from auto-run

--- a/.github/workflows/ghcr_build.yml
+++ b/.github/workflows/ghcr_build.yml
@@ -39,8 +39,14 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 10
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        if: ${{ github.event_name != 'pull_request_target' }}
+      - uses: actions/checkout@v4
+        if: ${{ github.event_name == 'pull_request_target' }}
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
       - name: Buildx
         uses: ./.github/actions/build
         with:
@@ -75,8 +81,13 @@ jobs:
   grafana:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        if: ${{ github.event_name != 'pull_request_target' }}
+      - uses: actions/checkout@v4
+        if: ${{ github.event_name == 'pull_request_target' }}
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3.0.0


### PR DESCRIPTION
In fact the pull_request_target event only plays the CI with the destination branch. This does not embed the changes made by the PR.

I modified the action to pull sources from the PR if necessary so that I can offer images per PR in the packages in this repo.

Besides, we could only trigger this pull_request_target when you set certain labels to control what is build.

PS: I added CI branch to the pull_request_target in order to test it on the CI branch.