### PR TITLE
Add navigation active route drive state data

### DIFF
--- a/lib/tesla_api/vehicle/state.ex
+++ b/lib/tesla_api/vehicle/state.ex
@@ -167,6 +167,13 @@ defmodule TeslaApi.Vehicle.State do
 
   defmodule Drive do
     defstruct [
+      :active_route_destination,
+      :active_route_energy_at_arrival,
+      :active_route_latitude,
+      :active_route_longitude,
+      :active_route_miles_to_arrival,
+      :active_route_minutes_to_arrival,
+      :active_route_traffic_minutes_delay,
       :gps_as_of,
       :heading,
       :latitude,
@@ -183,6 +190,13 @@ defmodule TeslaApi.Vehicle.State do
 
     def result(drive) when is_map(drive) do
       %__MODULE__{
+        active_route_destination: drive["active_route_destination"],
+        active_route_energy_at_arrival: drive["active_route_energy_at_arrival"],
+        active_route_latitude: drive["active_route_latitude"],
+        active_route_longitude: drive["active_route_longitude"],
+        active_route_miles_to_arrival: drive["active_route_miles_to_arrival"],
+        active_route_minutes_to_arrival: drive["active_route_minutes_to_arrival"],
+        active_route_traffic_minutes_delay: drive["active_route_traffic_minutes_delay"],
         gps_as_of: drive["gps_as_of"],
         heading: drive["heading"],
         latitude: drive["latitude"],


### PR DESCRIPTION
Addresses https://github.com/teslamate-org/teslamate/discussions/3250 

There are additional fields from the `drive_state` object that contain destination name and metadata if it is set in the vehicle routing.

```json
        "drive_state": {
            "active_route_destination": "Home",
            "active_route_energy_at_arrival": 73,
            "active_route_latitude": -1.123456,
            "active_route_longitude": 1.123456,
            "active_route_miles_to_arrival": 6.485299,
            "active_route_minutes_to_arrival": 23.466667,
            "active_route_traffic_minutes_delay": 0.0,
            "gps_as_of": 1686894025,
            "heading": 254,
            "latitude": -1.123456,
            "longitude": 1.123456,
```

Unfortunately I don't have the environment set up so I didn't test this but this matches the existing logic. I'm also hoping this automatically flows through the MQTT broker since the entire drive state is already sent.