### PR TITLE
docs: update Home Assistant integration documentation with configuration URL and model name hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - build(deps): bump cachix/install-nix-action from 27 to 30 (#4342)
 - build(deps): bump tesla from 1.12.1 to 1.13.0 (#4335)
 - build(deps): bump floki from 0.36.2 to 0.36.3 (#4336)
+- feat: add CONTRIBUTING file to exclusion lists for treefmt
 
 #### Dashboards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - build(deps): bump cachix/install-nix-action from 27 to 30 (#4342)
 - build(deps): bump tesla from 1.12.1 to 1.13.0 (#4335)
 - build(deps): bump floki from 0.36.2 to 0.36.3 (#4336)
-- feat: add CONTRIBUTING file to exclusion lists for treefmt
+- feat: add CONTRIBUTING file to exclusion lists for treefmt (#4359 - @JakobLichterfeld)
 
 #### Dashboards
 
@@ -31,6 +31,7 @@
 #### Documentation
 
 docs: add contributing guidelines link for GitHub (#4345 - @JakobLichterfeld)
+docs: update Home Assistant integration documentation with configuration URL and model name hints (#4359 - @JakobLichterfeld)
 
 ## [1.31.1] - 2024-10-29
 

--- a/nix/flake-modules/formatter.nix
+++ b/nix/flake-modules/formatter.nix
@@ -19,6 +19,7 @@
           "*.dockerignore"
           ".envrc"
           "*.node-version"
+          "CONTRIBUTING"
           "Dockerfile"
           "grafana/Dockerfile"
           "Makefile"

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -6,6 +6,7 @@ excludes = [
     "*.dockerignore",
     ".envrc",
     "*.node-version",
+    "CONTRIBUTING",
     "Dockerfile",
     "grafana/Dockerfile",
     "Makefile",

--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -1,21 +1,27 @@
 ---
-title: HomeAssistant Integration
-sidebar_label: HomeAssistant
+title: Home Assistant Integration
+sidebar_label: Home Assistant
 ---
 
-Whilst HomeAssistant provides an official component for Tesla vehicles, the component has not been updated recently, and does not have the sophistication of TeslaMate's polling mechanism, resulting in the component's default values keeping the vehicle awake and draining the battery.
+## Introduction
+
+Whilst Home Assistant provides an official component for Tesla vehicles, the component has not been updated recently, and does not have the sophistication of TeslaMate's polling mechanism, resulting in the component's default values keeping the vehicle awake and draining the battery.
 
 The ultimate goal of this guide is to consume as much of the TeslaMate polling data as possible to replace the majority of the official Tesla component's polling functionality.
 
 If your intention is to only use read-only sensor values, those provided by TeslaMate via MQTT are sufficient, and you do not need to utilise the official Tesla component. If however you would like to be able to write values to the Tesla API (Lock/Unlock Doors or automate Climate), there is a solution which involves configuring an extremely high polling interval for the Tesla component and using automation to populate the values from the TeslaMate MQTT parameters.
 
-**Screenshots**
+### Car ID
+
+The following configuarations assumes a car ID of 1 (`teslamate/cars/1`). It usually starts at 1, but it can be different if you have multiple cars in TeslaMate for example.
+
+### Screenshots
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 <img alt="HASS Screenshot" src={useBaseUrl('img/hass-dashboard.png')} />
 
-**Current Status**
+### Current Status
 
 - Sensors: All sensors exposed by the Tesla component are available
 - Locks: Not implemented
@@ -53,7 +59,7 @@ binary_sensor: !include binary_sensor.yaml
 
 ### mqtt_sensors.yaml (mqtt: section of configuration.yaml)
 
-Don't forget to replace `<teslamate url>` and `<your tesla model>` with correct corresponding values.
+Don't forget to replace `<teslamate url>`, `<your tesla model>` and `<your tesla name>` with correct corresponding values.
 
 ```yml title="mqtt_sensors.yaml"
 - sensor:
@@ -66,10 +72,10 @@ Don't forget to replace `<teslamate url>` and `<your tesla model>` with correct 
         payload_not_available: "false"
     device: &teslamate_device_info
       identifiers: [teslamate_car_1]
-      configuration_url: https://teslamate.zxxz.io/ # update this with your teslamate URL
+      configuration_url: <teslamate url> # update this with your teslamate URL, e.g. https://teslamate.example.com/
       manufacturer: Tesla
-      model: Model 3 # update this with your car model
-      name: Tesla Model 3 # update this with your car name
+      model: Model 3 # <your tesla model>, update this with your car model
+      name: Tesla Model 3 # <your tesla name> update this with your car name
     state_topic: "teslamate/cars/1/display_name"
     icon: mdi:car
 
@@ -1045,7 +1051,8 @@ The following set of automations and scripts will detect when a Tesla door, frun
 
 By default, the script will repeatedly notify every 5 minutes. Remove the recursive `script.turn_on` sequence in the `notify_tesla_open` script if you'd only like to be informed once.
 
-We add the random 30 second interval after each notification to avoid clobbering the notification script when we have multiple things open at once. For example, opening the door will open the door and the window. If we don't delay the calls, we will only get a message about the window (as it is the last call to the script) and if we then close the window, we won't get notifications about other things left open. This results in more notifications but less chance on missing out on knowing something was left open.
+We add the random 30 second interval after each notification to avoid clobbering the notification script when we have multiple things open at once.
+For example, opening the door will open the door and the window. If we don't delay the calls, we will only get a message about the window (as it is the last call to the script) and if we then close the window, we won't get notifications about other things left open. This results in more notifications but less chance on missing out on knowing something was left open.
 
 #### automation.yaml
 

--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -74,8 +74,8 @@ Don't forget to replace `<teslamate url>`, `<your tesla model>` and `<your tesla
       identifiers: [teslamate_car_1]
       configuration_url: <teslamate url> # update this with your teslamate URL, e.g. https://teslamate.example.com/
       manufacturer: Tesla
-      model: Model 3 # <your tesla model>, update this with your car model
-      name: Tesla Model 3 # <your tesla name> update this with your car name
+      model: <your tesla model> # update this with your car model, e.g. Model 3
+      name: <your tesla name> # update this with your car name, e.g. Tesla Model 3
     state_topic: "teslamate/cars/1/display_name"
     icon: mdi:car
 

--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -66,10 +66,10 @@ Don't forget to replace `<teslamate url>` and `<your tesla model>` with correct 
         payload_not_available: "false"
     device: &teslamate_device_info
       identifiers: [teslamate_car_1]
-      configuration_url: https://teslamate.zxxz.io/
+      configuration_url: https://teslamate.zxxz.io/ # update this with your teslamate URL
       manufacturer: Tesla
-      model: Model 3
-      name: Tesla Model 3
+      model: Model 3 # update this with your car model
+      name: Tesla Model 3 # update this with your car name
     state_topic: "teslamate/cars/1/display_name"
     icon: mdi:car
 

--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -11,10 +11,6 @@ The ultimate goal of this guide is to consume as much of the TeslaMate polling d
 
 If your intention is to only use read-only sensor values, those provided by TeslaMate via MQTT are sufficient, and you do not need to utilise the official Tesla component. If however you would like to be able to write values to the Tesla API (Lock/Unlock Doors or automate Climate), there is a solution which involves configuring an extremely high polling interval for the Tesla component and using automation to populate the values from the TeslaMate MQTT parameters.
 
-### Car ID
-
-The following configuarations assumes a car ID of 1 (`teslamate/cars/1`). It usually starts at 1, but it can be different if you have multiple cars in TeslaMate for example.
-
 ### Screenshots
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -28,6 +24,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 - Climate: Not implemented
 
 ## Configuration
+
+The following configurations assume a car ID of 1 (`teslamate/cars/1`). It usually starts at 1, but it can be different if you have multiple cars in TeslaMate for example.
 
 ### configuration.yaml
 


### PR DESCRIPTION
fixes #4351 