### PR TITLE
Added expected finish charging localtime to teslamate site

### DIFF
--- a/lib/teslamate_web/live/car_live/summary.html.heex
+++ b/lib/teslamate_web/live/car_live/summary.html.heex
@@ -148,16 +148,26 @@
               end
             )%></td>
           </tr>
-          <%= if @summary.state == :charging and not is_nil(@summary.time_to_full_charge) do %>
-          <tr>
-            <td class="has-text-weight-medium"><%= gettext "Remaining Time" %></td>
-            <td><%=
+            <%= if @summary.state == :charging and not is_nil(@summary.time_to_full_charge) do %>
+            <%
+              current_time = DateTime.utc_now()
+              finish_time = DateTime.add(current_time, round(@summary.time_to_full_charge * 60 * 60))
+              formatted_finish_time = Timex.format!(finish_time, "%Y-%m-%d %H:%M:%S", :strftime)
+
+              remaining_time_text =
                 round(@summary.time_to_full_charge * 60 * 60)
                 |> Convert.sec_to_str()
                 |> Enum.reject(&String.ends_with?(&1, "s"))
-                |> Enum.join(", ")
-            %></td>
-          </tr>
+                |> Enum.join(", ")
+            %>
+            <tr>
+              <td class="has-text-weight-medium"><%= gettext "Remaining Time" %></td>
+              <td><%= remaining_time_text %></td>
+            </tr>
+            <tr>
+              <td class="has-text-weight-medium"><%= gettext "Expected Finish Time" %></td>
+              <td><%= formatted_finish_time %></td>
+            </tr>
           <% end %>
           <%= unless is_nil(@summary.ideal_battery_range_km) do %>
           <tr>

--- a/lib/teslamate_web/live/car_live/summary.html.heex
+++ b/lib/teslamate_web/live/car_live/summary.html.heex
@@ -148,26 +148,26 @@
               end
             )%></td>
           </tr>
-            <%= if @summary.state == :charging and not is_nil(@summary.time_to_full_charge) do %>
-            <%
-              current_time = DateTime.utc_now()
-              finish_time = DateTime.add(current_time, round(@summary.time_to_full_charge * 60 * 60))
-              formatted_finish_time = Timex.format!(finish_time, "%Y-%m-%d %H:%M:%S", :strftime)
+          <%= if @summary.state == :charging and not is_nil(@summary.time_to_full_charge) do %>
+          <%
+            current_time = DateTime.utc_now()
+            finish_time = DateTime.add(current_time, round(@summary.time_to_full_charge * 60 * 60))
+            formatted_finish_time = Timex.format!(finish_time, "%Y-%m-%d %H:%M:%S", :strftime)
 
-              remaining_time_text =
-                round(@summary.time_to_full_charge * 60 * 60)
-                |> Convert.sec_to_str()
-                |> Enum.reject(&String.ends_with?(&1, "s"))
-                |> Enum.join(", ")
-            %>
-            <tr>
-              <td class="has-text-weight-medium"><%= gettext "Remaining Time" %></td>
-              <td><%= remaining_time_text %></td>
-            </tr>
-            <tr>
-              <td class="has-text-weight-medium"><%= gettext "Expected Finish Time" %></td>
-              <td><%= formatted_finish_time %></td>
-            </tr>
+            remaining_time_text =
+              round(@summary.time_to_full_charge * 60 * 60)
+              |> Convert.sec_to_str()
+              |> Enum.reject(&String.ends_with?(&1, "s"))
+              |> Enum.join(", ")
+          %>
+          <tr>
+            <td class="has-text-weight-medium"><%= gettext "Remaining Time" %></td>
+            <td><%= remaining_time_text %></td>
+          </tr>
+          <tr>
+            <td class="has-text-weight-medium"><%= gettext "Expected Finish Time" %></td>
+            <td><%= formatted_finish_time %></td>
+          </tr>
           <% end %>
           <%= unless is_nil(@summary.ideal_battery_range_km) do %>
           <tr>

--- a/lib/teslamate_web/live/car_live/summary.html.heex
+++ b/lib/teslamate_web/live/car_live/summary.html.heex
@@ -153,16 +153,15 @@
             current_time = DateTime.utc_now()
             finish_time = DateTime.add(current_time, round(@summary.time_to_full_charge * 60 * 60))
             formatted_finish_time = Timex.format!(finish_time, "%Y-%m-%d %H:%M:%S", :strftime)
-
-            remaining_time_text =
-              round(@summary.time_to_full_charge * 60 * 60)
-              |> Convert.sec_to_str()
-              |> Enum.reject(&String.ends_with?(&1, "s"))
-              |> Enum.join(", ")
           %>
           <tr>
             <td class="has-text-weight-medium"><%= gettext "Remaining Time" %></td>
-            <td><%= remaining_time_text %></td>
+            <td><%=
+                round(@summary.time_to_full_charge * 60 * 60)
+                |> Convert.sec_to_str()
+                |> Enum.reject(&String.ends_with?(&1, "s"))
+                |> Enum.join(", ")
+            %></td>
           </tr>
           <tr>
             <td class="has-text-weight-medium"><%= gettext "Expected Finish Time" %></td>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -15,17 +15,17 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:281
+#: lib/teslamate_web/live/car_live/summary.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "Speed"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:273
+#: lib/teslamate_web/live/car_live/summary.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "State of Charge"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:209
+#: lib/teslamate_web/live/car_live/summary.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Charged"
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:224
+#: lib/teslamate_web/live/car_live/summary.html.heex:223
 #, elixir-autogen, elixir-format
 msgid "Scheduled Charging"
 msgstr ""
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Plugged In"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:233
+#: lib/teslamate_web/live/car_live/summary.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "Charge Limit"
 msgstr ""
