### PR TITLE
build: pin elixir image full version to elixir:1.16.1-otp-26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.16 AS builder
+FROM elixir:1.16.1-otp-26 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
closes #3730 