### PR TITLE
fix(migration): cast final result to smallint

### DIFF
--- a/lib/teslamate/log.ex
+++ b/lib/teslamate/log.ex
@@ -304,13 +304,13 @@ defmodule TeslaMate.Log do
            select: %{
              elevation_gains:
                fragment(
-                 "COALESCE(NULLIF(LEAST(SUM(CASE WHEN ? > 0 THEN ? ELSE 0 END), 32768), 32768), 0)",
+                 "COALESCE(NULLIF(LEAST(SUM(CASE WHEN ? > 0 THEN ? ELSE 0 END), 32768), 32768), 0)::SMALLINT",
                  p1.elevation_diff,
                  p1.elevation_diff
                ),
              elevation_losses:
                fragment(
-                 "COALESCE(NULLIF(LEAST(SUM(CASE WHEN ? < 0 THEN ABS(?) ELSE 0 END), 32768), 32768), 0)",
+                 "COALESCE(NULLIF(LEAST(SUM(CASE WHEN ? < 0 THEN ABS(?) ELSE 0 END), 32768), 32768), 0)::SMALLINT",
                  p1.elevation_diff,
                  p1.elevation_diff
                )

--- a/priv/repo/migrations/20250613133700_add_and_calculate_elevation_changes.exs
+++ b/priv/repo/migrations/20250613133700_add_and_calculate_elevation_changes.exs
@@ -14,8 +14,8 @@ defmodule TeslaMate.Repo.Migrations.AddAndCalculateElevationChanges do
     WITH elevation_changes AS (
       SELECT
         drive_id,
-        COALESCE(NULLIF(LEAST(SUM(CASE WHEN elevation_diff > 0 THEN elevation_diff ELSE 0 END), 32768), 32768), 0) as ascent,
-        COALESCE(NULLIF(LEAST(SUM(CASE WHEN elevation_diff < 0 THEN ABS(elevation_diff) ELSE 0 END), 32768), 32768), 0) as descent
+        COALESCE(NULLIF(LEAST(SUM(CASE WHEN elevation_diff > 0 THEN elevation_diff ELSE 0 END), 32768), 32768), 0)::SMALLINT as ascent,
+        COALESCE(NULLIF(LEAST(SUM(CASE WHEN elevation_diff < 0 THEN ABS(elevation_diff) ELSE 0 END), 32768), 32768), 0)::SMALLINT as descent
       FROM (
         SELECT
           drive_id,


### PR DESCRIPTION
The SUM function in the CTE produces a NUMERIC or BIGINT result, and even though you cap it with LEAST, the final value may not be explicitly cast to SMALLINT before being assigned to the drives table's ascent and descent columns