### PR TITLE
fix(nix): wait for mosquitto to start before starting teslamate

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -173,6 +173,7 @@ in
         after = [
           "network.target"
           "postgresql.service"
+          "mosquitto.service"
         ];
         wantedBy = mkIf cfg.autoStart [ "multi-user.target" ];
         serviceConfig = {


### PR DESCRIPTION
After reboot, I noticed a number of errors from teslamate, because it started before mosquitto started.