### PR TITLE
Update vehicle.ex with marketing name for Model Y SR

### DIFF
--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -88,6 +88,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
             {"Y", "P74D", _} -> "LR AWD Performance"
             {"Y", "74D", _} -> "LR AWD"
             {"Y", "74", _} -> "LR"
+            {"Y", "50", _} -> "SR"
             {_model, _trim, _type} -> nil
           end
 

--- a/lib/teslamate_web/live/car_live/summary.html.heex
+++ b/lib/teslamate_web/live/car_live/summary.html.heex
@@ -115,6 +115,14 @@
             <span class="mdi mdi-shield-check"></span>
           </span>
         <% end %>
+        <%= if @summary.center_display_state == 7 do %>
+          <span
+            class="icon has-text-grey-dark has-tooltip-top has-tooltip-left-mobile"
+            data-tooltip={gettext("Sentry Mode recording")}
+          >
+            <span class="mdi mdi-cctv"></span>
+          </span>
+        <% end %>
         <%= unless is_nil(@summary.locked) do %>
           <span
             class="icon has-text-grey-dark has-tooltip-top has-tooltip-left-mobile"


### PR DESCRIPTION
Add marketing name for Model Y SR. This solves an issue where the Model Y SR is currently named "Model Y 50" in TeslaMate's main screen.