### PR TITLE
Fix errors from Timex.Timezone.local() during switchover to DST.

### DIFF
--- a/lib/teslamate_web/live/car_live/summary.html.heex
+++ b/lib/teslamate_web/live/car_live/summary.html.heex
@@ -214,8 +214,7 @@
             finish_time =
               Timex.add(current_time, Timex.Duration.from_hours(@summary.time_to_full_charge))
 
-            local_timezone = Timex.Timezone.local()
-            local_finish_time = Timex.Timezone.convert(finish_time, local_timezone)
+            local_finish_time = Timex.local(finish_time)
 
             formatted_finish_time =
               Timex.format!(local_finish_time, "%Y-%m-%d %H:%M:%S", :strftime) %>


### PR DESCRIPTION
During the hour of the switchover to DST at the end of March, errors like below were logged while the car was charging:
```
** (ArgumentError) time_zone_not_found
    (timex 3.7.11) lib/format/datetime/formatter.ex:55: Timex.Format.DateTime.Formatter.lformat!/4
    (teslamate 1.28.4) lib/teslamate_web/live/car_live/summary.html.heex:221: anonymous fn/2 in TeslaMateWeb.CarLive.Summary.render/1
    (phoenix_live_view 0.18.18) lib/phoenix_live_view/diff.ex:398: Phoenix.LiveView.Diff.traverse/7
    (phoenix_live_view 0.18.18) lib/phoenix_live_view/diff.ex:544: anonymous fn/4 in Phoenix.LiveView.Diff.traverse_dynamic/7
    (elixir 1.15.7) lib/enum.ex:2510: Enum."-reduce/3-lists^foldl/2-0-"/3
    (phoenix_live_view 0.18.18) lib/phoenix_live_view/diff.ex:373: Phoenix.LiveView.Diff.traverse/7
    (phoenix_live_view 0.18.18) lib/phoenix_live_view/diff.ex:139: Phoenix.LiveView.Diff.render/3
    (phoenix_live_view 0.18.18) lib/phoenix_live_view/channel.ex:833: Phoenix.LiveView.Channel.render_diff/3
Last message: %TeslaMate.Vehicles.Vehicle.Summary{car: %TeslaMate.Log.Car{__meta__: #Ecto.Schema.Metadata<:loaded, "cars">, id: 1, name: nil, efficiency: 0.15225, model: "3", trim_badging: "P74D", marketing_name: "LR AWD Performance", exterior_color: "DeepBlue", wheel_type: "Stiletto20DarkSquare", spoiler_type: "Passive", eid: <<redacted>>, vid: <<redacted>>, vin: "<<redacted>>", settings_id: 1, settings: %TeslaMate.Settings.CarSettings{__meta__: #Ecto.Schema.Metadata<:loaded, "car_settings">, id: 1, suspend_min: 21, suspend_after_idle_min: 15, req_not_unlocked: true, free_supercharging: false, use_streaming_api: true, car: #Ecto.Association.NotLoaded<association :car is not loaded>}, charging_processes: #Ecto.Association.NotLoaded<association :charging_processes is not loaded>, positions: #Ecto.Association.NotLoaded<association :positions is not loaded>, drives: #Ecto.Association.NotLoaded<association :drives is not loaded>, inserted_at: ~N[2020-03-05 00:16:49], updated_at: ~N[2023-02-17 00:29:21]}, display_name: "", state: :charging, since: ~U[2024-03-31 00:30:12.417247Z], healthy: true, latitude: <<redacted>>, longitude: <<redacted>>, heading: 283, battery_level: 38, charging_state: "Charging", usable_battery_level: 37, ideal_battery_range_km: 177.12, est_battery_range_km: 175.43, rated_battery_range_km: 177.12, charge_energy_added: 1.74, speed: nil, outside_temp: 12.5, inside_temp: 13.0, is_climate_on: false, is_preconditioning: false, locked: true, sentry_mode: false, plugged_in: true, scheduled_charging_start_time: ~U[2024-03-31 23:30:00Z], charge_limit_soc: 50, charger_power: 2, windows_open: false, doors_open: false, odometer: <<redacted>>, shift_state: nil, charge_port_door_open: true, time_to_full_charge: 3.92, charger_phases: 1, charger_actual_current: 10, charger_voltage: 237, version: "2024.8.7", update_available: false, update_version: "", is_user_present: false, geofence: %TeslaMate.Locations.GeoFence{__meta__: #Ecto.Schema.Metadata<:loaded, "geofences">, id: 1, name: "Home", latitude: nil, longitude: nil, radius: nil, billing_type: nil, cost_per_unit: nil, session_fee: nil, inserted_at: nil, ...}, model: "3", trim_badging: "P74D", exterior_color: "DeepBlue", wheel_type: "Stiletto20DarkSquare", spoiler_type: "Passive", trunk_open: false, frunk_open: false, elevation: 22, power: -2, charge_current_request: 10, ...}
2024-03-31 02:35:05.618 [error] GenServer #PID<0.20634.1> terminating
```
I've reported this as a bug in Timex at https://github.com/bitwalker/timex/issues/755 but the problem can be avoided in TeslaMate with the attached pull request.
