### PR TITLE
feat: check Postgres version on startup, require 16.7 / 17.3, update earthdistance extension

### DIFF
--- a/lib/teslamate/application.ex
+++ b/lib/teslamate/application.ex
@@ -11,6 +11,8 @@ defmodule TeslaMate.Application do
     :ok = :telemetry.detach({Phoenix.Logger, [:phoenix, :socket_connected]})
     :ok = :telemetry.detach({Phoenix.Logger, [:phoenix, :channel_joined]})
 
+    TeslaMate.DatabaseCheck.check_postgres_version()
+
     Supervisor.start_link(children(), strategy: :one_for_one, name: TeslaMate.Supervisor)
   end
 

--- a/lib/teslamate/database_check.ex
+++ b/lib/teslamate/database_check.ex
@@ -1,0 +1,61 @@
+defmodule TeslaMate.DatabaseCheck do
+  alias Ecto.Adapters.SQL
+  alias TeslaMate.Repo
+
+  # Minimum versions for supported major releases
+  @min_version_16 "16.7"
+  @min_version_17 "17.3"
+
+  def check_postgres_version do
+    # Start the Repo manually without running migrations
+    {:ok, _pid} = Repo.start_link()
+
+    # Query the PostgreSQL version
+    {:ok, result} = SQL.query(Repo, "SELECT regexp_replace(version(), 'PostgreSQL ([^ ]+) .*', '\\1') AS version", [])
+    raw_version = result.rows |> List.first() |> List.first()
+
+    # Normalize to SemVer by appending .0 if needed
+    version = normalize_version(raw_version)
+
+    # Split into major and minor parts
+    [major, _minor] = String.split(version, ".", parts: 2)
+    major_int = String.to_integer(major)
+
+    # Check based on major version
+    case major_int do
+      16 ->
+        case Version.compare(version, normalize_version(@min_version_16)) do
+          :lt ->
+            raise "PostgreSQL version #{raw_version} is not supported. Minimum required for 16.x is #{@min_version_16}."
+          _ ->
+            IO.puts("PostgreSQL version #{raw_version} is compatible (16.x series).")
+        end
+
+      17 ->
+        case Version.compare(version, normalize_version(@min_version_17)) do
+          :lt ->
+            raise "PostgreSQL version #{raw_version} is not supported. Minimum required for 17.x is #{@min_version_17}."
+          _ ->
+            IO.puts("PostgreSQL version #{raw_version} is compatible (17.x series).")
+        end
+
+      major_int when major_int > 17 ->
+        IO.puts("PostgreSQL version #{raw_version} is not officially tested or supported yet. Use at your own risk.")
+
+      _ ->
+        raise "PostgreSQL version #{raw_version} is not supported. Only 16.x (min #{@min_version_16}) and 17.x (min #{@min_version_17}) are supported."
+    end
+
+    # Stop the Repo after the check
+    Repo.stop()
+  end
+
+  # Helper function to normalize PostgreSQL version to SemVer
+  defp normalize_version(version) do
+    case String.split(version, ".") do
+      [major, minor] -> "#{major}.#{minor}.0"
+      [major, minor, patch | _] -> "#{major}.#{minor}.#{patch}"
+      _ -> raise "Invalid PostgreSQL version format: #{version}"
+    end
+  end
+end

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -82,8 +82,7 @@ in
         '';
       };
 
-      package = mkPackageOption pkgs "postgresql_16" {
-        # 17 is not yet available in nixpkgs
+      package = mkPackageOption pkgs "postgresql_17" {
         extraDescription = ''
           The postgresql package to use.
         '';

--- a/priv/repo/migrations/20250407155134_upgrade_earthdistance.exs
+++ b/priv/repo/migrations/20250407155134_upgrade_earthdistance.exs
@@ -1,0 +1,7 @@
+defmodule TeslaMate.Repo.Migrations.UpgradeEarthdistance do
+  use Ecto.Migration
+
+  def change do
+    execute("ALTER EXTENSION earthdistance UPDATE")
+  end
+end

--- a/website/docs/development.md
+++ b/website/docs/development.md
@@ -7,7 +7,7 @@ sidebar_label: Development and Contributing
 ## Requirements
 
 - **Elixir** >= 1.17.3-otp-26
-- **Postgres** >= 17
+- **Postgres** >= 17.3
 - An **MQTT broker** e.g. mosquitto (_optional_)
 - **NodeJS** >= 20.15.0
 

--- a/website/docs/installation/debian.md
+++ b/website/docs/installation/debian.md
@@ -10,7 +10,7 @@ This document provides the necessary steps for installation of TeslaMate on a va
 Click on the following items to view detailed installation steps.
 
 <details>
-  <summary>Postgres (v17+)</summary>
+  <summary>Postgres (v17.3+)</summary>
 
 ```bash
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
@@ -37,7 +37,7 @@ Source: [erlang.org/downloads](https://www.erlang.org/downloads#prebuilt)
 </details>
 
 <details>
-  <summary>Grafana (v11.5.0+)</summary>
+  <summary>Grafana (v11.6.0+)</summary>
 
 ```bash
 sudo apt-get install -y apt-transport-https software-properties-common

--- a/website/docs/installation/freebsd.md
+++ b/website/docs/installation/freebsd.md
@@ -50,11 +50,11 @@ pkg install elixir
 </details>
 
 <details>
-  <summary>Postgres (v17+)</summary>
+  <summary>Postgres (v17.3+)</summary>
 
 ```bash
-pkg install postgresql17-server-17.0
-pkg install postgresql17-contrib-17.0
+pkg install postgresql17-server
+pkg install postgresql17-contrib
 echo postgres_enable="yes" >> /etc/rc.conf
 ```
 
@@ -70,7 +70,7 @@ service postgresql initdb
 </details>
 
 <details>
-  <summary>Grafana (v11.5.0+)</summary>
+  <summary>Grafana (v11.6.0+)</summary>
 
 ```bash
 pkg install grafana
@@ -93,8 +93,8 @@ echo mosquitto_enable="yes" >> /etc/rc.conf
   <summary>Node.js (v20+)</summary>
 
 ```bash
-pkg install node20-20.18.1
-pkg install npm-node20-10.9.0
+pkg install node20
+pkg install npm-node20
 ```
 
 </details>


### PR DESCRIPTION
This PR adds a check for on startup that validates the PostgreSQL version used.
Requirements are set to 16.7+ / 17.3+ - if not matched, an exception is raised.

In addition a migration is added that updates the earthdistance extension to 1.2 (bundled since 16.7 / 17.3).

Feedback welcome, fixes #4638 