### PR TITLE
fix: url for releases in home dashboard

### DIFF
--- a/grafana/dashboards/internal/home.json
+++ b/grafana/dashboards/internal/home.json
@@ -87,7 +87,7 @@
       },
       "id": 3,
       "options": {
-        "feedUrl": "https://corsproxy.io/?https://github.com/teslamate-org/teslamate/tags.atom",
+        "feedUrl": "https://corsproxy.io/?url=https://github.com/teslamate-org/teslamate/tags.atom",
         "showImage": false
       },
       "pluginVersion": "11.4.0",


### PR DESCRIPTION
Grafana panel "Releases" in dashboard Internal > Home wasn't loading because the url format of corsproxy.io changed.