### PR TITLE
fix: allow using different PostgreSQL port than default when using socket_dir connection

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -110,7 +110,9 @@ case System.get_env("DATABASE_SOCKET_DIR") do
       port: System.get_env("DATABASE_PORT", "5432")
 
   socket_dir ->
-    config :teslamate, TeslaMate.Repo, socket_dir: socket_dir
+    config :teslamate, TeslaMate.Repo,
+      socket_dir: socket_dir,
+      port: System.get_env("DATABASE_PORT", "5432")
 end
 
 config :teslamate, TeslaMate.Repo,


### PR DESCRIPTION
fix https://github.com/teslamate-org/teslamate/issues/4720 

when config DATABASE_SOCKET_DIR, runtime.exs will not pass port: System.getEnv(DATABASE_PORT) to TeslaMate.Repo, so Ecto will fallback to s.PGSQL.5432