### PR TITLE
increase max battery charge gauge threshold to 101 in case of LFP

### DIFF
--- a/grafana/dashboards/overview.json
+++ b/grafana/dashboards/overview.json
@@ -203,7 +203,7 @@
           "format": "table",
           "hide": false,
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  0 as lowest,\r\n  10 as low,\r\n  20 as mid,\r\n  CASE WHEN lfp_battery THEN 100 ELSE 81 END as high,\r\n  CASE WHEN lfp_battery THEN 100 ELSE 91 END as highest\r\nfrom cars inner join car_settings on cars.settings_id = car_settings.id\r\nwhere cars.id = $car_id",
+          "rawSql": "SELECT\r\n  0 as lowest,\r\n  10 as low,\r\n  20 as mid,\r\n  CASE WHEN lfp_battery THEN 101 ELSE 81 END as high,\r\n  CASE WHEN lfp_battery THEN 101 ELSE 91 END as highest\r\nfrom cars inner join car_settings on cars.settings_id = car_settings.id\r\nwhere cars.id = $car_id",
           "refId": "B",
           "sql": {
             "columns": [

--- a/grafana/dashboards/overview.json
+++ b/grafana/dashboards/overview.json
@@ -2167,6 +2167,6 @@
   "timezone": "",
   "title": "Overview",
   "uid": "kOuP_Fggz",
-  "version": 9,
+  "version": 10,
   "weekStart": ""
 }


### PR DESCRIPTION
fixes #4184: visualization issue of gauge turning "red" in case of 100% battery charged on lfp teslas