### PR TITLE
dashboards: re-enable time picker by default in drive-details, charge…

### DIFF
--- a/grafana/dashboards/internal/charge-details.json
+++ b/grafana/dashboards/internal/charge-details.json
@@ -2045,7 +2045,6 @@
     "to": "now"
   },
   "timepicker": {
-    "hidden": true,
     "refresh_intervals": [
       "5s",
       "10s",

--- a/grafana/dashboards/internal/drive-details.json
+++ b/grafana/dashboards/internal/drive-details.json
@@ -2764,7 +2764,6 @@
     ]
   },
   "timepicker": {
-    "hidden": true,
     "refresh_intervals": [],
     "time_options": []
   },


### PR DESCRIPTION
…-details

While the time picker doesn't work quite correctly with internal dashboards (i.e., not meant to be called independently, which will cause N/A data errors), it is still useful to have it enabled:

It provides at-a-glance from-to time at the top bar for easy reference. When you call it independently, it allows you to monitor real-time stats (e.g., Using "Last 1 hour" with auto refresh).