### PR TITLE
downgrade grafana until maps issue in upstream grafana is resolved

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,6 +1,6 @@
 # Ensure selecting a tag that is available for arm/v7, arm64, and amd64
 # https://hub.docker.com/r/grafana/grafana/tags
-FROM grafana/grafana:11.1.0
+FROM grafana/grafana:11.0.1
 
 ENV GF_ANALYTICS_REPORTING_ENABLED=false \
     GF_AUTH_ANONYMOUS_ENABLED=false \


### PR DESCRIPTION
before releasing this potentially as 1.30.1 please check if maps are working fine again

https://github.com/teslamate-org/teslamate/pull/4019#issuecomment-2218427564

sorry rushing the grafana update. always try to stay on latest. (at least 1.30.1 would bring some grafana localization improvements as well ;))

once grafana 11.1.1 is released we can upgrade again as it will include this fix: https://github.com/grafana/grafana/pull/89248