### PR TITLE
Fix agressive switch to offline when stream gets offline message

### DIFF
--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -528,7 +528,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   def handle_event(:info, {:stream, msg}, _state, data)
       when msg in [:vehicle_offline] do
-    Logger.info("Stream reports vehicle as offline, fetching vehicle state ...",
+    Logger.warning("Stream reports vehicle as offline, fetching vehicle state ...",
       car_id: data.car.id
     )
 

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -528,10 +528,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   def handle_event(:info, {:stream, msg}, _state, data)
       when msg in [:vehicle_offline] do
-    Logger.info("Stream reports vehicle as offline … ", car_id: data.car.id)
+    Logger.info("Stream reports vehicle as offline, fetching vehicle state ...",
+      car_id: data.car.id
+    )
 
-    {:next_state, :start, data,
-     [broadcast_fetch(false), {:next_event, :internal, {:update, {:offline, data.last_response}}}]}
+    # fetch data right away and let the result decide the real state
+    {:keep_state_and_data, schedule_fetch(0, data)}
   end
 
   def handle_event(:info, {:stream, stream_data}, _state, data) do

--- a/test/teslamate/vehicles/vehicle/streaming_test.exs
+++ b/test/teslamate/vehicles/vehicle/streaming_test.exs
@@ -572,22 +572,10 @@ defmodule TeslaMate.Vehicles.Vehicle.StreamingTest do
   end
 
   describe "offline" do
-    test "go offline when stream get :vehicle_offline", %{test: name} do
-      me = self()
-
+    test "fetch state when stream get :vehicle_offline", %{test: name} do
       events = [
         {:ok, online_event()},
         {:ok, online_event()},
-        {:ok, online_event()},
-        fn ->
-          send(me, :continue?)
-
-          receive do
-            :continue -> {:ok, %TeslaApi.Vehicle{state: "offline"}}
-          after
-            5_000 -> raise "No :continue after 5s"
-          end
-        end,
         fn -> Process.sleep(10_000) end
       ]
 
@@ -601,16 +589,10 @@ defmodule TeslaMate.Vehicles.Vehicle.StreamingTest do
       assert_receive {ApiMock, {:stream, _eid, func}} when is_function(func)
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
 
-      send(name, {:stream, :vehicle_offline})
-
-      assert_receive :continue?
-      send(:"api_#{name}", :continue)
-
-      assert_receive {:start_state, _, :offline, _}
-      assert_receive {:"$websockex_cast", :disconnect}
-      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :offline}}}
-
-      refute_receive _
+      assert capture_log(@log_opts, fn ->
+               send(name, {:stream, :vehicle_offline})
+               refute_receive _
+             end) =~ "Stream reports vehicle as offline, fetching vehicle state ..."
     end
   end
 end


### PR DESCRIPTION
Initiated by #3658 

When stream got a message that the vehicle was offline, it switched directly to Start / :offline
This is to aggressive and does not reflect the true state of the vehicle

Now its changed to just fetch data right way and let the result handle the true state of the vehicle.