### PR TITLE
publish charge rate to MQTT

### DIFF
--- a/lib/teslamate/log/charging_process.ex
+++ b/lib/teslamate/log/charging_process.ex
@@ -14,6 +14,7 @@ defmodule TeslaMate.Log.ChargingProcess do
     field :end_ideal_range_km, :decimal, read_after_writes: true
     field :start_rated_range_km, :decimal, read_after_writes: true
     field :end_rated_range_km, :decimal, read_after_writes: true
+    field :charge_rate, :integer, read_after_writes: true
     field :start_battery_level, :integer
     field :end_battery_level, :integer
     field :duration_min, :integer
@@ -42,6 +43,7 @@ defmodule TeslaMate.Log.ChargingProcess do
       :end_ideal_range_km,
       :start_rated_range_km,
       :end_rated_range_km,
+      :charge_rate,
       :start_battery_level,
       :end_battery_level,
       :duration_min,

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -39,7 +39,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
 
   @always_published ~w(charge_energy_added charger_actual_current charger_phases
                        charger_power charger_voltage scheduled_charging_start_time
-                       time_to_full_charge shift_state geofence trim_badging)a
+                       time_to_full_charge shift_state geofence trim_badging
+                       charge_rate)a
 
   @impl true
   def handle_info(%Summary{} = summary, state) do

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -9,7 +9,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     car display_name state since healthy latitude longitude heading battery_level charging_state usable_battery_level
     ideal_battery_range_km est_battery_range_km rated_battery_range_km charge_energy_added
     speed outside_temp inside_temp is_climate_on is_preconditioning locked sentry_mode
-    plugged_in scheduled_charging_start_time charge_limit_soc charger_power windows_open
+    plugged_in scheduled_charging_start_time charge_limit_soc charger_power windows_open charge_rate
     doors_open driver_front_door_open driver_rear_door_open passenger_front_door_open passenger_rear_door_open
     odometer shift_state charge_port_door_open time_to_full_charge charger_phases
     charger_actual_current charger_voltage version update_available update_version is_user_present geofence
@@ -104,6 +104,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       charge_current_request_max: charge(vehicle, :charge_current_request_max),
       charge_energy_added: charge(vehicle, :charge_energy_added),
       charge_limit_soc: charge(vehicle, :charge_limit_soc),
+      charge_rate: charge(vehicle, :charge_rate),
       charge_port_door_open: charge(vehicle, :charge_port_door_open),
       charger_actual_current: charge(vehicle, :charger_actual_current),
       charger_phases: charge(vehicle, :charger_phases),

--- a/test/teslamate/import_test.exs
+++ b/test/teslamate/import_test.exs
@@ -120,6 +120,7 @@ defmodule TeslaMate.ImportTest do
                address_id: nil,
                cost: nil,
                duration_min: 70,
+               charge_rate: decimal(123),
                start_battery_level: 57,
                end_battery_level: 70,
                start_date: ~U[2016-06-26 23:04:32.000000Z],

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -89,7 +89,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
           :charger_power,
           :charger_voltage,
           :scheduled_charging_start_time,
-          :time_to_full_charge
+          :time_to_full_charge,
+          :charge_rate
         ] do
       topic = "teslamate/cars/0/#{key}"
       assert_receive {MqttPublisherMock, {:publish, ^topic, "", [retain: true, qos: 1]}}
@@ -145,7 +146,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
       ideal_battery_range_km: 230.52,
       rated_battery_range_km: 230.52,
       scheduled_charging_start_time: DateTime.utc_now() |> DateTime.add(60 * 60 * 10, :second),
-      time_to_full_charge: 2.5
+      time_to_full_charge: 2.5,
+      charge_rate: 123
     }
 
     send(pid, summary)
@@ -251,7 +253,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
           :time_to_full_charge,
           :shift_state,
           :geofence,
-          :trim_badging
+          :trim_badging,
+          :charge_rate
         ] do
       topic = "teslamate/account_0/cars/0/#{key}"
       assert_receive {MqttPublisherMock, {:publish, ^topic, "", [retain: true, qos: 1]}}

