### PR TITLE
ci(dependabot): add ignore rules for path-based dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     directory: "/assets"
     schedule:
       interval: "monthly"
+    ignore:
+    # ignore the path based dependencies to prevent "Dependabot couldn't fetch all your path-based dependencies"
+      - dependency-name: phoenix
+      - dependency-name: phoenix_html
+      - dependency-name: phoenix_live_view
 
   - package-ecosystem: "npm"
     directory: "/website"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - build(deps): bump estree-util-value-to-estree in /website (#4641)
 - build(deps): update flake.lock (#4653)
 - fix(nix): update mix dependency hash in nix builds ([3d08431](https://github.com/teslamate-org/teslamate/commit/3d08431ee3de0eaf3d3045aa0018c687627c4dac) - @JakobLichterfeld)
+- ci(dependabot): add ignore rules for path-based dependencies (#4666 - @JakobLichterfeld)
 
 #### Dashboards
 


### PR DESCRIPTION
ignore the path based dependencies to prevent "Dependabot couldn't fetch all your path-based dependencies"