### PR TITLE
Fix the issue of failing to restore  efficiency dashboard.

### DIFF
--- a/grafana/dashboards.sh
+++ b/grafana/dashboards.sh
@@ -62,7 +62,7 @@ restore() {
       while IFS= read -r -d '' dashboard_path; do
           folder_id=$(get_folder_id "$(basename "$dashboard_path" .json)")
           curl \
-            --silent --show-error --output /dev/null \
+            --silent --fail --show-error --output /dev/null \
             --user "$LOGIN" \
             -X POST -H "Content-Type: application/json" \
             -d "{\"dashboard\":$(cat "$dashboard_path"), \

--- a/grafana/dashboards/efficiency.json
+++ b/grafana/dashboards/efficiency.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_TESLAMATE",
-      "label": "TeslaMate",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "grafana-postgresql-datasource",
-      "pluginName": "PostgreSQL"
-    }
-  ],
   "__elements": {},
   "__requires": [
     {


### PR DESCRIPTION
The __inputs field in efficiency.json will cause the efficiency dashboard restore to fail.

The error message is: 
{"message":"dashboard import failed: missing dashboard input variable DS_TESLAMATE","traceID":""}

A sample command to reproduce this behavior is: 
```bash
curl   --user "admin:admin" --show-error   -X POST -H "Content-Type: application/json"   -d "{\"dashboard\":$(cat ./grafana/dashboards/efficiency.json), \
      \"overwrite\":true, \
      \"folderId\": null, \
      \"inputs\":[{\"name\":\"DS_CLOUDWATCH\", \
      \"type\":\"datasource\", \
      \"pluginId\":\"cloudwatch\", \
      \"value\":\"TeslaMate\"}]}"   "localhost:3000/api/dashboards/import"
```

Due to the absence of error messages within dashboards.sh and the uninterrupted nature of the restore process, I've added the --fail parameter to the curl command. This modification will cause the restore process to terminate upon encountering an restore failure for the dashboard, allowing for timely detection and resolution of the issue.