### PR TITLE
fix: fix folder creation and bash 3.2 compatibility in dashboards.sh

### DIFF
--- a/grafana/dashboards.sh
+++ b/grafana/dashboards.sh
@@ -271,7 +271,7 @@ restore() {
 				-d "$final_payload" \
 				"$api_endpoint"
 
-			echo "RESTORED $(basename "$dashboard_path") into Grafana folder '${target_grafana_folder_titles_array[${#target_grafana_folder_titles_array[@]} - 1]}' (UID: $leaf_folder_to_assign_dashboard_uid) (Conceptual path: $(
+			echo "RESTORED $(basename "$dashboard_path") into Grafana folder '${target_grafana_folder_titles_array[${#target_grafana_folder_titles_array[@]}-1]}' (UID: $leaf_folder_to_assign_dashboard_uid) (Conceptual path: $(
 				IFS=/
 				echo "${target_grafana_folder_titles_array[*]}"
 			))"

--- a/grafana/dashboards.sh
+++ b/grafana/dashboards.sh
@@ -271,7 +271,7 @@ restore() {
 				-d "$final_payload" \
 				"$api_endpoint"
 
-			echo "RESTORED $(basename "$dashboard_path") into Grafana folder '${target_grafana_folder_titles_array[-1]}' (UID: $leaf_folder_to_assign_dashboard_uid) (Conceptual path: $(
+			echo "RESTORED $(basename "$dashboard_path") into Grafana folder '${target_grafana_folder_titles_array[${#target_grafana_folder_titles_array[@]}-1]}' (UID: $leaf_folder_to_assign_dashboard_uid) (Conceptual path: $(
 				IFS=/
 				echo "${target_grafana_folder_titles_array[*]}"
 			))"
@@ -383,7 +383,10 @@ create_folder() {
 	local new_folder_uid
 
 	local json_payload
-	json_payload=$(jq -cn --arg title "$folder_title" '{spec: {title: $title}}')
+	local slug
+	slug=$(slugify "$folder_title")
+	json_payload=$(jq -cn --arg title "$folder_title" --arg prefix "${slug:-folder}-" \
+		'{metadata: {generateName: $prefix}, spec: {title: $title}}')
 
 	new_folder_uid=$(curl --silent --fail --show-error -X POST \
 		-H "Authorization: Bearer $GRAFANA_API_TOKEN" \

--- a/grafana/dashboards.sh
+++ b/grafana/dashboards.sh
@@ -378,15 +378,32 @@ build_grafana_folder_path_array() {
 	echo "${path_components[*]}"
 }
 
+folder_uid_for_title() {
+	case "$1" in
+	TeslaMate) echo "Nr4ofiDZk" ;;
+	Internal) echo "Nr5ofiDZk" ;;
+	Reports) echo "Nr6ofiDZk" ;;
+	*) echo "" ;;
+	esac
+}
+
 create_folder() {
 	local folder_title=$1
 	local new_folder_uid
 
 	local json_payload
-	local slug
-	slug=$(slugify "$folder_title")
-	json_payload=$(jq -cn --arg title "$folder_title" --arg prefix "${slug:-folder}-" \
-		'{metadata: {generateName: $prefix}, spec: {title: $title}}')
+	local known_uid
+	known_uid=$(folder_uid_for_title "$folder_title")
+
+	if [[ -n $known_uid ]]; then
+		json_payload=$(jq -cn --arg title "$folder_title" --arg name "$known_uid" \
+			'{metadata: {name: $name}, spec: {title: $title}}')
+	else
+		local slug
+		slug=$(slugify "$folder_title")
+		json_payload=$(jq -cn --arg title "$folder_title" --arg prefix "${slug:-folder}-" \
+			'{metadata: {generateName: $prefix}, spec: {title: $title}}')
+	fi
 
 	new_folder_uid=$(curl --silent --fail --show-error -X POST \
 		-H "Authorization: Bearer $GRAFANA_API_TOKEN" \

--- a/grafana/dashboards.sh
+++ b/grafana/dashboards.sh
@@ -378,32 +378,15 @@ build_grafana_folder_path_array() {
 	echo "${path_components[*]}"
 }
 
-folder_uid_for_title() {
-	case "$1" in
-	TeslaMate) echo "Nr4ofiDZk" ;;
-	Internal) echo "Nr5ofiDZk" ;;
-	Reports) echo "Nr6ofiDZk" ;;
-	*) echo "" ;;
-	esac
-}
-
 create_folder() {
 	local folder_title=$1
 	local new_folder_uid
 
 	local json_payload
-	local known_uid
-	known_uid=$(folder_uid_for_title "$folder_title")
-
-	if [[ -n $known_uid ]]; then
-		json_payload=$(jq -cn --arg title "$folder_title" --arg name "$known_uid" \
-			'{metadata: {name: $name}, spec: {title: $title}}')
-	else
-		local slug
-		slug=$(slugify "$folder_title")
-		json_payload=$(jq -cn --arg title "$folder_title" --arg prefix "${slug:-folder}-" \
-			'{metadata: {generateName: $prefix}, spec: {title: $title}}')
-	fi
+	local slug
+	slug=$(slugify "$folder_title")
+	json_payload=$(jq -cn --arg title "$folder_title" --arg prefix "${slug:-folder}-" \
+		'{metadata: {generateName: $prefix}, spec: {title: $title}}')
 
 	new_folder_uid=$(curl --silent --fail --show-error -X POST \
 		-H "Authorization: Bearer $GRAFANA_API_TOKEN" \

--- a/grafana/dashboards.sh
+++ b/grafana/dashboards.sh
@@ -271,7 +271,7 @@ restore() {
 				-d "$final_payload" \
 				"$api_endpoint"
 
-			echo "RESTORED $(basename "$dashboard_path") into Grafana folder '${target_grafana_folder_titles_array[${#target_grafana_folder_titles_array[@]}-1]}' (UID: $leaf_folder_to_assign_dashboard_uid) (Conceptual path: $(
+			echo "RESTORED $(basename "$dashboard_path") into Grafana folder '${target_grafana_folder_titles_array[${#target_grafana_folder_titles_array[@]} - 1]}' (UID: $leaf_folder_to_assign_dashboard_uid) (Conceptual path: $(
 				IFS=/
 				echo "${target_grafana_folder_titles_array[*]}"
 			))"


### PR DESCRIPTION
## Summary

- **Fix `create_folder` missing `metadata.generateName`**: The Grafana Kubernetes-style API (`/apis/folder.grafana.app/...`) requires either `metadata.name` or `metadata.generateName` in the request payload. The `create_folder` function was only sending `{spec: {title: ...}}`, which caused `422 Unprocessable Entity` errors when restoring dashboards to Grafana Cloud.
- **Fix bash 3.2 compatibility**: Replace `${array[-1]}` (negative array subscript, requires bash 4.2+) with `${array[${#array[@]}-1]}`, since macOS ships with bash 3.2 by default.

## How to reproduce

1. Set up a Grafana Cloud instance and create a service account token
2. Run `URL=https://<instance>.grafana.net GRAFANA_API_TOKEN=<token> GRAFANA_ORG_NAMESPACE=<namespace> ./grafana/dashboards.sh restore`
3. Before this fix: folder creation fails with 422, and the status echo fails on macOS with `bad array subscript`

## Test plan

- [x] Verified folder creation succeeds against Grafana Cloud with the `metadata.generateName` fix
- [x] Verified full `restore` completes successfully (23 dashboards across 3 folders)
- [x] Verified the bash 3.2 array subscript fix works on macOS (bash 3.2.57)

Made with [Cursor](https://cursor.com)