### PR TITLE
Statistics: fix temperature colors and column layout for Fahrenheit

### DIFF
--- a/grafana/dashboards/statistics.json
+++ b/grafana/dashboards/statistics.json
@@ -429,7 +429,34 @@
               {
                 "id": "unit",
                 "value": "fahrenheit"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "super-light-blue",
+                      "value": null
+                    },
+                    {
+                      "color": "super-light-green",
+                      "value": 50
+                    },
+                    {
+                      "color": "super-light-red",
+                      "value": 68
+                    }
+                  ]
+                }
               }
+
             ]
           },
           {
@@ -723,6 +750,7 @@
               "avg_cost_mi": 20,
               "avg_cost_kwh": 11,
               "avg_outside_temp_c": 5,
+              "avg_outside_temp_f": 5,
               "cnt": 6,
               "cnt_charges": 11,
               "cost_charges": 10,


### PR DESCRIPTION
Add the missing temperature color thresholds when using Fahrenheit
Use the same index value for the temperature column so the layout is the same with Fahrenheit or Celsius

![image](https://github.com/teslamate-org/teslamate/assets/904020/90663240-85f9-4428-9a8f-36b7b5b466b7)
