### PR TITLE
Update vehicle.ex with marketing name for Model Y Long Range RWD

### DIFF
--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -74,6 +74,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
             {"X", "P100D", "tamarind"} -> "Plaid"
             {"Y", "P74D", _} -> "LR AWD Performance"
             {"Y", "74D", _} -> "LR AWD"
+            {"Y", "74", _} -> "LR"
             {_model, _trim, _type} -> nil
           end
 


### PR DESCRIPTION
Add marketing name for Model Y LR RWD. This solves an issue where the new Model Y is currently named "Model Y 74" in TeslaMate's main screen.