### PR TITLE
small visual distinguish between AC & DC charging in charges dashboard and unification of the DC coloring in all dashboards

### DIFF
--- a/grafana/dashboards/charges.json
+++ b/grafana/dashboards/charges.json
@@ -896,7 +896,7 @@
                         "index": 0
                       },
                       "DC": {
-                        "color": "orange",
+                        "color": "light-orange",
                         "index": 1
                       }
                     },

--- a/grafana/dashboards/charges.json
+++ b/grafana/dashboards/charges.json
@@ -876,6 +876,35 @@
                 "value": 62
               }
             ]
+          },
+	      {
+            "matcher": {
+              "id": "byName",
+              "options": "charge_type"
+            },
+            "properties": [
+              {
+                "id": "color"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "AC": {
+                        "color": "green",
+                        "index": 0
+                      },
+                      "DC": {
+                        "color": "orange",
+                        "index": 1
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
           }
         ]
       },

--- a/grafana/dashboards/charging-stats.json
+++ b/grafana/dashboards/charging-stats.json
@@ -1230,7 +1230,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "#FADE2A",
+                  "fixedColor": "light-orange",
                   "mode": "fixed"
                 }
               }
@@ -1556,7 +1556,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "#FADE2A",
+                  "fixedColor": "light-orange",
                   "mode": "fixed"
                 }
               }


### PR DESCRIPTION
This commit just adds a different colour to the DC charges so that it can be easily visualized

![image](https://github.com/user-attachments/assets/af406b4c-7d4c-4b69-9d2d-414bc24950dd)
