### PR TITLE
feat(mqtt): always publish healthy status and disable retain to prevent stale healthy status via mqtt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - feat: preserve the folders when restoring dashboards (#4715 - @IngmarStein)
 - feat: use Grafana 12.0.1+security-01 (#4799 - @swiffer)
 - feat: use Grafana 12.0.2 (#4805 - @swiffer)
+- feat(mqtt): always publish healthy status and disable retain to prevent stale healthy status via mqtt (#4817 - @allivshits)
 
 #### Build, CI, internal
 

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -24,15 +24,18 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
 
   @do_not_retain ~w(healthy)a
 
+  # Clears previously retained messages for topics that should not be retained
+  # This ensures backward compatibility by cleaning up stale retained messages
+  # from installations before PR #4817: https://github.com/teslamate-org/teslamate/pull/4817
   defp clear_retained(car_id, namespace, publisher) do
-    for key <- @do_not_retain do
+    Enum.each(@do_not_retain, fn key ->
       topic =
         ["teslamate", namespace, "cars", car_id, key]
         |> Enum.reject(&is_nil(&1))
         |> Enum.join("/")
 
       call(publisher, :publish, [topic, "", [retain: true, qos: 1]])
-    end
+    end)
   end
 
   @impl true

--- a/test/teslamate/vehicles/vehicle_sync_test.exs
+++ b/test/teslamate/vehicles/vehicle_sync_test.exs
@@ -146,8 +146,13 @@ defmodule TeslaMate.Vehicles.VehicleSyncTest do
           ] do
         topic = "teslamate/cars/#{car.id}/#{key}"
         data = to_string(val)
-        assert_receive {MqttPublisherMock, {:publish, ^topic, ^data, [retain: true, qos: 1]}}
+        retain = key not in [:healthy]
+        assert_receive {MqttPublisherMock, {:publish, ^topic, ^data, [retain: ^retain, qos: 1]}}
       end
+
+      # Handle the healthy message that's published separately with retain: true
+      topic = "teslamate/cars/#{car.id}/healthy"
+      assert_receive {MqttPublisherMock, {:publish, ^topic, "", [retain: true, qos: 1]}}
 
       topic = "teslamate/cars/#{car.id}/location"
       assert_receive {MqttPublisherMock, {:publish, ^topic, data, [retain: true, qos: 1]}}


### PR DESCRIPTION
This update improves MQTT health signaling by ensuring the :healthy topic is always published and never retained.

🔧 Key changes:

1. Introduced @do_not_retain for topics like :healthy that:
    - Must be published on every poll (even if value unchanged)
    - Must not be retained by the MQTT broker
2. Renamed @always_published to @publish_if_nil for clarity

✅ Benefit:
Prevents stale healthy: true messages from giving a false sense of system status. This makes TeslaMate easier to monitor using MQTT liveness tools like Home Assistant’s expire_after.