### PR TITLE
docs: add best practice section to contribution guide

### DIFF
--- a/website/docs/development.md
+++ b/website/docs/development.md
@@ -141,7 +141,21 @@ The Grafana VS Code extension allows you to open Grafana dashboards as JSON file
 
 see: [grafana-vs-code-extension](https://github.com/grafana/grafana-vs-code-extension)
 
-### Best Practices
+## Best Practices
+
+### Queries involving timestamp columns
+
+Datetime values are currently stored in columns of type `timestamp`. [This is NOT recommended](https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timestamp_.28without_time_zone.29_to_store_UTC_times).
+
+While [Grafana macros](https://grafana.com/docs/grafana/latest/datasources/postgres/#macros) like `$__timeFilter` & `$__timeGroup` are working PostgreSQL functions like `DATE_TRUNC()` require additional treatment.
+
+```sql
+DATE_TRUNC('day', TIMEZONE('UTC', date))
+```
+
+In addition ensure to compare either values with or without time zone.
+
+### Streaming API data / positions table usage in dashboard queries
 
 When Streaming API is enabled roughly 1 GB of data is gathered per car and 30.000km. Most of that data (95+ percent) is stored in positions table. For optimal dashboard performance these recommendations should be followed:
 

--- a/website/docs/development.md
+++ b/website/docs/development.md
@@ -182,7 +182,7 @@ To quickly identify performance bottlenecks we encourage all contributors to ena
 - Create Extension to enable `pg_stat_statements` view
 
   ```sql
-  CREATE EXTENSION IF NOT EXISTS `pg_stat_statements`;
+  CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
   ```
 
 - Identify potentially slow queries (mean_exec_time)

--- a/website/docs/development.md
+++ b/website/docs/development.md
@@ -165,6 +165,7 @@ When Streaming API is enabled roughly 1 GB of data is gathered per car and 30.00
 Before opening pull requests please diagnose index usage & query performance by making use of `EXPLAIN ANALYZE`.
 
 ### Enable _pg_stat_statements_ to collect query statistics
+
 To quickly identify performance bottlenecks we encourage all contributors to enable the pg_stat_statements extension in their instance. For docker based installs you can follow these steps:
 
 - Enable the pg_stat_statements module


### PR DESCRIPTION
this adds a best practice section to contribution guide:

- usage of timestamp columns
- enabling pg_stat_statements
- usage of streaming api / positions table in dashboard queries

fixes #4269