### PR TITLE
feat: preserve the folders when restoring dashboards

### DIFF
--- a/grafana/dashboards.sh
+++ b/grafana/dashboards.sh
@@ -63,13 +63,9 @@ restore() {
 				--user "$LOGIN" \
 				-X POST -H "Content-Type: application/json" \
 				-d "{\"dashboard\":$(cat "$dashboard_path"), \
-                    \"overwrite\":true, \
-                    \"folderId\":$folder_id, \
-                    \"inputs\":[{\"name\":\"DS_CLOUDWATCH\", \
-                                 \"type\":\"datasource\", \
-                                 \"pluginId\":\"cloudwatch\", \
-                                 \"value\":\"TeslaMate\"}]}" \
-				"$URL/api/dashboards/import"
+					\"overwrite\":true, \
+					\"folderId\":$folder_id}" \
+				"$URL/api/dashboards/db"
 
 			echo "RESTORED $(basename "$dashboard_path")"
 		done

--- a/grafana/dashboards.sh
+++ b/grafana/dashboards.sh
@@ -57,7 +57,7 @@ backup() {
 restore() {
 	find "$DASHBOARDS_DIRECTORY" -type f -name \*.json -print0 |
 		while IFS= read -r -d '' dashboard_path; do
-			folder_id=$(get_folder_id "$(basename "$dashboard_path" .json)")
+			folder_id=$(get_folder_id "$(jq -r '.uid' <"$dashboard_path")")
 			curl \
 				--silent --fail --show-error --output /dev/null \
 				--user "$LOGIN" \
@@ -105,7 +105,7 @@ get_folder_id() {
 	curl \
 		--silent \
 		--user "$LOGIN" \
-		"$URL/api/dashboards/db/$dashboard" |
+		"$URL/api/dashboards/uid/$dashboard" |
 		jq '.meta | .folderId'
 }
 


### PR DESCRIPTION
Use the dashboard UID instead of the dashboard name to get the folder ID. This way, the dashboards get restored to their current location instead of the root folder.