### PR TITLE
improve charge level dashboard

### DIFF
--- a/grafana/dashboards/charge-level.json
+++ b/grafana/dashboards/charge-level.json
@@ -171,12 +171,13 @@
             "type": "grafana-postgresql-datasource",
             "uid": "TeslaMate"
           },
+          "editorMode": "code",
           "format": "time_series",
           "group": [],
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\t$__time(date),\n\tbattery_level AS \"Battery Level\",\n\tusable_battery_level AS \"Usable Battery Level\"\nfrom positions\n\tWHERE $__timeFilter(date) AND car_id = $car_id\n\tORDER BY Time ASC\n;",
+          "rawSql": "SELECT\n\tdate_bin(($__interval_ms / 1000 || ' milliseconds')::INTERVAL, date, TIMESTAMP '2003-07-01') as time,\n\tavg(battery_level) AS \"Battery Level\",\n\tavg(usable_battery_level) AS \"Usable Battery Level\"\nfrom positions\n\tWHERE $__timeFilter(date) AND car_id = $car_id\n\tGROUP BY time\n\tORDER BY time ASC\n;",
           "refId": "A",
           "select": [
             [
@@ -188,6 +189,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "time",
           "where": [
             {
@@ -319,7 +337,7 @@
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-6M",
     "to": "now"
   },
   "timepicker": {
@@ -350,6 +368,6 @@
   "timezone": "",
   "title": "Charge Level",
   "uid": "WopVO_mgz",
-  "version": 5,
+  "version": 7,
   "weekStart": ""
 }


### PR DESCRIPTION
fixes #4185

by making use of $__interval_ms and time bucketing long periods can be shown without hitting the row limit of 1000000.

$__interval_ms is divided by 1000 to ensure avg() calcuations to not smooth out the charge level or still show min / max values reflecting reality but significantly reducing number of data points returned by the query (70.000 instead of 2.000.000) for 6 months in my case.

would be great if someone with long lasting history or slow performing hardware could test to see performance impact (as we are time bucketing now this could mean longer query load time). to make it a fair comparsion going like for like (6 months vs 6 months) would be fair i guess.

After the change - see linked issue for a screenshot before introducing the change

![grafik](https://github.com/user-attachments/assets/d7f4e3e1-c9a2-43a8-bcd7-65466da5f241)
