### PR TITLE
Tesla Tokens (Android) is no longer available. Use a new open-source …

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -8,7 +8,7 @@ sidebar_label: FAQ
 There are multiple apps available to securely generate access tokens yourself, for example:
 
 - [Auth app for Tesla (iOS, macOS)](https://apps.apple.com/us/app/auth-app-for-tesla/id1552058613)
-- [Tesla Tokens (Android)](https://play.google.com/store/apps/details?id=net.leveugle.teslatokens)
+- [Tesla Auth (Android)](https://github.com/mywind2020/TeslaAuth)
 - [Tesla Auth (macOS, Linux, Windows)](https://github.com/adriankumpf/tesla_auth)
 
 ## Why are no consumption values displayed in Grafana?


### PR DESCRIPTION
Tesla Tokens (Android) is no longer available. (#3830)
This is a new app for generate access tokens, and it is an open source project.
https://github.com/mywind2020/TeslaAuth