### PR TITLE
Add stat panel for selected duration in drive details dashboard

### DIFF
--- a/grafana/dashboards/internal/drive-details.json
+++ b/grafana/dashboards/internal/drive-details.json
@@ -334,7 +334,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.5.4",
       "targets": [
         {
           "alias": "",
@@ -450,7 +449,6 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.6",
       "targets": [
         {
           "format": "table",
@@ -488,8 +486,82 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
           "decimals": 1,
-          "displayName": "Duration",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 3,
+        "x": 18,
+        "y": 0
+      },
+      "id": 34,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": "TeslaMate",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT ${__to:date:seconds} - ${__from:date:seconds}",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Selected duration",
+      "type": "stat"
+    },
+    {
+      "datasource": "TeslaMate",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
           "mappings": [
             {
               "options": {
@@ -516,8 +588,8 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 6,
-        "x": 18,
+        "w": 3,
+        "x": 21,
         "y": 0
       },
       "id": 14,
@@ -535,9 +607,9 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.6",
       "targets": [
         {
           "format": "table",
@@ -568,6 +640,7 @@
           ]
         }
       ],
+      "title": "Drive duration",
       "type": "stat"
     },
     {
@@ -623,7 +696,6 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.6",
       "targets": [
         {
           "format": "table",
@@ -729,7 +801,6 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.6",
       "targets": [
         {
           "format": "table",
@@ -1173,7 +1244,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.5.4",
       "targets": [
         {
           "alias": "",
@@ -1327,7 +1397,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.5.4",
       "targets": [
         {
           "datasource": "TeslaMate",
@@ -1587,7 +1656,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.5.4",
       "targets": [
         {
           "datasource": "TeslaMate",
@@ -1673,7 +1741,6 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.5.6",
       "targets": [
         {
           "format": "table",
@@ -1749,7 +1816,6 @@
         "text": {},
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.5.6",
       "targets": [
         {
           "datasource": "TeslaMate",


### PR DESCRIPTION
I sometimes want to compare actual driving time for two different routes between specific points on a drive, so I've added a "selected duration" stat panel that simply shows the number of minutes between the chosen from/to in grafana, e.g. in this screen I've selected a particular subsection of the drive to see how long it took.

Also removed some ancient pinned pluginVersions for panels. We're on at least 10.1 now, so it doesn't make sense to use those.

![Screenshot 2024-02-11 at 14 39 44](https://github.com/teslamate-org/teslamate/assets/153668/0179b1ac-65ca-4930-9877-b383a37f8bc0)
