### PR TITLE
Respect Retry-After header on 429 response code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ config/*.env
 .eclipse/
 .elixir_ls/
 /.project
+.vscode/
 
 # Mac files
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ config/*.env
 .elixir_ls/
 /.project
 .vscode/
-
+ 
 # Mac files
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ config/*.env
 .elixir_ls/
 /.project
 .vscode/
- 
+
 # Mac files
 .DS_Store
 

--- a/lib/tesla_api/vehicle.ex
+++ b/lib/tesla_api/vehicle.ex
@@ -114,14 +114,14 @@ defmodule TeslaApi.Vehicle do
         {:error, %Error{reason: :vehicle_unavailable, env: env}}
 
       %Tesla.Env{status: 429, headers: headers} ->
-         retry_after =
-           case Enum.find(headers, fn {key, _value} -> key == "retry-after" end) do
-             nil ->
-               "300"
+        retry_after =
+          case Enum.find(headers, fn {key, _value} -> key == "retry-after" end) do
+            nil ->
+              "300"
 
-             {"retry-after", value} ->
-               value
-           end
+            {"retry-after", value} ->
+              value
+          end
 
         {:error, %Error{reason: :too_many_request, message: String.to_integer(retry_after)}}
 

--- a/lib/tesla_api/vehicle.ex
+++ b/lib/tesla_api/vehicle.ex
@@ -113,6 +113,18 @@ defmodule TeslaApi.Vehicle do
       %Tesla.Env{status: 408, body: %{"error" => "vehicle unavailable:" <> _}} = env ->
         {:error, %Error{reason: :vehicle_unavailable, env: env}}
 
+      %Tesla.Env{status: 429, headers: headers} ->
+         retry_after =
+           case Enum.find(headers, fn {key, _value} -> key == "retry-after" end) do
+             nil ->
+               "300"
+
+             {"retry-after", value} ->
+               value
+           end
+
+        {:error, %Error{reason: :too_many_request, message: String.to_integer(retry_after)}}
+
       %Tesla.Env{status: 504} = env ->
         {:error, %Error{reason: :timeout, env: env}}
 

--- a/lib/teslamate/api.ex
+++ b/lib/teslamate/api.ex
@@ -278,6 +278,10 @@ defmodule TeslaMate.Api do
         Logger.error("TeslaApi.Error / #{status} – #{inspect(body, pretty: true)}")
         {:error, reason}
 
+      {:error, %TeslaApi.Error{reason: :too_many_request, message: retry_after}} ->
+        Logger.warning("TeslaApi.Error / :too_many_request #{retry_after}")
+        {:error, :too_many_request, retry_after}
+
       {:error, %TeslaApi.Error{reason: reason, message: msg}} ->
         if is_binary(msg) and msg != "", do: Logger.warning("TeslaApi.Error / #{msg}")
         {:error, reason}

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -386,6 +386,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {:keep_state, data,
          [broadcast_fetch(false), broadcast_summary(), schedule_fetch(30, data)]}
 
+      {:error, :too_many_request, retry_after} ->
+        Logger.error("Too many request / Retry after #{retry_after} seconds", car_id: data.car.id)
+
+        {:keep_state, data,
+         [broadcast_fetch(false), broadcast_summary(), schedule_fetch(retry_after, data)]}
+
       {:error, reason} ->
         Logger.error("Error / #{inspect(reason)}", car_id: data.car.id)
 


### PR DESCRIPTION
As seen [in this ticket](https://github.com/teslamate-org/teslamate/issues/3928) and in the @brianmay [related PR](https://github.com/teslamate-org/teslamate/pull/3451), the API response code 429 contains a `Retry-After` header which must be respected to avoid unnecessary calls.