### PR TITLE
PostgreSQL 17

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -129,7 +129,7 @@ jobs:
 
     services:
       db:
-        image: postgres:16
+        image: postgres:17
         ports: ["5432:5432"]
         env:
           POSTGRES_PASSWORD: postgres

--- a/priv/repo/migrations/20190925152807_create_geo_extensions.exs
+++ b/priv/repo/migrations/20190925152807_create_geo_extensions.exs
@@ -2,8 +2,15 @@ defmodule TeslaMate.Repo.Migrations.CreateGeoExtensions do
   use Ecto.Migration
 
   def change do
-    execute("CREATE EXTENSION IF NOT EXISTS cube", "DROP EXTENSION cube")
-    execute("CREATE EXTENSION IF NOT EXISTS earthdistance", "DROP EXTENSION earthdistance")
+    execute("CREATE EXTENSION IF NOT EXISTS cube WITH SCHEMA public", "DROP EXTENSION cube")
+
+    execute(
+      "CREATE EXTENSION IF NOT EXISTS earthdistance WITH SCHEMA public",
+      "DROP EXTENSION earthdistance"
+    )
+
+    execute("ALTER FUNCTION ll_to_earth SET search_path = public")
+    execute("ALTER FUNCTION earth_box SET search_path = public")
     create(index(:geofences, ["(earth_box(ll_to_earth(latitude, longitude), radius))"]))
   end
 end

--- a/priv/repo/migrations/20240929084639_recreate_geo_extensions.exs
+++ b/priv/repo/migrations/20240929084639_recreate_geo_extensions.exs
@@ -1,0 +1,9 @@
+defmodule TeslaMate.Repo.Migrations.RecreateGeoExtensions do
+  use Ecto.Migration
+
+  def change do
+    execute("DROP EXTENSION cube CASCADE")
+    execute("CREATE EXTENSION cube WITH SCHEMA public")
+    execute("CREATE EXTENSION earthdistance WITH SCHEMA public")
+  end
+end

--- a/website/docs/development.md
+++ b/website/docs/development.md
@@ -7,7 +7,7 @@ sidebar_label: Development and Contributing
 ## Requirements
 
 - **Elixir** >= 1.16.2-otp-26
-- **Postgres** >= 16
+- **Postgres** >= 17
 - An **MQTT broker** e.g. mosquitto (_optional_)
 - **NodeJS** >= 20.15.0
 

--- a/website/docs/guides/apache.md
+++ b/website/docs/guides/apache.md
@@ -50,7 +50,7 @@ services:
       - all
 
   database:
-    image: postgres:16
+    image: postgres:17
     restart: always
     environment:
       - POSTGRES_USER=${TM_DB_USER}

--- a/website/docs/guides/traefik.md
+++ b/website/docs/guides/traefik.md
@@ -60,7 +60,7 @@ services:
       - ALL
 
   database:
-    image: postgres:16
+    image: postgres:17
     restart: always
     environment:
       - POSTGRES_USER=${TM_DB_USER}

--- a/website/docs/installation/debian.md
+++ b/website/docs/installation/debian.md
@@ -10,13 +10,13 @@ This document provides the necessary steps for installation of TeslaMate on a va
 Click on the following items to view detailed installation steps.
 
 <details>
