### PR TITLE
publish center_display_state to mqtt

### DIFF
--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -88,7 +88,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
     charger_actual_current charger_voltage version update_available update_version is_user_present
     model trim_badging exterior_color wheel_type spoiler_type trunk_open frunk_open elevation power
     charge_current_request charge_current_request_max tpms_pressure_fl tpms_pressure_fr tpms_pressure_rl tpms_pressure_rr
-    tpms_soft_warning_fl tpms_soft_warning_fr tpms_soft_warning_rl tpms_soft_warning_rr climate_keeper_mode
+    tpms_soft_warning_fl tpms_soft_warning_fr tpms_soft_warning_rl tpms_soft_warning_rr climate_keeper_mode center_display_state
   )a
 
   defp add_simple_values(map, %Summary{} = summary) do

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -17,6 +17,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     tpms_soft_warning_fl tpms_soft_warning_fr tpms_soft_warning_rl tpms_soft_warning_rr climate_keeper_mode
     active_route_destination active_route_latitude active_route_longitude active_route_energy_at_arrival
     active_route_miles_to_arrival active_route_minutes_to_arrival active_route_traffic_minutes_delay
+    center_display_state
   )a
 
   def into(nil, %{state: :start, healthy?: healthy?, car: car}) do
@@ -142,7 +143,8 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       tpms_soft_warning_fl: get_in_struct(vehicle, [:vehicle_state, :tpms_soft_warning_fl]),
       tpms_soft_warning_fr: get_in_struct(vehicle, [:vehicle_state, :tpms_soft_warning_fr]),
       tpms_soft_warning_rl: get_in_struct(vehicle, [:vehicle_state, :tpms_soft_warning_rl]),
-      tpms_soft_warning_rr: get_in_struct(vehicle, [:vehicle_state, :tpms_soft_warning_rr])
+      tpms_soft_warning_rr: get_in_struct(vehicle, [:vehicle_state, :tpms_soft_warning_rr]),
+      center_display_state: get_in_struct(vehicle, [:vehicle_state, :center_display_state])
     }
   end
 

--- a/website/docs/integrations/mqtt.md
+++ b/website/docs/integrations/mqtt.md
@@ -80,6 +80,7 @@ Vehicle data will be published to the following topics:
 | `teslamate/cars/$car_id/active_route_latitude`         | 35.278131                                    | DEPRECATED: Navigation destination latitude (or "nil")                                |
 | `teslamate/cars/$car_id/active_route_longitude`        | 29.744801                                    | DEPRECATED: Navigation destination longitude (or "nil")                               |
 | `teslamate/cars/$car_id/active_route`                  | _See below_                                  | Navigation details (json blob)                                                        |
+| `teslamate/cars/$car_id/center_display_state`          | 0                                            | Center Display State                                                                  |
 
 :::note
 `$car_id` usually starts at 1


### PR DESCRIPTION
I would love to have the ability to track the `center_display_state` from a published topic in mqtt.

BTW: Does something speak against publishing a `vehicle_state` topic with the full tesla json response? I would love to have something like that.