### PR TITLE
fix: update mix dependency hash in nix builds.

### DIFF
--- a/nix/flake-modules/package.nix
+++ b/nix/flake-modules/package.nix
@@ -13,7 +13,7 @@
         TOP_SRC = src;
         pname = "${pname}-mix-deps";
         inherit src version;
-        hash = "sha256-eJlaKYIitGGMq5ll5N3vQQLlZKl6/s3fAT771qv+MnE=";
+        hash = "sha256-hdZJP6LIAY4VZDkuGJ/EdhofA6hTF+ZlTqRbSmPxKHk=";
         # hash = pkgs.lib.fakeHash;
       };
 


### PR DESCRIPTION
Fixed the hash mismatch so nix can build.

Tested locally on an x86 machine running NixOS 24.11.