### PR TITLE
perf: exclude streaming data when getting battery level

### DIFF
--- a/grafana/dashboards/overview.json
+++ b/grafana/dashboards/overview.json
@@ -160,7 +160,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "(SELECT battery_level, date\nFROM positions\nWHERE car_id = $car_id\nORDER BY date DESC\nLIMIT 1)\nUNION\nSELECT battery_level, date\nFROM charges c\nJOIN charging_processes p ON p.id = c.charging_process_id\nWHERE $__timeFilter(date) AND p.car_id = $car_id\nORDER BY date DESC\nLIMIT 1",
+          "rawSql": "(SELECT battery_level, date\nFROM positions\nWHERE car_id = $car_id and ideal_battery_range_km is not null\nORDER BY date DESC\nLIMIT 1)\nUNION\nSELECT battery_level, date\nFROM charges c\nJOIN charging_processes p ON p.id = c.charging_process_id\nWHERE $__timeFilter(date) AND p.car_id = $car_id\nORDER BY date DESC\nLIMIT 1",
           "refId": "A",
           "select": [
             [
@@ -2167,6 +2167,6 @@
   "timezone": "",
   "title": "Overview",
   "uid": "kOuP_Fggz",
-  "version": 10,
+  "version": 13,
   "weekStart": ""
 }


### PR DESCRIPTION
another performance fix - query detected to be "slow" / having high mean_exec_time via pg_stat_statements.

in difference to other queries the "Battery Level" in "Overview" dashboard is not filtering positions based on selected time range causing a filter over positions_date_index.

adding the condition `ideal_battery_range_km is not null` is ok here, reduces rows to scan drastically.

could be further optimized (not neccessary) if adding time range filter to positions subquery, however the value would be empty then if no data recorded in last 24 hours.

i wonder if positions_car_id_index and positions_date_index provide the best value as positions data is filtered by car & date in most cases and indexes cannot be combined. it might be benefitical to change those indexes similary to the change of the positions_drive_id_index in https://github.com/teslamate-org/teslamate/pull/3186