### PR TITLE
docs: add recommended RAM size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - doc: fix markdownlint warnings in fleet api documentation (#4173 - @JakobLichterfeld)
 - doc: clarify using fleet api has lots of drawbacks (#4173 - @JakobLichterfeld)
 - docs: fix Home Assistant MQTT sensor JSON templates warnings (#4257 - @longzheng)
+- docs: add recommended RAM size (#4278 - @JakobLichterfeld)
 
 ## [1.30.1] - 2024-07-10
 

--- a/website/docs/installation/docker.md
+++ b/website/docs/installation/docker.md
@@ -11,7 +11,7 @@ This setup is recommended only if you are running TeslaMate **on your home netwo
 
 - Docker _(if you are new to Docker, see [Installing Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/linux/))_
 - A Machine that's always on, so TeslaMate can continually fetch data
-- At least 1 GB of RAM on the machine for the installation to succeed.
+- At least 1 GB of RAM on the machine for the installation to succeed. It is recommended to have at least 2 GB of RAM for optimal operation.
 - External internet access, to talk to tesla.com
 
 ## Instructions


### PR DESCRIPTION
Successor of #4250 

1GB of Ram is sufficient for installation. I personally have been running TeslaMate on a Raspberry Pi 3B+ with 1 GB Ram for 5 years without any problems. And yes, this does require some background knowledge, such as how to set up ZRAM.

Nevertheless, in this day and age it is advisable to have at least 2 GB Ram.

In version 1.30.1, we have increased the performance of a dashboard by a factor of 100. The next version will include further performance improvements and the dashboards run smoothly on a Raspberry Pi3 B with 1 GB Ram (there is only one value that takes a long time to load in a dashboard, but we will fix that too). In addition, we have improved the background load that occurs, e.g. to add missing elevation data etc. by a factor of 900.

