### PR TITLE
Typo on manually_fixing_data.mdx

### DIFF
--- a/website/docs/maintenance/manually_fixing_data.mdx
+++ b/website/docs/maintenance/manually_fixing_data.mdx
@@ -51,7 +51,7 @@ values={[
 
 ```bash
 docker compose exec teslamate bin/teslamate rpc \
-    "TeslaMate.Repo.get!(TeslaMate.Log.Drive, 9999) |> TeslaMate.Log.close_drive()"
+    "TeslaMate.Repo.get(TeslaMate.Log.Drive, 9999) |> TeslaMate.Log.close_drive()"
 ```
 
 </TabItem>
@@ -59,7 +59,7 @@ docker compose exec teslamate bin/teslamate rpc \
 
 ```bash
 docker compose exec teslamate bin/teslamate rpc \
-    "TeslaMate.Repo.get!(TeslaMate.Log.ChargingProcess, 9999) |> TeslaMate.Log.complete_charging_process()"
+    "TeslaMate.Repo.get(TeslaMate.Log.ChargingProcess, 9999) |> TeslaMate.Log.complete_charging_process()"
 ```
 
 </TabItem>


### PR DESCRIPTION
Here is the result with the current commands:
`bash: !: event not found`

I fixed the typo to get a better result:
`11:36:02.917 [info] GET https://nominatim.openstreetmap.org/reverse -> 200 (1383.440 ms)
11:36:03.049 [info] GET https://nominatim.openstreetmap.org/reverse -> 200 (129.275 ms)`