### PR TITLE
perf: Optimize Grafana query for trip view to leverage indexes more effectively

### DIFF
--- a/grafana/dashboards/trip.json
+++ b/grafana/dashboards/trip.json
@@ -176,7 +176,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n\t$__timeGroup(date, '5s') AS time,\n\tavg(latitude) AS latitude,\n\tavg(longitude) AS longitude\nFROM\n\tpositions\nWHERE\n  car_id = $car_id and (drive_id in (select id from drives where $__timeFilter(start_date)) or drive_id is null and $__timeFilter(date))\nGROUP BY\n\t1\nORDER BY\n\t1 ASC",
+          "rawSql": "SELECT\n  t.time AS time,\n  avg(t.latitude)  AS latitude,\n  avg(t.longitude) AS longitude\nFROM (\n  SELECT\n    $__timeGroup(p.date, '5s') AS time,\n    avg(p.latitude)  AS latitude,\n    avg(p.longitude) AS longitude\n  FROM positions p\n  JOIN drives d ON d.id = p.drive_id\n  WHERE p.car_id = $car_id\n    AND $__timeFilter(d.start_date)\n  GROUP BY 1\n\n  UNION ALL\n\n  SELECT\n    $__timeGroup(p.date, '5s') AS time,\n    avg(p.latitude)  AS latitude,\n    avg(p.longitude) AS longitude\n  FROM positions p\n  WHERE p.car_id = $car_id\n    AND p.drive_id IS NULL\n    AND $__timeFilter(p.date)\n  GROUP BY 1\n) AS t\nGROUP BY 1\nORDER BY 1 ASC\n",
           "refId": "A",
           "sql": {
             "columns": [

--- a/grafana/dashboards/trip.json
+++ b/grafana/dashboards/trip.json
@@ -176,7 +176,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n  t.time AS time,\n  avg(t.latitude)  AS latitude,\n  avg(t.longitude) AS longitude\nFROM (\n  SELECT\n    $__timeGroup(p.date, '5s') AS time,\n    avg(p.latitude)  AS latitude,\n    avg(p.longitude) AS longitude\n  FROM positions p\n  JOIN drives d ON d.id = p.drive_id\n  WHERE p.car_id = $car_id\n    AND $__timeFilter(d.start_date)\n  GROUP BY 1\n\n  UNION ALL\n\n  SELECT\n    $__timeGroup(p.date, '5s') AS time,\n    avg(p.latitude)  AS latitude,\n    avg(p.longitude) AS longitude\n  FROM positions p\n  WHERE p.car_id = $car_id\n    AND p.drive_id IS NULL\n    AND $__timeFilter(p.date)\n  GROUP BY 1\n) AS t\nGROUP BY 1\nORDER BY 1 ASC\n",
+          "rawSql": "with unioned_positions as (\n\n    -- fetch all positions based on start_date of drives so the map aligns with data shown in other panels\n    select p.*\n    from positions p\n             inner join drives d on p.drive_id = d.id\n    where p.car_id = $car_id and $__timeFilter(d.start_date)\n\n    union all\n\n    -- get all positions logged while not driving\n    select *\n    from positions p\n    where p.car_id = $car_id and drive_id is null and $__timeFilter(date))\n\nSELECT $__timeGroup(date, '5s')                AS time,\n       avg(latitude)                           AS latitude,\n       avg(longitude)                          AS longitude\nfrom unioned_positions\nGROUP BY 1\nORDER BY 1 ASC",
           "refId": "A",
           "sql": {
             "columns": [


### PR DESCRIPTION
This PR replaces the original positions aggregation query that used OR + subquery with a UNION ALL based query shape. The new form preserves the same result but allows PostgreSQL to leverage indexes more effectively.


old version:
```sql
SELECT
	$__timeGroup(date, '5s') AS time,
	avg(latitude) AS latitude,
	avg(longitude) AS longitude
FROM
	positions
WHERE
  car_id = $car_id and (drive_id in (select id from drives where $__timeFilter(start_date)) or drive_id is null and $__timeFilter(date))
GROUP BY
	1
ORDER BY
	1 ASC
```

new version:

```sql
SELECT
  t.time AS time,
  avg(t.latitude)  AS latitude,
  avg(t.longitude) AS longitude
FROM (
  SELECT
    $__timeGroup(p.date, '5s') AS time,
    avg(p.latitude)  AS latitude,
    avg(p.longitude) AS longitude
  FROM positions p
  JOIN drives d ON d.id = p.drive_id
  WHERE p.car_id = $car_id
    AND $__timeFilter(d.start_date)
  GROUP BY 1

  UNION ALL

  SELECT
    $__timeGroup(p.date, '5s') AS time,
    avg(p.latitude)  AS latitude,
    avg(p.longitude) AS longitude
  FROM positions p
  WHERE p.car_id = $car_id
    AND p.drive_id IS NULL
    AND $__timeFilter(p.date)
  GROUP BY 1
) AS t
GROUP BY 1
ORDER BY 1 ASC
```


for instance:
old version:
```sql
SELECT floor(extract(epoch from date) / 5) * 5 AS time,
       avg(latitude)                           AS latitude,
       avg(longitude)                          AS longitude
FROM positions
WHERE car_id = '1'
  and (drive_id in (select id from drives where start_date BETWEEN '2025-09-22T16:00:00Z' AND '2025-09-23T16:00:00Z')
    or drive_id is null and date BETWEEN '2025-09-22T16:00:00Z' AND '2025-09-23T16:00:00Z')
GROUP BY 1
ORDER BY 1 ASC
```

new version:
```sql
SELECT
  t.time AS time,
  avg(t.latitude)  AS latitude,
  avg(t.longitude) AS longitude
FROM (
  SELECT
    floor(extract(epoch from date) / 5) * 5 AS time,
    avg(p.latitude)  AS latitude,
    avg(p.longitude) AS longitude
  FROM positions p
  JOIN drives d ON d.id = p.drive_id
  WHERE p.car_id = '1'
    AND start_date BETWEEN '2025-09-22T16:00:00Z' AND '2025-09-23T16:00:00Z'
  GROUP BY 1

  UNION ALL

  SELECT
    floor(extract(epoch from date) / 5) * 5 AS time,
    avg(p.latitude)  AS latitude,
    avg(p.longitude) AS longitude
  FROM positions p
  WHERE p.car_id = '1'
    AND p.drive_id IS NULL
    AND date BETWEEN '2025-09-22T16:00:00Z' AND '2025-09-23T16:00:00Z'
  GROUP BY 1
) AS t
GROUP BY 1
ORDER BY 1 ASC

```


explain:
old version:
```
Finalize GroupAggregate  (cost=445244.60..1011242.59 rows=3871731 width=96)
  Group Key: ((floor((EXTRACT(epoch FROM positions.date) / '5'::numeric)) * '5'::numeric))
  ->  Gather Merge  (cost=445244.60..874118.79 rows=3226442 width=96)
        Workers Planned: 2
        ->  Partial GroupAggregate  (cost=444244.57..500707.31 rows=1613221 width=96)
              Group Key: ((floor((EXTRACT(epoch FROM positions.date) / '5'::numeric)) * '5'::numeric))
              ->  Sort  (cost=444244.57..448277.63 rows=1613221 width=48)
                    Sort Key: ((floor((EXTRACT(epoch FROM positions.date) / '5'::numeric)) * '5'::numeric))
                    ->  Parallel Seq Scan on positions  (cost=130.23..178656.29 rows=1613221 width=48)
                          Filter: ((car_id = '1'::smallint) AND ((ANY (drive_id = (hashed SubPlan 1).col1)) OR ((drive_id IS NULL) AND (date >= '2025-09-22 16:00:00'::timestamp without time zone) AND (date <= '2025-09-23 16:00:00'::timestamp without time zone))))
                          SubPlan 1
                            ->  Seq Scan on drives  (cost=0.00..130.22 rows=6 width=4)
                                  Filter: ((start_date >= '2025-09-22 16:00:00'::timestamp without time zone) AND (start_date <= '2025-09-23 16:00:00'::timestamp without time zone))
JIT:
  Functions: 23
"  Options: Inlining true, Optimization true, Expressions true, Deforming true"

```

new version:
```
Sort  (cost=39751.44..39751.94 rows=200 width=96)
  Sort Key: ((floor((EXTRACT(epoch FROM p.date) / '5'::numeric)) * '5'::numeric))
  ->  HashAggregate  (cost=39740.79..39743.79 rows=200 width=96)
        Group Key: ((floor((EXTRACT(epoch FROM p.date) / '5'::numeric)) * '5'::numeric))
        ->  Append  (cost=38826.46..39603.12 rows=18356 width=96)
              ->  HashAggregate  (cost=38826.46..39282.31 rows=18234 width=96)
                    Group Key: (floor((EXTRACT(epoch FROM p.date) / '5'::numeric)) * '5'::numeric)
                    ->  Nested Loop  (cost=0.43..38689.71 rows=18234 width=48)
                          ->  Seq Scan on drives d  (cost=0.00..130.22 rows=6 width=4)
                                Filter: ((start_date >= '2025-09-22 16:00:00'::timestamp without time zone) AND (start_date <= '2025-09-23 16:00:00'::timestamp without time zone))
                          ->  Index Scan using positions_drive_id_date_index on positions p  (cost=0.43..6357.27 rows=3892 width=28)
                                Index Cond: (drive_id = d.id)
                                Filter: (car_id = '1'::smallint)
              ->  HashAggregate  (cost=225.98..229.03 rows=122 width=96)
                    Group Key: (floor((EXTRACT(epoch FROM p_1.date) / '5'::numeric)) * '5'::numeric)
                    ->  Index Scan using positions_drive_id_date_index on positions p_1  (cost=0.43..225.07 rows=122 width=48)
                          Index Cond: ((drive_id IS NULL) AND (date >= '2025-09-22 16:00:00'::timestamp without time zone) AND (date <= '2025-09-23 16:00:00'::timestamp without time zone))
                          Filter: (car_id = '1'::smallint)

```