### PR TITLE
perf: exclude streaming data in visited dashboard

### DIFF
--- a/grafana/dashboards/visited.json
+++ b/grafana/dashboards/visited.json
@@ -213,7 +213,7 @@
           "format": "table",
           "hide": false,
           "rawQuery": true,
-          "rawSql": "SELECT\n  date_trunc('minute', date) as time,\n  avg(latitude) as latitude,\n  avg(longitude) as longitude\nFROM\n  positions\nWHERE\n  car_id = $car_id AND $__timeFilter(date)\nGROUP BY 1\nORDER BY 1",
+          "rawSql": "SELECT\n  date_trunc('minute', date) as time,\n  avg(latitude) as latitude,\n  avg(longitude) as longitude\nFROM\n  positions\nWHERE\n  car_id = $car_id AND $__timeFilter(date) and ideal_battery_range_km is not null\nGROUP BY 1\nORDER BY 1",
           "refId": "Positions",
           "sql": {
             "columns": [
@@ -738,7 +738,6 @@
     "from": "now-90d",
     "to": "now"
   },
-  "timeRangeUpdatedDuringEditOrView": false,
   "timepicker": {
     "refresh_intervals": [
       "5s",
@@ -767,6 +766,6 @@
   "timezone": "",
   "title": "Visited",
   "uid": "RG_DxSmgk",
-  "version": 3,
+  "version": 5,
   "weekStart": ""
 }


### PR DESCRIPTION
exclude streaming data in visited dashboard as well. query has been found to be "slow" by checking pg_stat_statements.

as data is bucketed by minute and non streaming data is gathered every 15 seconds i see no reason not to do. greatly reduces query time.

i just want to mention one discussion around a similar change (index on odometer) back from april #3801 where @DrMichael voted against adding this index.

i still think it's right to add it based on all the improvements making it into this release.

@JakobLichterfeld - last PR from my end. voting to include these and cutting a release afterwards.