### PR TITLE
fix: update mix deps hash to fix build error on recent NixOS 24.11 update

### DIFF
--- a/nix/flake-modules/package.nix
+++ b/nix/flake-modules/package.nix
@@ -13,7 +13,7 @@
         TOP_SRC = src;
         pname = "${pname}-mix-deps";
         inherit src version;
-        hash = "sha256-RVsoxqRtOmtFJgzLc0W6WPkcljsebtreAa63n5PMskI=";
+        hash = "sha256-lJmT6HJ3bsfMp8ZboX0gW7pa4gnSb6d0bewAc6Vptqg=";
         # hash = pkgs.lib.fakeHash;
       };
 


### PR DESCRIPTION
After upgrading to NixOS 24.11 and using the latest commit (1b839e6195228226afcf700a4d5a3a19ad81459b) of TeslaMate, I encountered a build error on my local machine due to a hash value mismatch.
```bash
error: hash mismatch in fixed-output derivation '/nix/store/9vp8qny77s6xzars89nz5vffcnwh7ryw-teslamate-mix-deps-1.32.1-dev.drv':
         specified: sha256-RVsoxqRtOmtFJgzLc0W6WPkcljsebtreAa63n5PMskI=
            got:    sha256-lJmT6HJ3bsfMp8ZboX0gW7pa4gnSb6d0bewAc6Vptqg=
error: 1 dependencies of derivation '/nix/store/wm488dqgqphk179k250mvgs6p7k9ihf3-teslamate-1.32.1-dev.drv' failed to build
error: 1 dependencies of derivation '/nix/store/34wbva9b95ffcw233kvfpv3x14cx1abi-unit-teslamate.service.drv' failed to build
error: 1 dependencies of derivation '/nix/store/lygi5n0m2ygvqxjnbag2bx3b3q5gmqyv-system-units.drv' failed to build
error: 1 dependencies of derivation '/nix/store/1rpf3mri9jbdhz16lpyiy6458k4p40wi-etc.drv' failed to build
error: 1 dependencies of derivation '/nix/store/6q1rg3k3y2v49pqwgzldz9z4nxr7mja0-nixos-system-unit-01-24.11.20241205.4dc2fc4.drv' failed to build
```

This PR updates the hash to the correct value. (I'm not a NixOS expert, so I'm not sure if this is the most nixy way to resolve it.)