--- a/test/teslamate/vehicles/vehicle/charging_test.exs
+++ b/test/teslamate/vehicles/vehicle/charging_test.exs
@@ -43,6 +43,7 @@ defmodule TeslaMate.Vehicles.Vehicle.ChargingTest do
                       date: _,
                       charge_energy_added: 0.1,
                       rated_battery_range_km: 1.61,
+                      charge_rate: 0,
                       ideal_battery_range_km: 1.61
                     }}
 
@@ -54,6 +55,7 @@ defmodule TeslaMate.Vehicles.Vehicle.ChargingTest do
                       date: _,
                       charge_energy_added: 0.2,
                       rated_battery_range_km: 3.22,
+                      charge_rate: 2,
                       ideal_battery_range_km: 3.22
                     }}
 
@@ -64,6 +66,7 @@ defmodule TeslaMate.Vehicles.Vehicle.ChargingTest do
                       date: _,
                       charge_energy_added: 0.3,
                       rated_battery_range_km: 4.83,
+                      charge_rate: 10,
                       ideal_battery_range_km: 4.83
                     }}
 
@@ -76,6 +79,7 @@ defmodule TeslaMate.Vehicles.Vehicle.ChargingTest do
                       date: _,
                       charge_energy_added: 0.4,
                       rated_battery_range_km: 6.44,
+                      charge_rate: 10,
                       ideal_battery_range_km: 6.44
                     }}
 

--- a/test/teslamate/vehicles/vehicle_sync_test.exs
+++ b/test/teslamate/vehicles/vehicle_sync_test.exs
@@ -84,6 +84,7 @@ defmodule TeslaMate.Vehicles.VehicleSyncTest do
                charger_phases: :unknown,
                charger_power: :unknown,
                charger_voltage: :unknown,
+               charge_rate: :unknown,
                display_name: "bar",
                doors_open: nil,
                elevation: nil,

--- a/test/teslamate_web/controllers/car_controller_test.exs
+++ b/test/teslamate_web/controllers/car_controller_test.exs
@@ -263,6 +263,7 @@ defmodule TeslaMateWeb.CarControllerTest do
              charger_voltage: 229,
              charger_actual_current: 16,
              battery_range: 200,
+             charge_rate: 123,
              est_battery_range: 180,
              ideal_battery_range: 175,
              charging_state: "Charging",
@@ -316,6 +317,7 @@ defmodule TeslaMateWeb.CarControllerTest do
              charging_state: "Charging",
              charge_energy_added: "4.32",
              ideal_battery_range: 200,
+             charge_rate: 123,
              time_to_full_charge: 0.33
            }
          )}

--- a/website/docs/integrations/mqtt.md
+++ b/website/docs/integrations/mqtt.md
@@ -63,6 +63,7 @@ Vehicle data will be published to the following topics:
 | `teslamate/cars/$car_id/plugged_in`                    | true                                         | If car is currently plugged into a charger                                            |
 | `teslamate/cars/$car_id/charge_energy_added`           | 5.06                                         | Last added energy in kWh                                                              |
 | `teslamate/cars/$car_id/charge_limit_soc`              | 90                                           | Charge Limit Configured in Percentage                                                 |
+| `teslamate/cars/$car_id/charge_rate`                   | 0.0                                          | Charge rate, in the user configured unit                                              |
 | `teslamate/cars/$car_id/charge_port_door_open`         | true                                         | Indicates if the charger door is open                                                 |
 | `teslamate/cars/$car_id/charger_actual_current`        | 2.05                                         | Current amperage supplied by charger                                                  |
 | `teslamate/cars/$car_id/charger_phases`                | 3                                            | Number of charger power phases (1-3)                                                  |


### PR DESCRIPTION
User @jonnylangefeld had implemented some changes in order to capture the charge_rate. I think this data is crucial in being able to accurately calculate the charging efficiency, in summer for instance I can be "charging" at 7kW at home and teslamate reports 7kW, but due to cooling I'm in fact not charging as the charge_rate is 0 because the car is using all the energy for HVAC.
I did get the changes that were done on a previous unfinished PR and I'm just getting knowledge on how the project works behind the scenes so any comments are appreciated, I'll do my best.