### PR TITLE
Update vehicle.ex with marketing name for Model Y SR

### DIFF
--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -88,6 +88,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
             {"Y", "P74D", _} -> "LR AWD Performance"
             {"Y", "74D", _} -> "LR AWD"
             {"Y", "74", _} -> "LR"
+            {"Y", "50", _} -> "SR"
             {_model, _trim, _type} -> nil
           end
 


### PR DESCRIPTION
Add marketing name for Model Y SR. This solves an issue where the Model Y SR is currently named "Model Y 50" in TeslaMate's main screen.