@@ -226,17 +226,17 @@ msgstr ""
 msgid "Driver present"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:352
+#: lib/teslamate_web/live/car_live/summary.html.heex:351
 #, elixir-autogen, elixir-format
 msgid "cancel sleep attempt"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:347
+#: lib/teslamate_web/live/car_live/summary.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "try to sleep"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:196
+#: lib/teslamate_web/live/car_live/summary.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Range (est.)"
 msgstr ""
@@ -256,12 +256,12 @@ msgstr ""
 msgid "Vehicle must be locked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:177
+#: lib/teslamate_web/live/car_live/summary.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Range (rated)"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:215
+#: lib/teslamate_web/live/car_live/summary.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Charger Power"
 msgstr ""
@@ -286,7 +286,7 @@ msgstr ""
 msgid "rated"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:176
+#: lib/teslamate_web/live/car_live/summary.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Range (ideal)"
 msgstr ""
@@ -311,17 +311,17 @@ msgstr ""
 msgid "Delete '%{geo_fence}'?"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:306
+#: lib/teslamate_web/live/car_live/summary.html.heex:305
 #, elixir-autogen, elixir-format
 msgid "Inside Temperature"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:294
+#: lib/teslamate_web/live/car_live/summary.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Outside Temperature"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:331
+#: lib/teslamate_web/live/car_live/summary.html.heex:330
 #: lib/teslamate_web/live/settings_live/index.html.heex:283
 #, elixir-autogen, elixir-format
 msgid "Version"
@@ -337,7 +337,7 @@ msgstr ""
 msgid "Unlocked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:164
+#: lib/teslamate_web/live/car_live/summary.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Remaining Time"
 msgstr ""
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Reduced Battery Range"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:266
+#: lib/teslamate_web/live/car_live/summary.html.heex:265
 #, elixir-autogen, elixir-format
 msgid "≈ %{range} at 100%"
 msgstr ""
@@ -523,7 +523,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:319
+#: lib/teslamate_web/live/car_live/summary.html.heex:318
 #, elixir-autogen, elixir-format
 msgid "Mileage"
 msgstr ""
@@ -650,7 +650,7 @@ msgstr ""
 msgid "Dog mode is enabled"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:168
+#: lib/teslamate_web/live/car_live/summary.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Expected Finish Time"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -15,17 +15,17 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:271
+#: lib/teslamate_web/live/car_live/summary.html.heex:281
 #, elixir-autogen, elixir-format
 msgid "Speed"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:263
+#: lib/teslamate_web/live/car_live/summary.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "State of Charge"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:199
+#: lib/teslamate_web/live/car_live/summary.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Charged"
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:214
+#: lib/teslamate_web/live/car_live/summary.html.heex:224
 #, elixir-autogen, elixir-format
 msgid "Scheduled Charging"
 msgstr ""
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Plugged In"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:223
+#: lib/teslamate_web/live/car_live/summary.html.heex:233
 #, elixir-autogen, elixir-format
 msgid "Charge Limit"
 msgstr ""
@@ -226,17 +226,17 @@ msgstr ""
 msgid "Driver present"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:342
+#: lib/teslamate_web/live/car_live/summary.html.heex:352
 #, elixir-autogen, elixir-format
 msgid "cancel sleep attempt"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:337
+#: lib/teslamate_web/live/car_live/summary.html.heex:347
 #, elixir-autogen, elixir-format
 msgid "try to sleep"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:186
+#: lib/teslamate_web/live/car_live/summary.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Range (est.)"
 msgstr ""
@@ -256,12 +256,12 @@ msgstr ""
 msgid "Vehicle must be locked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:167
+#: lib/teslamate_web/live/car_live/summary.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "Range (rated)"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:205
+#: lib/teslamate_web/live/car_live/summary.html.heex:215
 #, elixir-autogen, elixir-format
 msgid "Charger Power"
 msgstr ""
@@ -286,7 +286,7 @@ msgstr ""
 msgid "rated"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:166
+#: lib/teslamate_web/live/car_live/summary.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Range (ideal)"
 msgstr ""
@@ -311,17 +311,17 @@ msgstr ""
 msgid "Delete '%{geo_fence}'?"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:296
+#: lib/teslamate_web/live/car_live/summary.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "Inside Temperature"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:284
+#: lib/teslamate_web/live/car_live/summary.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "Outside Temperature"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:321
+#: lib/teslamate_web/live/car_live/summary.html.heex:331
 #: lib/teslamate_web/live/settings_live/index.html.heex:283
 #, elixir-autogen, elixir-format
 msgid "Version"
@@ -337,7 +337,7 @@ msgstr ""
 msgid "Unlocked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:153
+#: lib/teslamate_web/live/car_live/summary.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Remaining Time"
 msgstr ""
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Reduced Battery Range"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:256
+#: lib/teslamate_web/live/car_live/summary.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "≈ %{range} at 100%"
 msgstr ""
@@ -523,7 +523,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:309
+#: lib/teslamate_web/live/car_live/summary.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "Mileage"
 msgstr ""
@@ -648,4 +648,9 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.ex:139
 #, elixir-autogen, elixir-format
 msgid "Dog mode is enabled"
+msgstr ""
+
+#: lib/teslamate_web/live/car_live/summary.html.heex:168
+#, elixir-autogen, elixir-format
+msgid "Expected Finish Time"
 msgstr ""


### PR DESCRIPTION
I've added the requested feature for displaying the expected finishing time of charging on the TeslaMate site, as per the discussion in [issue #3483](https://github.com/teslamate-org/teslamate/issues/3483).

Here's an image showcasing the update:

![image](https://github.com/teslamate-org/teslamate/assets/45952578/8418316d-186e-46a1-8dd0-323be733859d)
