### PR TITLE
Track open/close states for individual doors

### DIFF
--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -83,7 +83,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
     display_name state since healthy latitude longitude heading battery_level charging_state usable_battery_level
     ideal_battery_range_km est_battery_range_km rated_battery_range_km charge_energy_added
     speed outside_temp inside_temp is_climate_on is_preconditioning locked sentry_mode
-    plugged_in scheduled_charging_start_time charge_limit_soc charger_power windows_open doors_open
+    plugged_in scheduled_charging_start_time charge_limit_soc charger_power windows_open
+    doors_open driver_front_door_open driver_rear_door_open passenger_front_door_open passenger_rear_door_open
     odometer shift_state charge_port_door_open time_to_full_charge charger_phases
     charger_actual_current charger_voltage version update_available update_version is_user_present
     model trim_badging exterior_color wheel_type spoiler_type trunk_open frunk_open elevation power

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -9,7 +9,8 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     car display_name state since healthy latitude longitude heading battery_level charging_state usable_battery_level
     ideal_battery_range_km est_battery_range_km rated_battery_range_km charge_energy_added
     speed outside_temp inside_temp is_climate_on is_preconditioning locked sentry_mode
-    plugged_in scheduled_charging_start_time charge_limit_soc charger_power windows_open doors_open
+    plugged_in scheduled_charging_start_time charge_limit_soc charger_power windows_open
+    doors_open driver_front_door_open driver_rear_door_open passenger_front_door_open passenger_rear_door_open
     odometer shift_state charge_port_door_open time_to_full_charge charger_phases
     charger_actual_current charger_voltage version update_available update_version is_user_present geofence
     model trim_badging exterior_color wheel_type spoiler_type trunk_open frunk_open elevation power
@@ -129,6 +130,10 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       sentry_mode: get_in_struct(vehicle, [:vehicle_state, :sentry_mode]),
       windows_open: window_open(vehicle),
       doors_open: doors_open(vehicle),
+      driver_front_door_open: driver_front_door_open(vehicle),
+      driver_rear_door_open: driver_rear_door_open(vehicle),
+      passenger_front_door_open: passenger_front_door_open(vehicle),
+      passenger_rear_door_open: passenger_rear_door_open(vehicle),
       trunk_open: trunk_open(vehicle),
       frunk_open: frunk_open(vehicle),
       is_user_present: get_in_struct(vehicle, [:vehicle_state, :is_user_present]),
@@ -181,6 +186,28 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
         nil
     end
   end
+
+  defp driver_front_door_open(%Vehicle{vehicle_state: %VehicleState{df: df}}) when is_number(df),
+    do: df > 0
+
+  defp driver_front_door_open(_vehicle), do: nil
+
+  defp driver_rear_door_open(%Vehicle{vehicle_state: %VehicleState{dr: dr}}) when is_number(dr),
+    do: dr > 0
+
+  defp driver_rear_door_open(_vehicle), do: nil
+
+  defp passenger_front_door_open(%Vehicle{vehicle_state: %VehicleState{pf: pf}})
+       when is_number(pf),
+       do: pf > 0
+
+  defp passenger_front_door_open(_vehicle), do: nil
+
+  defp passenger_rear_door_open(%Vehicle{vehicle_state: %VehicleState{pr: pr}})
+       when is_number(pr),
+       do: pr > 0
+
+  defp passenger_rear_door_open(_vehicle), do: nil
 
   defp trunk_open(%Vehicle{vehicle_state: %VehicleState{rt: rt}}) when is_number(rt), do: rt > 0
   defp trunk_open(_vehicle), do: nil

--- a/website/docs/integrations/mqtt.md
+++ b/website/docs/integrations/mqtt.md
@@ -40,6 +40,10 @@ Vehicle data will be published to the following topics:
 | `teslamate/cars/$car_id/sentry_mode`                   | false                                        | Indicates if Sentry Mode is active                                                    |
 | `teslamate/cars/$car_id/windows_open`                  | false                                        | Indicates if any of the windows are open                                              |
 | `teslamate/cars/$car_id/doors_open`                    | false                                        | Indicates if any of the doors are open                                                |
+| `teslamate/cars/$car_id/driver_front_door_open`        | false                                        | Indicates if the driver-side front door is open                                       |
+| `teslamate/cars/$car_id/driver_rear_door_open`         | false                                        | Indicates if the driver-side rear door is open                                        |
+| `teslamate/cars/$car_id/passenger_front_door_open`     | false                                        | Indicates if the passenger-side front door is open                                    |
+| `teslamate/cars/$car_id/passenger_rear_door_open`      | false                                        | Indicates if the passenger-side rear door is open                                     |
 | `teslamate/cars/$car_id/trunk_open`                    | false                                        | Indicates if the trunk is open                                                        |
 | `teslamate/cars/$car_id/frunk_open`                    | false                                        | Indicates if the frunk is open                                                        |
 | `teslamate/cars/$car_id/is_user_present`               | false                                        | Indicates if a user is present in the vehicle                                         |


### PR DESCRIPTION
This PR supersedes #3208.

In this PR, we introduce code changes to track the 4 individual door open/close states from Tesla's `vehicle_state` API, that are currently aggregated into the `doors_open` state in Teslamate.

This PR also includes changes required to publish these 4 states on MQTT.

I have tested the changes with my own car and HA's MQTT integration.