### PR TITLE
ci: add yeec and leex compilers to mix.exs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - ci: Upgrade PostgreSQL to v16 in elixir workflow (#3916 - @JakobLichterfeld)
 - build(deps): bump docker/login-action from 3.1.0 to 3.2.0 (#3933)
 - build(deps): bump elixir from 1.16.1-otp-26 to 1.16.2-otp-26 (#3935 - @JakobLichterfeld)
+- ci: add yeec and leex compilers to mix.exs (#3941 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule TeslaMate.MixProject do
       version: version(),
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
-      compilers: Mix.compilers(),
+      compilers: [:yecc, :leex] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       releases: releases(),


### PR DESCRIPTION
To fix the linter warnings, see for example here: https://github.com/teslamate-org/teslamate/actions/runs/9380988328