### PR TITLE
feat(nix): use datasources.settings.datasources to allow merging Grafana sources from multiple modules, correctly set default Grafana dashboard path and allow disabling default Grafana dashboard with setDefaultDashboard option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - feat(webview): show offline duration in extended view on mobile as well to improve UX (#4848 - @JakobLichterfeld)
 - feat: use Grafana 12.1.0 (#4855 - @swiffer)
+- feat(nix): use datasources.settings.datasources to allow merging Grafana sources from multiple modules (#4870 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - feat: use Grafana 12.1.0 (#4855 - @swiffer)
 - feat(nix): use datasources.settings.datasources to allow merging Grafana sources from multiple modules (#4870 - @JakobLichterfeld)
 - fix(nix): correctly set default Grafana dashboard path (#4870 - @JakobLichterfeld)
+- feat(nix): allow disabling default Grafana dashboard with setDefaultDashboard option (#4870 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - feat(webview): show offline duration in extended view on mobile as well to improve UX (#4848 - @JakobLichterfeld)
 - feat: use Grafana 12.1.0 (#4855 - @swiffer)
 - feat(nix): use datasources.settings.datasources to allow merging Grafana sources from multiple modules (#4870 - @JakobLichterfeld)
+- fix(nix): correctly set default Grafana dashboard path (#4870 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -266,10 +266,29 @@ in
           date_formats.use_browser_locale = true;
           plugins.preinstall_disabled = true;
           unified_alerting.enabled = false;
+          datasources.settings.datasources = [ # extracted from ../grafana/datasource.yml
+            {
+              name = "TeslaMate";
+              type = "postgres";
+              url = "http://${cfg.postgres.host}:${toString cfg.postgres.port}";
+              user = cfg.postgres.user;
+              access = "proxy";
+              basicAuth = false;
+              withCredentials = false;
+              isDefault = true;
+              secureJsonData.password = "\${DATABASE_PASS}";
+              jsonData = {
+                postgresVersion = 1500;
+                sslmode = "disable";
+                database = cfg.postgres.database;
+              };
+              version = 1;
+              editable = true;
+            }
+          ];
         };
         provision = {
           enable = true;
-          datasources.path = ../grafana/datasource.yml;
           # Need to duplicate dashboards.yml since it contains absolute paths
           # which are incompatible with NixOS
           dashboards.settings = {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -266,7 +266,8 @@ in
           date_formats.use_browser_locale = true;
           plugins.preinstall_disabled = true;
           unified_alerting.enabled = false;
-          datasources.settings.datasources = [ # extracted from ../grafana/datasource.yml
+          datasources.settings.datasources = [
+            # extracted from ../grafana/datasource.yml
             {
               name = "TeslaMate";
               type = "postgres";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -268,7 +268,7 @@ in
           "auth.anonymous".enabled = false;
           "auth.basic".enabled = false;
           analytics.reporting_enabled = false;
-          default_home_dashboard_path = mkIf cfg.grafana.setDefaultDashboard "${pkgs.lib.sources.sourceFilesBySuffices ../grafana/dashboards/internal [".json"]}/home.json";
+          dashboards.default_home_dashboard_path = mkIf cfg.grafana.setDefaultDashboard "${pkgs.lib.sources.sourceFilesBySuffices ../grafana/dashboards/internal [".json"]}/home.json";
           date_formats.use_browser_locale = true;
           plugins.preinstall_disabled = true;
           unified_alerting.enabled = false;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -272,6 +272,9 @@ in
           date_formats.use_browser_locale = true;
           plugins.preinstall_disabled = true;
           unified_alerting.enabled = false;
+        };
+        provision = {
+          enable = true;
           datasources.settings.datasources = [
             # extracted from ../grafana/datasource.yml
             {
@@ -293,9 +296,6 @@ in
               editable = true;
             }
           ];
-        };
-        provision = {
-          enable = true;
           # Need to duplicate dashboards.yml since it contains absolute paths
           # which are incompatible with NixOS
           dashboards.settings = {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -137,6 +137,12 @@ in
         default = "/";
         description = "Path that grafana is mounted on. Useful if using a reverse proxy to vend teslamate and grafana on the same port";
       };
+
+      setDefaultDashboard = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to set the TeslaMate home dashboard as the default dashboard in Grafana";
+      };
     };
 
     mqtt = {
@@ -262,7 +268,7 @@ in
           "auth.anonymous".enabled = false;
           "auth.basic".enabled = false;
           analytics.reporting_enabled = false;
-          default_home_dashboard_path = "${pkgs.lib.sources.sourceFilesBySuffices ../grafana/dashboards/internal [".json"]}/home.json";
+          default_home_dashboard_path = mkIf cfg.grafana.setDefaultDashboard "${pkgs.lib.sources.sourceFilesBySuffices ../grafana/dashboards/internal [".json"]}/home.json";
           date_formats.use_browser_locale = true;
           plugins.preinstall_disabled = true;
           unified_alerting.enabled = false;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -262,7 +262,7 @@ in
           "auth.anonymous".enabled = false;
           "auth.basic".enabled = false;
           analytics.reporting_enabled = false;
-          dashboards.default_home_dashboard_path = "../grafana/dashboards/internal/home.json";
+          default_home_dashboard_path = "${pkgs.lib.sources.sourceFilesBySuffices ../grafana/dashboards/internal [".json"]}/home.json";
           date_formats.use_browser_locale = true;
           plugins.preinstall_disabled = true;
           unified_alerting.enabled = false;


### PR DESCRIPTION
- [X] feat(nix): use datasources.settings.datasources to allow merging Grafana sources from multiple modules
- [X] fix(nix): correctly set default Grafana dashboard path
- [X] feat(nix): allow disabling default Grafana dashboard with setDefaultDashboard option