### PR TITLE
ci: create PR to udpate flake.lock every saturday

### DIFF
--- a/.github/workflows/update-flack-lock.yml
+++ b/.github/workflows/update-flack-lock.yml
@@ -1,0 +1,25 @@
+---
+name: update-flake-lock
+on:
+  workflow_dispatch:
+  schedule:
+    # runs weekly on Saturday at 00:00 UTC time
+    - cron: "0 0 * * 6"
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install Nix
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 #v30
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        id: update
+        uses: DeterminateSystems/update-flake-lock@a2bbe0274e3a0c4194390a1e445f734c597ebc37 #v24
+        with:
+          pr-title: "Update flake.lock"
+      - name: Print PR number
+        run: echo Pull request number is ${{ steps.update.outputs.pull-request-number }}.


### PR DESCRIPTION
If this works it should create PRs that look a bit like https://github.com/brianmay/robotica-rust/pull/701

Caveats:

* Might have problems because I didn't create a personal token. Hoping this won't be required, but for personal project found it was. Particularly with dependabot. See https://github.com/DeterminateSystems/update-flake-lock?tab=readme-ov-file#with-a-personal-authentication-token
* Might have implications for running out of cache space, see #4297.
* Not sure what timezone this cron job uses.