-  <summary>Postgres (v12+)</summary>
+  <summary>Postgres (v17+)</summary>
 
 ```bash
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | sudo tee  /etc/apt/sources.list.d/pgdg.list
+echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
 sudo apt-get update
-sudo apt-get install -y postgresql-12 postgresql-client-12
+sudo apt-get install -y postgresql-17 postgresql-client-17
 ```
 
 Source: [postgresql.org/download](https://www.postgresql.org/download/)
@@ -37,7 +37,7 @@ Source: [elixir-lang.org/install](https://elixir-lang.org/install)
 </details>
 
 <details>
-  <summary>Grafana (v8.3.4+) & Plugins</summary>
+  <summary>Grafana (v11.1.0+)</summary>
 
 ```bash
 sudo apt-get install -y apt-transport-https software-properties-common
@@ -50,15 +50,6 @@ sudo systemctl enable grafana-server.service # to start Grafana at boot time
 ```
 
 Source: [grafana.com/docs/installation](https://grafana.com/docs/grafana/latest/installation/)
-
-Install the required Grafana plugins as well:
-
-```bash
-sudo grafana-cli plugins install pr0ps-trackmap-panel 2.1.4
-sudo grafana-cli plugins install natel-plotly-panel 0.0.7
-sudo grafana-cli --pluginUrl https://github.com/panodata/panodata-map-panel/releases/download/0.16.0/panodata-map-panel-0.16.0.zip plugins install grafana-worldmap-panel-ng
-sudo systemctl restart grafana-server
-```
 
 [Import the Grafana dashboards](#import-grafana-dashboards) after [cloning the TeslaMate git repository](#clone-teslamate-git-repository).
 

--- a/website/docs/installation/docker.md
+++ b/website/docs/installation/docker.md
@@ -38,7 +38,7 @@ This setup is recommended only if you are running TeslaMate **on your home netwo
          - all
 
      database:
-       image: postgres:16
+       image: postgres:17
        restart: always
        environment:
          - POSTGRES_USER=teslamate

--- a/website/docs/installation/freebsd.md
+++ b/website/docs/installation/freebsd.md
@@ -50,11 +50,11 @@ pkg install elixir
 </details>
 
 <details>
-  <summary>Postgres (v14+)</summary>
+  <summary>Postgres (v17+)</summary>
 
 ```bash
-pkg install postgresql16-server-16.0
-pkg install postgresql16-contrib-16.0
+pkg install postgresql17-server-17.0
+pkg install postgresql17-contrib-17.0
 echo postgres_enable="yes" >> /etc/rc.conf
 ```
 
@@ -70,12 +70,12 @@ service postgresql initdb
 </details>
 
 <details>
-  <summary>Grafana (v8.3.4+) & Plugins</summary>
+  <summary>Grafana (v10.4.5+)</summary>
 
 (might be obsolete with Grafana 9, I had no issues with a fresh install) The latest Grafana from ports/pkg has a startup issue with the rc script, starting via rc.local is the workaround.
 
 ```bash
-pkg install grafana9-9.5.7_2
+pkg install grafana-10.4.5_1
 echo grafana_enable="yes" >> /etc/rc.conf
 # Only needed if grafana fails to start via rc.conf
 echo "cd /tmp && /usr/local/etc/rc.d/grafana onestart" >> /etc/rc.local

--- a/website/docs/maintenance/backup_restore.md
+++ b/website/docs/maintenance/backup_restore.md
@@ -41,16 +41,10 @@ docker compose stop teslamate
 
 # Drop existing data and reinitialize (Don't forget to replace first teslamate if using different TM_DB_USER)
 docker compose exec -T database psql -U teslamate teslamate << .
-drop schema public cascade;
-create schema public;
-create extension cube;
-create extension earthdistance;
-CREATE OR REPLACE FUNCTION public.ll_to_earth(float8, float8)
-    RETURNS public.earth
-    LANGUAGE SQL
-    IMMUTABLE STRICT
-    PARALLEL SAFE
-    AS 'SELECT public.cube(public.cube(public.cube(public.earth()*cos(radians(\$1))*cos(radians(\$2))),public.earth()*cos(radians(\$1))*sin(radians(\$2))),public.earth()*sin(radians(\$1)))::public.earth';
+DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+CREATE EXTENSION cube WITH SCHEMA public;
+CREATE EXTENSION earthdistance WITH SCHEMA public;
 .
 
 # Restore


### PR DESCRIPTION
PostgreSQL 17 is mentioning a change in how functions are using search_path. "Functions used by expression indexes and materialized views that need to reference non-default schemas must specify a search path during function creation."

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=2af07e2f7

OOTB earthdistance is not specifying a search path causing migration failures as earth_box and ll_to_earth have been used in indexes (they aren't any longer).

Therefore:

- change the migrations executed in the past to allow setup & testsuite to complete when using PostgreSQL 17

And as last indexes involing ll_to_earth / earth_box have been dropped in `20200502140646_drop_unused_indexes.exs` / `20191007105010_add_new_fkey_indexes.exs`:

- Add a new migration that drops and recreates the extensions so we ensure they are not manipulated any longer (`20191008191431_fix_ll_to_earth.exs`)
- rework Backup & Restore, as ll_to_earth is not used in indexes anymore the SQL used there is not needed

Updated Solution is taken from here (Adrian mentioned this issue back in 2019 as well):

- https://github.com/diogob/activerecord-postgres-earthdistance/issues/30#issuecomment-2122829036

Next to upgrading to PostgreSQL 17 I changed / updated some install docs as well to stay in line with currently supported / recommended versions of Grafana & Postgres.

Updated Restore instructions have been tested successfully on my instance.

PostgreSQL issue discussion: https://postgrespro.com/list/thread-id/2377019