### PR TITLE
Update README.md: link for MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A powerful, self-hosted data logger for your Tesla.
 - Written in **[Elixir](https://elixir-lang.org/)**
 - Data is stored in a **Postgres** database
 - Visualization and data analysis with **Grafana**
-- Vehicle data is published to a local **MQTT** Broker
+- Vehicle data is published to a local **[MQTT](https://en.wikipedia.org/wiki/MQTT)** Broker
 
 ## Documentation
 


### PR DESCRIPTION
- Vehicle data is published to a local **[MQTT](https://en.wikipedia.org/wiki/MQTT)** Broker