### PR TITLE
ci: enable dependabot for mix and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
     schedule:
       interval: "monthly"
 
-  # - package-ecosystem: "npm"
-  #   directory: "/assets"
-  #   schedule:
-  #     interval: "monthly"
+  - package-ecosystem: "npm"
+    directory: "/assets"
+    schedule:
+      interval: "monthly"
 
   # - package-ecosystem: "npm"
   #   directory: "/website"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 version: 2
 updates:
-  # - package-ecosystem: "mix"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "monthly"
+  - package-ecosystem: "mix"
+    directory: "/"
+    schedule:
+      interval: "monthly"
 
   # - package-ecosystem: "npm"
   #   directory: "/assets"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,10 @@ updates:
     schedule:
       interval: "monthly"
 
-  # - package-ecosystem: "npm"
-  #   directory: "/website"
-  #   schedule:
-  #     interval: "monthly"
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "monthly"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
reenable Dependabot for

- [x] mix
- [x] npm in `/assets`
- [x] nom in `/website`

it was disabled 2 years ago in https://github.com/teslamate-org/teslamate/commit/6e876d76852c34b48b3ca664ac0cd5df1d97ff56