### PR TITLE
[Docs] Add network flows that should be authorized

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -63,3 +63,23 @@ Calling the [Vehicle API](https://www.teslaapi.io/vehicles/list#vehicle) does no
 ## Why are my Docker timestamp logs different than my machine?
 
 Docker container timezones default to UTC. To set the timezone for your container, use the `TZ` Environment Variable in your YML file. More information found at [Environment Variables](https://docs.teslamate.org/docs/configuration/environment_variables)
+
+## Which network flows must be authorized?
+
+⚠️ This is for advanced users!
+
+You might want to prohibit all network flows except those necessary for teslamate.
+This is a common practice to harden an installation (e.g., to reduce the risk of data leakage).
+
+The following flows must be authorized (egress traffic and DNS resolution):
+
+HTTPS (TCP/443)  
+auth.tesla.com  
+owner-api.teslamotors.com  
+streaming.vn.teslamotors.com  
+nominatim.openstreetmap.org  
+
+HTTP (TCP/80)  
+step.esa.int  
+
+Note: This may change when Teslamate is updated!


### PR DESCRIPTION
Hello,

Some users would like to restrict network flows, but currently it's hard to determine which flow should be authorized.
Therefore, keeping a list of remote services (URLs) required for Teslamate is useful.

Furthermore, blocking network traffic leads to error messages that are not obviously related to network.
For instance, if streaming API is not reachable, Teslamate logs are:
```
2024-05-09 15:58:15.849 car_id=1 [info] Start / :online
2024-05-09 15:58:15.907 car_id=1 [info] Connecting ...
2024-05-09 15:58:16.197 car_id=1 [info] Start / :online
2024-05-09 15:58:16.233 car_id=1 [info] Connecting ...
2024-05-09 15:58:16.583 car_id=1 [info] Start / :online
2024-05-09 15:58:16.636 car_id=1 [info] Connecting ...
2024-05-09 15:58:16.940 car_id=1 [info] Start / :online
2024-05-09 15:58:16.979 car_id=1 [info] Connecting ...
2024-05-09 15:58:17.427 car_id=1 [info] Start / :online
2024-05-09 15:58:17.440 car_id=1 [info] Connecting ...
2024-05-09 15:58:17.780 car_id=1 [info] Start / :online
2024-05-09 15:58:17.818 car_id=1 [info] Connecting ...
```

And PostgreSQL logs are:
```
ERROR:  canceling statement due to user request
```

Log messages don't allow straightforward identification of the root cause (but this is to be improved in another PR ;) )