### PR TITLE
Fix hard coded informations (timezone and orgId)

### DIFF
--- a/grafana/dashboards/battery-health.json
+++ b/grafana/dashboards/battery-health.json
@@ -1978,7 +1978,7 @@
   "timepicker": {
     "hidden": true
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "Battery Health",
   "uid": "jchmRiqUfXgTM",
   "version": 9,

--- a/grafana/dashboards/overview.json
+++ b/grafana/dashboards/overview.json
@@ -1955,7 +1955,7 @@
         {
           "targetBlank": true,
           "title": "States",
-          "url": "/d/xo4BNRkZz/states?orgId=1&${__url_time_range}"
+          "url": "/d/xo4BNRkZz/states?${__url_time_range}"
         }
       ],
       "options": {

--- a/grafana/dashboards/statistics.json
+++ b/grafana/dashboards/statistics.json
@@ -1009,7 +1009,7 @@
       "1d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "Statistics",
   "uid": "1EZnXszMk",
   "version": 1,


### PR DESCRIPTION
I noticed that the timezone was hard in 2 dashboards

The browser is the default behavior: https://grafana.com/docs/grafana/latest/administration/organization-preferences/#change-the-grafana-default-timezone

On the other hand, by forcing it, overrides (coming from the server, organization, team, or individual user level) are not taken into account.