### PR TITLE
Grafana 12.0.0+security-01

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,6 +1,6 @@
 # Ensure selecting a tag that is available for arm/v7, arm64, and amd64
 # https://hub.docker.com/r/grafana/grafana/tags
-FROM grafana/grafana:12.0.0
+FROM grafana/grafana-oss:12.0.0-security-01
 
 ENV GF_ANALYTICS_REPORTING_ENABLED=false \
     GF_AUTH_ANONYMOUS_ENABLED=false \


### PR DESCRIPTION
Updates Grafana to Grafana 12.0.0+security-01

In addition change to grafana/grafana-oss as this is image referred to on the official download page.

https://grafana.com/grafana/download?edition=oss&platform=docker

(the digest is identicial to the one uploaded to grafana/grafana).