### PR TITLE
Update Teslemetry

### DIFF
--- a/website/docs/guides/api.md
+++ b/website/docs/guides/api.md
@@ -76,6 +76,8 @@ MyTeslaMate also provides streaming by [reproducing the old streaming from the d
 
 #### Teslemetry Fleet API
 
+**_Important: Teslemetry's vehicle data polling is [pay-per-use](https://teslemetry.com/blog/road-away-from-polling)._**
+
 1. Log in the [Teslemetry website](https://teslemetry.com) and create your `TOKEN`.
 1. Use this `TOKEN` instead of _`xxxx-xxxx-xxxx-xxxx`_ and add the following environment variables:
 
@@ -90,7 +92,7 @@ MyTeslaMate also provides streaming by [reproducing the old streaming from the d
 
 #### Teslemetry Streaming
 
-**_Important: no streaming provided by Teslemetry, you MUST disable manually the streaming in Teslamate settings._**
+**_Important: Teslemetry's streaming is incompatible with Teslamate, you MUST disable manually the streaming in Teslamate settings._**
 
 ## Guide to using the official Tesla API directly (free)
 


### PR DESCRIPTION
Hey Teslamate team! Teslemetry here.

We are [moving away](https://teslemetry.com/blog/road-away-from-polling) from `vehicle_data` polling on July 1st, which means the Teslamate approch of using Teslemetry's vehicle_data endpoint is likely going to get very expensive for users.

I am notifying my customers each month, but I want to make sure your documentation sets the right expectation too. If you would prefer to remove Teslemetry all together I fully understand.

I also tweaked the line about streaming. We do offer streaming, and in fact thats the primary way of consuming data in Teslemetry moving forward, however it is not a legacy compatible WSS stream like MyTeslaMate offers, but rather a SSE stream containing the near-raw fleet telemetry messages.

That said, looking at the code for `MyTeslaMate/websocket` I might consider adding a WSS option to Teslemetry if that helps mitigate the loss of vehicle_data.