### PR TITLE
fix(nix): update cldr hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improvements and bug fixes
 
+- fix(nix): update cldr hash (#4723 - @brianmay)
+
 #### Build, CI, internal
 
 #### Dashboards

--- a/nix/flake-modules/package.nix
+++ b/nix/flake-modules/package.nix
@@ -50,8 +50,8 @@
       cldr = pkgs.fetchFromGitHub {
         owner = "elixir-cldr";
         repo = "cldr";
-        rev = "v2.40.0";
-        sha256 = "sha256-B3kIJx684kg3uxdFaWWMn9SBktb1GUqCzSJwN1a0oNo=";
+        rev = "v2.42.0";
+        sha256 = "sha256-FLGUKfAKAKL2nqf/7YXQuuuEvVuSy2RVhZves9XOI1Q=";
         # sha256 = pkgs.lib.fakeHash;
       };
 


### PR DESCRIPTION
See https://github.com/teslamate-org/teslamate/discussions/4503

My feeling is that there should be a better solution. e.g. we should be able to use the files downloaded by `mixRelease`.

But my current home environment is somewhat distracting right now :-(

So this should do.