### PR TITLE
docs: allow to add energy added to the Home Assistant's Energy tab to measure how much energy each session uses

### DIFF
--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -323,6 +323,7 @@ Don't forget to replace `<teslamate url>`, `<your tesla model>` and `<your tesla
     device: *teslamate_device_info
     state_topic: "teslamate/cars/1/charge_energy_added"
     device_class: energy
+    state_class: total
     unit_of_measurement: kWh
     icon: mdi:battery-charging
 


### PR DESCRIPTION
This commit adds the `state_class: total` in the energy sensor that allows to add it in the energy tab to measure how much energy each session consumes. The value is set to `total` as each charge session does not cumulative increase.