### PR TITLE
docs: Introducing TeslaMate Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![](https://img.shields.io/docker/v/teslamate/teslamate/latest)](https://hub.docker.com/r/teslamate/teslamate)
 [![](https://img.shields.io/docker/image-size/teslamate/teslamate/latest)](https://hub.docker.com/r/teslamate/teslamate)
 [![](https://img.shields.io/docker/pulls/teslamate/teslamate?color=%23099cec)](https://hub.docker.com/r/teslamate/teslamate)
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20TeslaMate%20Guru-006BFF)](https://gurubase.io/g/teslamate)
 
 A powerful, self-hosted data logger for your Tesla.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![](https://img.shields.io/docker/v/teslamate/teslamate/latest)](https://hub.docker.com/r/teslamate/teslamate)
 [![](https://img.shields.io/docker/image-size/teslamate/teslamate/latest)](https://hub.docker.com/r/teslamate/teslamate)
 [![](https://img.shields.io/docker/pulls/teslamate/teslamate?color=%23099cec)](https://hub.docker.com/r/teslamate/teslamate)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20TeslaMate%20Guru-006BFF)](https://gurubase.io/g/teslamate)
 
 A powerful, self-hosted data logger for your Tesla.
 

--- a/website/docs/projects.md
+++ b/website/docs/projects.md
@@ -90,3 +90,9 @@ For all [TeslaMate](https://www.myteslamate.com) users, MyTeslaMate also provide
 LINK: [MyTeslaMate Website](https://www.myteslamate.com)
 
 LINK: [Follow this guide](/docs/guides/api#myteslamate-fleet-api) to use official Tesla APIs on your Teslamate.
+
+## [TeslaMate Guru on Gurubase](https://gurubase.io/g/teslamate)
+
+TeslaMate Guru is a TeslaMate-focused AI to answer your questions. It primarily uses the TeslaMate documentation and the TeslaMate GitHub repository to generate responses.
+
+LINK: [https://gurubase.io/g/teslamate](https://gurubase.io/g/teslamate)


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [TeslaMate Guru](https://gurubase.io/g/teslamate) to Gurubase. TeslaMate Guru uses the data from this repo and data from the [docs](https://docs.teslamate.org) to answer questions by leveraging the LLM.

In this PR, I showcased the "TeslaMate Guru", which highlights that TeslaMate now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable TeslaMate Guru in Gurubase, just let me know that's totally fine.
