### PR TITLE
OTP 27.2 exploration

### DIFF
--- a/.github/actions/setup-elixir-and-cache-deps/action.yml
+++ b/.github/actions/setup-elixir-and-cache-deps/action.yml
@@ -4,11 +4,11 @@ inputs:
   elixir-version:
     description: "Elixir version"
     required: false
-    default: "1.17.3"
+    default: "1.18.1"
   otp-version:
     description: "OTP version"
     required: false
-    default: "26"
+    default: "27"
   cache-name-deps:
     description: "Cache name for dependencies"
     required: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.17.3-otp-26 AS builder
+FROM elixir:1.18.1-otp-27 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/nix/flake-modules/package.nix
+++ b/nix/flake-modules/package.nix
@@ -2,8 +2,8 @@
 {
   perSystem = { lib, pkgs, system, ... }:
     let
-      elixir = pkgs.beam.packages.erlang_26.elixir_1_17;
-      beamPackages = pkgs.beam.packagesWith pkgs.beam.interpreters.erlang_26;
+      elixir = pkgs.beam.packages.erlang_27.elixir_1_17;
+      beamPackages = pkgs.beam.packagesWith pkgs.beam.interpreters.erlang_27;
 
       src = ../..;
       version = builtins.readFile "${src}/VERSION";

--- a/website/docs/development.md
+++ b/website/docs/development.md
@@ -6,7 +6,7 @@ sidebar_label: Development and Contributing
 
 ## Requirements
 
-- **Elixir** >= 1.17.3-otp-26
+- **Elixir** >= 1.18.1-otp-27
 - **Postgres** >= 17
 - An **MQTT broker** e.g. mosquitto (_optional_)
 - **NodeJS** >= 20.15.0


### PR DESCRIPTION
OTP brought performance issues, that's why we are sticking at OTP 26. -> #4319 / #4307

As [27.1.3 has been released](https://www.erlang.org/patches/otp-27.1.3), let's try and see if regressions have been resolved.