### PR TITLE
feat: use Grafana 11.0.6-security-01

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,6 +1,6 @@
 # Ensure selecting a tag that is available for arm/v7, arm64, and amd64
 # https://hub.docker.com/r/grafana/grafana/tags
-FROM grafana/grafana:11.0.1
+FROM grafana/grafana:11.0.6-security-01
 
 ENV GF_ANALYTICS_REPORTING_ENABLED=false \
     GF_AUTH_ANONYMOUS_ENABLED=false \


### PR DESCRIPTION
- bumps Grafana to 11.0.6-security-01 (https://grafana.com/blog/2024/10/17/grafana-security-release-critical-severity-fix-for-cve-2024-9264/)
- 11.0.x is latest version with geomap layer zoom working as of writing.