### PR TITLE
docs: Grafana 11.4 for manual install on FreeBSD

### DIFF
--- a/website/docs/installation/freebsd.md
+++ b/website/docs/installation/freebsd.md
@@ -70,15 +70,11 @@ service postgresql initdb
 </details>
 
 <details>
-  <summary>Grafana (v10.4.5+)</summary>
-
-(might be obsolete with Grafana 9, I had no issues with a fresh install) The latest Grafana from ports/pkg has a startup issue with the rc script, starting via rc.local is the workaround.
+  <summary>Grafana (v11.4.0+)</summary>
 
 ```bash
-pkg install grafana-10.4.5_1
+pkg install grafana
 echo grafana_enable="yes" >> /etc/rc.conf
-# Only needed if grafana fails to start via rc.conf
-echo "cd /tmp && /usr/local/etc/rc.d/grafana onestart" >> /etc/rc.local
 ```
 
 </details>


### PR DESCRIPTION
Bump Grafana to 11.4.0 as it became available in FreeBSD finally (now in line with all other install methods)

https://www.freshports.org/www/grafana/#history