### PR TITLE
Fix Odometer_mi charger dashboard

### DIFF
--- a/grafana/dashboards/charges.json
+++ b/grafana/dashboards/charges.json
@@ -1354,6 +1354,6 @@
   "timezone": "",
   "title": "Charges",
   "uid": "TSmNYvRRk",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/grafana/dashboards/charges.json
+++ b/grafana/dashboards/charges.json
@@ -770,7 +770,7 @@
               },
               {
                 "id": "unit",
-                "value": "km"
+                "value": "mi"
               },
               {
                 "id": "decimals"


### PR DESCRIPTION
Odometer_mi override was set to km instead of mi in charges dashboard

should fix #3533 


(edited this is in codespaces so dunno if this would break updating it)

also added a version change to the dashboard don't know what is required to be updated or if a single change in the json breaks them
