### PR TITLE
fix: permissions denied error when specifying user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     chown -R nonroot:nonroot .
 
 USER nonroot:nonroot
-COPY --chown=nonroot:nonroot --chmod=544 entrypoint.sh /
-COPY --from=builder --chown=nonroot:nonroot --chmod=544 /opt/built .
+COPY --chown=nonroot:nonroot --chmod=555 entrypoint.sh /
+COPY --from=builder --chown=nonroot:nonroot --chmod=555 /opt/built .
 RUN mkdir $SRTM_CACHE
 
 EXPOSE 4000


### PR DESCRIPTION
Fix `Permission denied` error when launching container with `user` variables reported in #3769.

Changes permissions so that content copied by _Dockerfile_ into `/opt/app` gets both readable and executable for owner, group and everyone.

fix #3769
rel #3740