### PR TITLE
fix: restore earthdistance function search paths

### DIFF
--- a/nix/backup_and_restore.nix
+++ b/nix/backup_and_restore.nix
@@ -25,6 +25,8 @@ let
       create schema public;
       CREATE EXTENSION cube WITH SCHEMA public;
       CREATE EXTENSION earthdistance WITH SCHEMA public;
+      ALTER FUNCTION ll_to_earth SET search_path = public;
+      ALTER FUNCTION earth_box SET search_path = public;
     .
 
     # Restore

--- a/priv/repo/migrations/20260502120000_set_search_path_for_earthdistance_functions.exs
+++ b/priv/repo/migrations/20260502120000_set_search_path_for_earthdistance_functions.exs
@@ -1,0 +1,12 @@
+defmodule TeslaMate.Repo.Migrations.SetSearchPathForEarthdistanceFunctions do
+  use Ecto.Migration
+
+  def up do
+    execute("ALTER FUNCTION ll_to_earth SET search_path = public")
+    execute("ALTER FUNCTION earth_box SET search_path = public")
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/website/docs/installation/unsupported/unraid.md
+++ b/website/docs/installation/unsupported/unraid.md
@@ -187,6 +187,8 @@ DROP SCHEMA private CASCADE;
 CREATE SCHEMA public;
 CREATE EXTENSION cube WITH SCHEMA public;
 CREATE EXTENSION earthdistance WITH SCHEMA public;
+ALTER FUNCTION ll_to_earth SET search_path = public;
+ALTER FUNCTION earth_box SET search_path = public;
 SQL
 
 if [ $? -ne 0 ]; then

--- a/website/docs/maintenance/backup_restore.mdx
+++ b/website/docs/maintenance/backup_restore.mdx
@@ -80,6 +80,8 @@ DROP SCHEMA private CASCADE;
 CREATE SCHEMA public;
 CREATE EXTENSION cube WITH SCHEMA public;
 CREATE EXTENSION earthdistance WITH SCHEMA public;
+ALTER FUNCTION ll_to_earth SET search_path = public;
+ALTER FUNCTION earth_box SET search_path = public;
 .
 
 # Restore


### PR DESCRIPTION
## Summary
Reapply the public search path for the ll_to_earth and earth_box functions after the earthdistance extension upgrade.

## Why
TeslaMate previously added search_path = public for these functions in the PostgreSQL 17 compatibility work because earthdistance functions without an explicit search path can fail to resolve the earth type correctly.

Later, the earthdistance v1.2 upgrade migration updated the extension but did not restore that custom function metadata. That appears to drop the expected search path from the extension-managed functions.

This follow-up migration restores the public search path for both functions.

## Context
- Original qualification/search-path issue: #192
- Search-path hardening added in: #4231
- Extension upgrade that likely reset the function metadata: #4648

## Validation
- mix format priv/repo/migrations/20260312120000_set_search_path_for_earthdistance_functions.exs
- mix compile
