### PR TITLE
Fix an issue when car is could enter sleep mode while dog mode is enabled

### DIFF
--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1081,7 +1081,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
           Logger.error(
             """
             Unexpected update status: #{software_update.status}
-
+            
             #{inspect(software_update, pretty: true)}
             """,
             car_id: data.car.id
@@ -1354,6 +1354,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {:keep_state, %Data{data | last_used: DateTime.utc_now()},
          [broadcast_summary(), schedule_fetch(30 * i, data)]}
 
+      {:error, :dogmode} ->
+        if suspend?, do: Logger.warning("Dog Mode is enabled ...", car_id: car.id)
+
+        {:keep_state, %Data{data | last_used: DateTime.utc_now()},
+         [broadcast_summary(), schedule_fetch(30 * i, data)]}
+
       {:error, :user_present} ->
         if suspend?, do: Logger.warning("User present ...", car_id: car.id)
 
@@ -1412,6 +1418,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
       {%Vehicle{climate_state: %Climate{is_preconditioning: true}}, _} ->
         {:error, :preconditioning}
+
+      {%Vehicle{climate_state: %Climate{climate_keeper_mode: "dog"}}, _} ->
+        {:error, :dogmode}
 
       {%Vehicle{vehicle_state: %VehicleState{sentry_mode: true}}, _} ->
         {:error, :sentry_mode}

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -14,7 +14,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     charger_actual_current charger_voltage version update_available update_version is_user_present geofence
     model trim_badging exterior_color wheel_type spoiler_type trunk_open frunk_open elevation power
     charge_current_request charge_current_request_max tpms_pressure_fl tpms_pressure_fr tpms_pressure_rl tpms_pressure_rr
-    tpms_soft_warning_fl tpms_soft_warning_fr tpms_soft_warning_rl tpms_soft_warning_rr
+    tpms_soft_warning_fl tpms_soft_warning_fr tpms_soft_warning_rl tpms_soft_warning_rr climate_keeper_mode
   )a
 
   def into(nil, %{state: :start, healthy?: healthy?, car: car}) do
@@ -106,6 +106,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       # Climate State
       is_climate_on: get_in_struct(vehicle, [:climate_state, :is_climate_on]),
       is_preconditioning: get_in_struct(vehicle, [:climate_state, :is_preconditioning]),
+      climate_keeper_mode: get_in_struct(vehicle, [:climate_state, :climate_keeper_mode]),
       outside_temp: get_in_struct(vehicle, [:climate_state, :outside_temp]),
       inside_temp: get_in_struct(vehicle, [:climate_state, :inside_temp]),
 

--- a/lib/teslamate_web/live/car_live/summary.ex
+++ b/lib/teslamate_web/live/car_live/summary.ex
@@ -136,6 +136,7 @@ defmodule TeslaMateWeb.CarLive.Summary do
   defp error_to_str(:trunk_open), do: gettext("Trunk is open")
   defp error_to_str(:sentry_mode), do: gettext("Sentry mode is enabled")
   defp error_to_str(:preconditioning), do: gettext("Preconditioning")
+  defp error_to_str(:dogmode), do: gettext("Dog mode is enabled")
   defp error_to_str(:user_present), do: gettext("Driver present")
   defp error_to_str(:downloading_update), do: gettext("Downloading update")
   defp error_to_str(:update_in_progress), do: gettext("Update in progress")

--- a/lib/teslamate_web/live/car_live/summary.html.heex
+++ b/lib/teslamate_web/live/car_live/summary.html.heex
@@ -44,6 +44,11 @@
           <span class="mdi mdi-air-conditioner"></span>
         </span>
       <% end %>
+      <%= if @summary.climate_keeper_mode == "dog" do %>
+        <span class="icon has-text-grey-dark has-tooltip-top has-tooltip-left-mobile" data-tooltip={gettext "Dog Mode"}>
+          <span class="mdi mdi-dog-side"></span>
+        </span>
+      <% end %>
       <%= if not is_nil(@summary.battery_level) and not is_nil(@summary.usable_battery_level) and @summary.battery_level - @summary.usable_battery_level > 2 do %>
         <span class="icon has-text-link has-tooltip-top has-tooltip-left-mobile" data-tooltip={gettext "Reduced Battery Range"}>
           <span class="mdi mdi-snowflake"></span>
@@ -327,7 +332,8 @@
           @summary.state == :online and
           !@summary.sentry_mode and
           !@summary.is_user_present and
-          !@summary.is_preconditioning ->
+          !@summary.is_preconditioning and
+           @summary.climate_keeper_mode == "dog" ->
             link gettext("try to sleep"), to: "#", phx_click: "suspend_logging",
                                           class: "button is-info is-small is-outlined is-fullwidth" <>
                                                    (if @loading, do: " is-loading", else: "")

--- a/test/teslamate/vehicles/vehicle/suspend_test.exs
+++ b/test/teslamate/vehicles/vehicle/suspend_test.exs
@@ -143,6 +143,39 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
   end
 
   @tag :capture_log
+  test "does not suspend if dog mode is active", %{test: name} do
+    not_suspendable =
+      online_event(
+        drive_state: %{timestamp: 0, latitude: 0.0, longitude: 0.0},
+        climate_state: %{climate_keeper_mode: "dog"}
+      )
+
+    events = [
+      {:ok, online_event()},
+      {:ok, not_suspendable}
+    ]
+
+    suspend_after_idle_ms = 10
+    suspend_ms = 100
+
+    :ok =
+      start_vehicle(name, events,
+        settings: %{
+          suspend_after_idle_min: round(suspend_after_idle_ms / 60),
+          suspend_min: suspend_ms
+        }
+      )
+
+    assert_receive {:start_state, car, :online, date: _}
+    assert_receive {ApiMock, {:stream, 1000, _}}
+    assert_receive {:insert_position, ^car, %{}}
+    assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
+    refute_receive _, round(suspend_ms * 0.5)
+
+    refute_receive _
+  end
+
+  @tag :capture_log
   test "does not suspend if user is present", %{test: name} do
     not_suspendable =
       online_event(


### PR DESCRIPTION
Fix an issue when car is could enter sleep mode while dog mode is enabled and also added dog icon that indicates if dog mode is activate.

<img width="379" alt="First" src="https://github.com/teslamate-org/teslamate/assets/45952578/253c7d25-71b2-4dfc-98d4-6222076bdad2">

when clicking on try sleep button

![second](https://github.com/teslamate-org/teslamate/assets/45952578/5cf040a0-4cab-488d-856f-a0abc390bc8d)

the current state when dog mode is active (1.28.1)

<img width="461" alt="thrid" src="https://github.com/teslamate-org/teslamate/assets/45952578/afb45ced-677a-4259-945b-a843c6471abf">


#3535 