### PR TITLE
Fix broken link from Docker page to upgrading page

### DIFF
--- a/website/docs/installation/docker.md
+++ b/website/docs/installation/docker.md
@@ -91,6 +91,6 @@ This setup is recommended only if you are running TeslaMate **on your home netwo
 2. Sign in with your Tesla Account
 3. The Grafana dashboards are available at [http://your-ip-address:3000](http://localhost:3000). Log in with the default user `admin` (initial password `admin`) and enter a secure password.
 
-## [Update](../upgrading.mdx)
+## Update
 
-To update the running TeslaMate configuration to the latest version, follow: [Upgrading to a new version](../maintenance/upgrading.mdx)
+To update the running TeslaMate configuration to the latest version, follow: [Upgrading to a new version](../upgrading.mdx)


### PR DESCRIPTION
I think this was broken in dbf23faa31d84f222c99dba9f5de52c69dd43afb.

Also remove link from header, seems redundant.