### PR TITLE
Handle "Vehicle is offline" from stream

### DIFF
--- a/lib/tesla_api/stream.ex
+++ b/lib/tesla_api/stream.ex
@@ -152,7 +152,15 @@ defmodule TeslaApi.Stream do
 
       {:ok,
        %{"msg_type" => "data:error", "tag" => ^tag, "error_type" => "vehicle_error", "value" => v}} ->
-        Logger.error("Vehicle Error: #{v}")
+        case v do
+          "Vehicle is offline" ->
+            Logger.info("Streaming API: Vehicle offline")
+            state.receiver.(:vehicle_offline)
+
+          _ ->
+            Logger.error("Vehicle Error: #{v}")
+        end
+
         {:ok, state}
 
       {:ok, %{"msg_type" => "data:error", "tag" => ^tag, "error_type" => "client_error"} = msg} ->

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -526,6 +526,14 @@ defmodule TeslaMate.Vehicles.Vehicle do
     {:keep_state, %Data{data | stream_pid: pid}}
   end
 
+  def handle_event(:info, {:stream, msg}, _state, data)
+      when msg in [:vehicle_offline] do
+    Logger.info("Stream reports vehicle as offline … ", car_id: data.car.id)
+
+    {:next_state, :start, data,
+     [broadcast_fetch(false), {:next_event, :internal, {:update, {:offline, data.last_response}}}]}
+  end
+
   def handle_event(:info, {:stream, stream_data}, _state, data) do
     Logger.info("Received stream data: #{inspect(stream_data)}", car_id: data.car.id)
     :keep_state_and_data


### PR DESCRIPTION
Handle stream getting the message "Vehicle is offline" and change the state to offline in vehicle.

Also a part of PR #3262, but just trying to split it up a little.

It was a side quest aiming to fix that the stream keeps reporting offline but nobody cares.
After the schedule_fetch timeout it gets handled:
https://user-images.githubusercontent.com/25175069/213937306-f8ead633-72c0-4bac-afb9-1af59d913b39.png
(image taken from #3084)

Also added a test.