### PR TITLE
refactor(vehicle): simplify the state machine: plain atom states, DB records moved into the state data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ Enjoy!
 - fix(charging): fall back to charger_power when phase detection fails (#5592 - @JakobLichterfeld)
 - fix(charges): enforce positive charger phases at the database (#5592 - @JakobLichterfeld)
 - fix(charging): recalculate charge_energy_used for existing processes (#5592 - @JakobLichterfeld)
+- refactor(vehicle): simplify the state machine: plain atom states, DB records moved into the state data (#5259 - @brianmay, @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,7 @@ Enjoy!
 - build(deps): update flake.lock (#5560)
 - build(deps-dev): bump sass from 1.101.0 to 1.102.0 in /assets (#5566)
 - build(deps): bump leaflet-control-geocoder from 3.3.1 to 4.0.0 in /assets (#5565)
+- test(vehicle): make the store-position interval configurable and lock the state-machine field lifecycle with regression tests (#5259 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -468,7 +468,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
         Logger.info("Vehicle is currently in service", car_id: data.car.id)
 
         case state do
-          {:driving, _, %Log.Drive{} = drive} ->
+          {:driving, _, _} when data.current_drive != nil ->
+            drive = data.current_drive
+
             {:ok, %Log.Drive{distance: km, duration_min: min}} =
               call(data.deps.log, :close_drive, [drive])
 
@@ -478,7 +480,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
               car_id: data.car.id
             )
 
-            {:next_state, :start, %Data{data | last_used: DateTime.utc_now()},
+            {:next_state, :start,
+             %Data{data | last_used: DateTime.utc_now(), driving_status: nil, current_drive: nil},
              [
                broadcast_fetch(false),
                broadcast_summary(),
@@ -525,11 +528,18 @@ defmodule TeslaMate.Vehicles.Vehicle do
         end
 
         interval =
-          case state do
-            {:driving, _, _} -> 10
-            {:charging, _} -> 15
-            :online -> 20
-            _ -> 30
+          case {data.current_drive != nil, data.current_charging_process != nil} do
+            {true, _} ->
+              10
+
+            {_, true} ->
+              15
+
+            _ ->
+              case state do
+                :online -> 20
+                _ -> 30
+              end
           end
 
         {:keep_state, data,
@@ -1206,7 +1216,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {:driving, {:offline, _last}, nil},
         %Data{} = data
       ) do
-    {:next_state, :start, %Data{data | last_used: DateTime.utc_now()}, schedule_fetch(data)}
+    {:next_state, :start, %Data{data | last_used: DateTime.utc_now(), driving_status: nil},
+     schedule_fetch(data)}
   end
 
   def handle_event(
@@ -1269,13 +1280,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         Logger.info("Vehicle was charged while being offline: #{added} kWh", car_id: data.car.id)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now()},
+        {:next_state, :start, %{data | last_used: DateTime.utc_now(), driving_status: nil},
          {:next_event, :internal, {:update, {:online, now}}}}
 
       not has_gained_range? and offline_min >= @drive_timeout_min ->
         unless is_nil(drv), do: timeout_drive(drv, data)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now()},
+        {:next_state, :start, %{data | last_used: DateTime.utc_now(), driving_status: nil},
          {:next_event, :internal, {:update, {:online, now}}}}
 
       not is_nil(drv) ->
@@ -1289,7 +1300,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   def handle_event(:internal, {:update, {:asleep, _vehicle}}, {:driving, _, drv}, data) do
     unless is_nil(drv), do: timeout_drive(drv, data)
-    {:next_state, :start, data, schedule_fetch(data)}
+    {:next_state, :start, %{data | driving_status: nil}, schedule_fetch(data)}
   end
 
   #### msg: :online
@@ -1345,7 +1356,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         Logger.info("End of drive initiated by: #{inspect(vehicle.drive_state)}")
         Logger.info("Driving / Ended / #{km && round(km)} km – #{min} min", car_id: data.car.id)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now(), geofence: geofence},
+        {:next_state, :start,
+         %{data | last_used: DateTime.utc_now(), driving_status: nil, geofence: geofence},
          {:next_event, :internal, {:update, {:online, vehicle}}}}
 
       %Vehicle{drive_state: nil} ->
@@ -1513,13 +1525,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
             :online ->
               true
 
-            {:driving, _, _} ->
+            {:driving, _, _} when data.current_drive != nil ->
               true
 
-            {:updating, _} ->
+            {:updating, _} when data.current_update != nil ->
               true
 
-            {:charging, _} ->
+            {:charging, _} when data.current_charging_process != nil ->
               true
 
             :start ->
@@ -1545,9 +1557,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
         reachable? =
           case expected_state do
             :online -> true
-            {:driving, _, _} -> true
-            {:updating, _} -> true
-            {:charging, _} -> true
+            {:driving, _, _} when data.current_drive != nil -> true
+            {:updating, _} when data.current_update != nil -> true
+            {:charging, _} when data.current_charging_process != nil -> true
             :start -> false
             {:offline, _} -> false
             {:asleep, _} -> false

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1534,13 +1534,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
             :online ->
               true
 
-            :driving when data.current_drive != nil ->
+            :driving ->
               true
 
-            :updating when data.current_update != nil ->
+            :updating ->
               true
 
-            :charging when data.current_charging_process != nil ->
+            :charging ->
               true
 
             :start ->
@@ -1566,9 +1566,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
         reachable? =
           case expected_state do
             :online -> true
-            :driving when data.current_drive != nil -> true
-            :updating when data.current_update != nil -> true
-            :charging when data.current_charging_process != nil -> true
+            :driving -> true
+            :updating -> true
+            :charging -> true
             :start -> false
             {:offline, _} -> false
             {:asleep, _} -> false

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -525,18 +525,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
         end
 
         interval =
-          case {data.current_drive != nil, data.current_charging_process != nil} do
-            {true, _} ->
-              10
-
-            {_, true} ->
-              15
-
-            _ ->
-              case state do
-                :online -> 20
-                _ -> 30
-              end
+          case state do
+            :driving -> 10
+            :charging -> 15
+            :online -> 20
+            _ -> 30
           end
 
         {:keep_state, data,

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -36,7 +36,17 @@ defmodule TeslaMate.Vehicles.Vehicle do
               #   :probing          – stream connected, waiting for first power reading
               #   :confirmed_fake   – stream reported power=nil, treating as fake online
               #   :confirmed_real   – stream reported numeric power, treating as real online
-              pre_online_check: :idle
+              pre_online_check: :idle,
+              # Future fields for extracting DB records from state tuples (not used yet)
+              # These will allow moving from {:driving, status, %Log.Drive{}} to :driving + data fields
+              # %Log.Drive{} | nil (will replace drive in {:driving, _, drive})
+              current_drive: nil,
+              # %Log.ChargingProcess{} | nil (will replace cproc in {:charging, cproc})  
+              current_charging_process: nil,
+              # %Log.Update{} | nil (will replace update in {:updating, update})
+              current_update: nil,
+              # :available | {:unavailable, n} | {:offline, last} (will replace status in {:driving, status, _})
+              driving_status: :available
   end
 
   @asleep_interval 30

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -37,15 +37,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
               #   :confirmed_fake   – stream reported power=nil, treating as fake online
               #   :confirmed_real   – stream reported numeric power, treating as real online
               pre_online_check: :idle,
-              # Future fields for extracting DB records from state tuples (not used yet)
-              # These will allow moving from {:driving, status, %Log.Drive{}} to :driving + data fields
-              # %Log.Drive{} | nil (will replace drive in {:driving, _, drive})
+              # DB records for active vehicle states (previously embedded in state tuples)
               current_drive: nil,
-              # %Log.ChargingProcess{} | nil (will replace cproc in {:charging, cproc})  
               current_charging_process: nil,
-              # %Log.Update{} | nil (will replace update in {:updating, update})
               current_update: nil,
-              # :available | {:unavailable, n} | {:offline, last} (will replace status in {:driving, status, _})
+              # Sub-state for driving: :available | {:unavailable, n} | {:offline, last_vehicle}
               driving_status: :available
   end
 
@@ -233,7 +229,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         healthy?: healthy?(data.car.id),
         elevation: data.elevation,
         geofence: data.geofence,
-        car: data.car
+        car: data.car,
+        driving_status: data.driving_status
       })
 
     {:keep_state_and_data, {:reply, from, summary}}
@@ -282,15 +279,15 @@ defmodule TeslaMate.Vehicles.Vehicle do
     {:keep_state_and_data, {:reply, from, :ok}}
   end
 
-  def handle_event({:call, from}, :suspend_logging, {:driving, _, _}, _data) do
+  def handle_event({:call, from}, :suspend_logging, :driving, _data) do
     {:keep_state_and_data, {:reply, from, {:error, :vehicle_not_parked}}}
   end
 
-  def handle_event({:call, from}, :suspend_logging, {:updating, _}, _data) do
+  def handle_event({:call, from}, :suspend_logging, :updating, _data) do
     {:keep_state_and_data, {:reply, from, {:error, :update_in_progress}}}
   end
 
-  def handle_event({:call, from}, :suspend_logging, {:charging, _}, _data) do
+  def handle_event({:call, from}, :suspend_logging, :charging, _data) do
     {:keep_state_and_data, {:reply, from, {:error, :charging_in_progress}}}
   end
 
@@ -468,7 +465,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         Logger.info("Vehicle is currently in service", car_id: data.car.id)
 
         case state do
-          {:driving, _, _} when data.current_drive != nil ->
+          :driving when data.current_drive != nil ->
             drive = data.current_drive
 
             {:ok, %Log.Drive{distance: km, duration_min: min}} =
@@ -641,7 +638,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         vehicle = merge(data.last_response, stream_data, time: true)
 
-        {:next_state, {:driving, :available, drive},
+        {:next_state, :driving,
          %Data{
            data
            | last_response: vehicle,
@@ -678,11 +675,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :info,
         {:stream, %Stream.Data{} = stream_data},
-        {:driving, status, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: :available, current_drive: drv} = data
       ) do
-    case {status, stream_data} do
-      {:available, %Stream.Data{shift_state: shift_state}} when shift_state in ~w(D N R) ->
+    case stream_data do
+      %Stream.Data{shift_state: shift_state} when shift_state in ~w(D N R) ->
         {:ok, %{elevation: elevation}} =
           call(data.deps.log, :insert_position, [drv, create_position(stream_data, data)])
 
@@ -692,7 +689,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {:keep_state, %{data | last_used: now, last_response: vehicle, elevation: elevation},
          broadcast_summary()}
 
-      {_status, %Stream.Data{}} ->
+      %Stream.Data{} ->
         {:keep_state_and_data, schedule_fetch(0, data)}
     end
   end
@@ -723,7 +720,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         vehicle = merge(data.last_response, stream_data, time: true)
 
-        {:next_state, {:driving, :available, drive},
+        {:next_state, :driving,
          %Data{
            data
            | last_response: vehicle,
@@ -903,7 +900,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         healthy?: healthy?(data.car.id),
         elevation: data.elevation,
         geofence: data.geofence,
-        car: data.car
+        car: data.car,
+        driving_status: data.driving_status
       })
 
     :ok =
@@ -1053,7 +1051,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         :ok = disconnect_stream(data)
 
-        {:next_state, {:updating, update},
+        {:next_state, :updating,
          %{
            data
            | last_state_change: DateTime.utc_now(),
@@ -1067,8 +1065,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         {drive, data} = start_drive(create_position(vehicle, data), data)
 
-        {:next_state, {:driving, :available, drive},
-         %{data | current_drive: drive, driving_status: :available},
+        {:next_state, :driving, %{data | current_drive: drive, driving_status: :available},
          [
            broadcast_summary(),
            schedule_fetch(driving_interval(), data)
@@ -1099,7 +1096,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         :ok = disconnect_stream(data)
 
-        {:next_state, {:charging, cproc},
+        {:next_state, :charging,
          %Data{
            data
            | last_state_change: DateTime.utc_now(),
@@ -1122,22 +1119,33 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   #### :charging
 
-  def handle_event(:internal, {:update, {:offline, _vehicle}}, {:charging, _}, data) do
+  def handle_event(:internal, {:update, {:offline, _vehicle}}, :charging, data) do
     Logger.warning("Vehicle went offline while charging", car_id: data.car.id)
 
     {:keep_state_and_data, schedule_fetch(data)}
   end
 
-  def handle_event(:internal, {:update, {:asleep, _vehicle}} = event, {:charging, cproc}, data) do
+  def handle_event(
+        :internal,
+        {:update, {:asleep, _vehicle}} = event,
+        :charging,
+        %Data{current_charging_process: cproc} = data
+      ) do
     Logger.warning("Vehicle went asleep while charging (?)", car_id: data.car.id)
 
     {:ok, _} = call(data.deps.log, :complete_charging_process, [cproc])
     Logger.info("Charging / Aborted", car_id: data.car.id)
 
-    {:next_state, :start, data, {:next_event, :internal, event}}
+    {:next_state, :start, %{data | current_charging_process: nil},
+     {:next_event, :internal, event}}
   end
 
-  def handle_event(:internal, {:update, {:online, vehicle}}, {:charging, cproc}, %Data{} = data) do
+  def handle_event(
+        :internal,
+        {:update, {:online, vehicle}},
+        :charging,
+        %Data{current_charging_process: cproc} = data
+      ) do
     data = %{data | last_used: DateTime.utc_now()}
 
     case vehicle do
@@ -1150,7 +1158,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
           |> Map.get(:charger_power)
           |> determince_interval()
 
-        {:next_state, {:charging, cproc}, %{data | current_charging_process: cproc},
+        {:next_state, :charging, %{data | current_charging_process: cproc},
          [broadcast_summary(), schedule_fetch(interval, data)]}
 
       %Vehicle{charge_state: %Charge{charging_state: state}} ->
@@ -1177,12 +1185,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, :available, drive},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: :available} = data
       ) do
     Logger.warning("Vehicle went offline while driving", car_id: data.car.id)
 
-    {:next_state, {:driving, {:unavailable, 0}, drive},
+    {:next_state, :driving,
      %{data | last_used: DateTime.utc_now(), driving_status: {:unavailable, 0}},
      schedule_fetch(5, data)}
   end
@@ -1190,11 +1198,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, {:unavailable, n}, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:unavailable, n}} = data
       )
       when n < 15 do
-    {:next_state, {:driving, {:unavailable, n + 1}, drv},
+    {:next_state, :driving,
      %{data | last_used: DateTime.utc_now(), driving_status: {:unavailable, n + 1}},
      schedule_fetch(5, data)}
   end
@@ -1202,10 +1210,10 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, {:unavailable, _n}, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:unavailable, _n}} = data
       ) do
-    {:next_state, {:driving, {:offline, data.last_response}, drv},
+    {:next_state, :driving,
      %{data | last_used: DateTime.utc_now(), driving_status: {:offline, data.last_response}},
      [broadcast_summary(), schedule_fetch(30, data)]}
   end
@@ -1213,8 +1221,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, {:offline, _last}, nil},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:offline, _}, current_drive: nil} = data
       ) do
     {:next_state, :start, %Data{data | last_used: DateTime.utc_now(), driving_status: nil},
      schedule_fetch(data)}
@@ -1223,8 +1231,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, {:offline, last}, drive},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:offline, last}, current_drive: drive} = data
       ) do
     offline_since = parse_timestamp(last.drive_state.timestamp)
 
@@ -1232,8 +1240,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
       min when min >= @drive_timeout_min ->
         timeout_drive(drive, data)
 
-        {:next_state, {:driving, {:offline, last}, nil},
-         %{data | last_used: DateTime.utc_now(), current_drive: nil},
+        {:next_state, :driving, %{data | last_used: DateTime.utc_now(), current_drive: nil},
          [broadcast_summary(), schedule_fetch(30, data)]}
 
       _min ->
@@ -1244,8 +1251,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:online, now}},
-        {:driving, {:offline, last}, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:offline, last}, current_drive: drv} = data
       ) do
     offline_start = parse_timestamp(last.drive_state.timestamp)
     offline_end = parse_timestamp(now.drive_state.timestamp)
@@ -1290,7 +1297,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
          {:next_event, :internal, {:update, {:online, now}}}}
 
       not is_nil(drv) ->
-        {:next_state, {:driving, :available, drv},
+        {:next_state, :driving,
          %{data | last_used: DateTime.utc_now(), driving_status: :available},
          {:next_event, :internal, {:update, {:online, now}}}}
     end
@@ -1298,7 +1305,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   #### msg: asleep
 
-  def handle_event(:internal, {:update, {:asleep, _vehicle}}, {:driving, _, drv}, data) do
+  def handle_event(
+        :internal,
+        {:update, {:asleep, _vehicle}},
+        :driving,
+        %Data{current_drive: drv} = data
+      ) do
     unless is_nil(drv), do: timeout_drive(drv, data)
     {:next_state, :start, %{data | driving_status: nil}, schedule_fetch(data)}
   end
@@ -1308,21 +1320,20 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:online, _} = e},
-        {:driving, {:unavailable, _}, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:unavailable, _}} = data
       ) do
     Logger.info("Vehicle is back online", car_id: data.car.id)
 
-    {:next_state, {:driving, :available, drv},
-     %{data | last_used: DateTime.utc_now(), driving_status: :available},
+    {:next_state, :driving, %{data | last_used: DateTime.utc_now(), driving_status: :available},
      {:next_event, :internal, {:update, e}}}
   end
 
   def handle_event(
         :internal,
         {:update, {:online, vehicle}},
-        {:driving, :available, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: :available, current_drive: drv} = data
       ) do
     interval = if streaming?(data), do: default_interval(), else: driving_interval()
 
@@ -1368,12 +1379,17 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   #### :updating
 
-  def handle_event(:internal, {:update, {:offline, _}}, {:updating, _update_id}, %Data{} = data) do
+  def handle_event(:internal, {:update, {:offline, _}}, :updating, %Data{} = data) do
     Logger.warning("Vehicle went offline while updating", car_id: data.car.id)
     {:keep_state, %{data | last_used: DateTime.utc_now()}, schedule_fetch(data)}
   end
 
-  def handle_event(:internal, {:update, {:online, vehicle}}, {:updating, update}, data) do
+  def handle_event(
+        :internal,
+        {:update, {:online, vehicle}},
+        :updating,
+        %Data{current_update: update} = data
+      ) do
     alias VehicleState.SoftwareUpdate, as: SW
 
     case vehicle.vehicle_state do
@@ -1525,13 +1541,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
             :online ->
               true
 
-            {:driving, _, _} when data.current_drive != nil ->
+            :driving when data.current_drive != nil ->
               true
 
-            {:updating, _} when data.current_update != nil ->
+            :updating when data.current_update != nil ->
               true
 
-            {:charging, _} when data.current_charging_process != nil ->
+            :charging when data.current_charging_process != nil ->
               true
 
             :start ->
@@ -1557,9 +1573,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
         reachable? =
           case expected_state do
             :online -> true
-            {:driving, _, _} when data.current_drive != nil -> true
-            {:updating, _} when data.current_update != nil -> true
-            {:charging, _} when data.current_charging_process != nil -> true
+            :driving when data.current_drive != nil -> true
+            :updating when data.current_update != nil -> true
+            :charging when data.current_charging_process != nil -> true
             :start -> false
             {:offline, _} -> false
             {:asleep, _} -> false

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -632,8 +632,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
         vehicle = merge(data.last_response, stream_data, time: true)
 
         {:next_state, {:driving, :available, drive},
-         %Data{data | last_response: vehicle, elevation: elevation},
-         [broadcast_summary(), schedule_fetch(0, data)]}
+         %Data{
+           data
+           | last_response: vehicle,
+             elevation: elevation,
+             current_drive: drive,
+             driving_status: :available
+         }, [broadcast_summary(), schedule_fetch(0, data)]}
 
       %Stream.Data{shift_state: nil, power: power} when is_number(power) and power < 0 ->
         vehicle = merge(data.last_response, stream_data, time: true)
@@ -709,8 +714,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
         vehicle = merge(data.last_response, stream_data, time: true)
 
         {:next_state, {:driving, :available, drive},
-         %Data{data | last_response: vehicle, elevation: elevation},
-         [broadcast_summary(), schedule_fetch(0, data)]}
+         %Data{
+           data
+           | last_response: vehicle,
+             elevation: elevation,
+             current_drive: drive,
+             driving_status: :available
+         }, [broadcast_summary(), schedule_fetch(0, data)]}
 
       %Stream.Data{shift_state: s, power: power}
       when s in [nil, "P"] and is_number(power) and power < 0 ->
@@ -1038,7 +1048,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
            data
            | last_state_change: DateTime.utc_now(),
              last_used: DateTime.utc_now(),
-             stream_pid: nil
+             stream_pid: nil,
+             current_update: update
          }, [broadcast_summary(), schedule_fetch(15, data)]}
 
       %V{drive_state: %Drive{shift_state: shift_state}} when shift_state in ~w(D N R) ->
@@ -1046,7 +1057,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         {drive, data} = start_drive(create_position(vehicle, data), data)
 
-        {:next_state, {:driving, :available, drive}, data,
+        {:next_state, {:driving, :available, drive},
+         %{data | current_drive: drive, driving_status: :available},
          [
            broadcast_summary(),
            schedule_fetch(driving_interval(), data)
@@ -1082,7 +1094,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
            data
            | last_state_change: DateTime.utc_now(),
              last_used: DateTime.utc_now(),
-             stream_pid: nil
+             stream_pid: nil,
+             current_charging_process: cproc
          }, [broadcast_summary(), schedule_fetch(5, data), schedule_position_storing()]}
 
       _ ->
@@ -1127,7 +1140,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
           |> Map.get(:charger_power)
           |> determince_interval()
 
-        {:next_state, {:charging, cproc}, data,
+        {:next_state, {:charging, cproc}, %{data | current_charging_process: cproc},
          [broadcast_summary(), schedule_fetch(interval, data)]}
 
       %Vehicle{charge_state: %Charge{charging_state: state}} ->
@@ -1159,7 +1172,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
       ) do
     Logger.warning("Vehicle went offline while driving", car_id: data.car.id)
 
-    {:next_state, {:driving, {:unavailable, 0}, drive}, %{data | last_used: DateTime.utc_now()},
+    {:next_state, {:driving, {:unavailable, 0}, drive},
+     %{data | last_used: DateTime.utc_now(), driving_status: {:unavailable, 0}},
      schedule_fetch(5, data)}
   end
 
@@ -1170,7 +1184,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         %Data{} = data
       )
       when n < 15 do
-    {:next_state, {:driving, {:unavailable, n + 1}, drv}, %{data | last_used: DateTime.utc_now()},
+    {:next_state, {:driving, {:unavailable, n + 1}, drv},
+     %{data | last_used: DateTime.utc_now(), driving_status: {:unavailable, n + 1}},
      schedule_fetch(5, data)}
   end
 
@@ -1181,7 +1196,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         %Data{} = data
       ) do
     {:next_state, {:driving, {:offline, data.last_response}, drv},
-     %{data | last_used: DateTime.utc_now()}, [broadcast_summary(), schedule_fetch(30, data)]}
+     %{data | last_used: DateTime.utc_now(), driving_status: {:offline, data.last_response}},
+     [broadcast_summary(), schedule_fetch(30, data)]}
   end
 
   def handle_event(
@@ -1205,7 +1221,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
       min when min >= @drive_timeout_min ->
         timeout_drive(drive, data)
 
-        {:next_state, {:driving, {:offline, last}, nil}, %{data | last_used: DateTime.utc_now()},
+        {:next_state, {:driving, {:offline, last}, nil},
+         %{data | last_used: DateTime.utc_now(), current_drive: nil},
          [broadcast_summary(), schedule_fetch(30, data)]}
 
       _min ->
@@ -1262,7 +1279,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
          {:next_event, :internal, {:update, {:online, now}}}}
 
       not is_nil(drv) ->
-        {:next_state, {:driving, :available, drv}, %{data | last_used: DateTime.utc_now()},
+        {:next_state, {:driving, :available, drv},
+         %{data | last_used: DateTime.utc_now(), driving_status: :available},
          {:next_event, :internal, {:update, {:online, now}}}}
     end
   end
@@ -1284,7 +1302,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
       ) do
     Logger.info("Vehicle is back online", car_id: data.car.id)
 
-    {:next_state, {:driving, :available, drv}, %{data | last_used: DateTime.utc_now()},
+    {:next_state, {:driving, :available, drv},
+     %{data | last_used: DateTime.utc_now(), driving_status: :available},
      {:next_event, :internal, {:update, e}}}
   end
 

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -37,15 +37,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
               #   :confirmed_fake   – stream reported power=nil, treating as fake online
               #   :confirmed_real   – stream reported numeric power, treating as real online
               pre_online_check: :idle,
-              # Future fields for extracting DB records from state tuples (not used yet)
-              # These will allow moving from {:driving, status, %Log.Drive{}} to :driving + data fields
-              # %Log.Drive{} | nil (will replace drive in {:driving, _, drive})
+              # DB records for active vehicle states (previously embedded in state tuples)
               current_drive: nil,
-              # %Log.ChargingProcess{} | nil (will replace cproc in {:charging, cproc})  
               current_charging_process: nil,
-              # %Log.Update{} | nil (will replace update in {:updating, update})
               current_update: nil,
-              # :available | {:unavailable, n} | {:offline, last} (will replace status in {:driving, status, _})
+              # Sub-state for driving: :available | {:unavailable, n} | {:offline, last_vehicle}
               driving_status: :available
   end
 
@@ -289,7 +285,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         healthy?: healthy?(data.car.id),
         elevation: data.elevation,
         geofence: data.geofence,
-        car: data.car
+        car: data.car,
+        driving_status: data.driving_status
       })
 
     {:keep_state_and_data, {:reply, from, summary}}
@@ -338,15 +335,15 @@ defmodule TeslaMate.Vehicles.Vehicle do
     {:keep_state_and_data, {:reply, from, :ok}}
   end
 
-  def handle_event({:call, from}, :suspend_logging, {:driving, _, _}, _data) do
+  def handle_event({:call, from}, :suspend_logging, :driving, _data) do
     {:keep_state_and_data, {:reply, from, {:error, :vehicle_not_parked}}}
   end
 
-  def handle_event({:call, from}, :suspend_logging, {:updating, _}, _data) do
+  def handle_event({:call, from}, :suspend_logging, :updating, _data) do
     {:keep_state_and_data, {:reply, from, {:error, :update_in_progress}}}
   end
 
-  def handle_event({:call, from}, :suspend_logging, {:charging, _}, _data) do
+  def handle_event({:call, from}, :suspend_logging, :charging, _data) do
     {:keep_state_and_data, {:reply, from, {:error, :charging_in_progress}}}
   end
 
@@ -529,7 +526,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         Logger.info("Vehicle is currently in service", car_id: data.car.id)
 
         case state do
-          {:driving, _, _} when data.current_drive != nil ->
+          :driving when data.current_drive != nil ->
             drive = data.current_drive
 
             {:ok, %Log.Drive{distance: km, duration_min: min}} =
@@ -702,7 +699,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         vehicle = merge(data.last_response, stream_data, time: true)
 
-        {:next_state, {:driving, :available, drive},
+        {:next_state, :driving,
          %Data{
            data
            | last_response: vehicle,
@@ -739,11 +736,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :info,
         {:stream, %Stream.Data{} = stream_data},
-        {:driving, status, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: :available, current_drive: drv} = data
       ) do
-    case {status, stream_data} do
-      {:available, %Stream.Data{shift_state: shift_state}} when shift_state in ~w(D N R) ->
+    case stream_data do
+      %Stream.Data{shift_state: shift_state} when shift_state in ~w(D N R) ->
         {elevation, geofence} =
           Repo.checkout(fn ->
             {:ok, %{elevation: elevation} = position} =
@@ -765,7 +762,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
              geofence: geofence
          }, broadcast_summary()}
 
-      {_status, %Stream.Data{}} ->
+      %Stream.Data{} ->
         {:keep_state_and_data, schedule_fetch(0, data)}
     end
   end
@@ -796,7 +793,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         vehicle = merge(data.last_response, stream_data, time: true)
 
-        {:next_state, {:driving, :available, drive},
+        {:next_state, :driving,
          %Data{
            data
            | last_response: vehicle,
@@ -976,7 +973,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         healthy?: healthy?(data.car.id),
         elevation: data.elevation,
         geofence: data.geofence,
-        car: data.car
+        car: data.car,
+        driving_status: data.driving_status
       })
 
     :ok =
@@ -1126,7 +1124,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         :ok = disconnect_stream(data)
 
-        {:next_state, {:updating, update},
+        {:next_state, :updating,
          %{
            data
            | last_state_change: DateTime.utc_now(),
@@ -1141,8 +1139,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {drive, data} = start_drive(create_position(vehicle, data), data)
         interval = if streaming?(data), do: default_interval(), else: driving_interval()
 
-        {:next_state, {:driving, :available, drive},
-         %{data | current_drive: drive, driving_status: :available},
+        {:next_state, :driving, %{data | current_drive: drive, driving_status: :available},
          [
            broadcast_summary(),
            schedule_fetch(interval, data)
@@ -1173,7 +1170,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         :ok = disconnect_stream(data)
 
-        {:next_state, {:charging, cproc},
+        {:next_state, :charging,
          %Data{
            data
            | last_state_change: DateTime.utc_now(),
@@ -1196,22 +1193,33 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   #### :charging
 
-  def handle_event(:internal, {:update, {:offline, _vehicle}}, {:charging, _}, data) do
+  def handle_event(:internal, {:update, {:offline, _vehicle}}, :charging, data) do
     Logger.warning("Vehicle went offline while charging", car_id: data.car.id)
 
     {:keep_state_and_data, schedule_fetch(data)}
   end
 
-  def handle_event(:internal, {:update, {:asleep, _vehicle}} = event, {:charging, cproc}, data) do
+  def handle_event(
+        :internal,
+        {:update, {:asleep, _vehicle}} = event,
+        :charging,
+        %Data{current_charging_process: cproc} = data
+      ) do
     Logger.warning("Vehicle went asleep while charging (?)", car_id: data.car.id)
 
     {:ok, _} = call(data.deps.log, :complete_charging_process, [cproc])
     Logger.info("Charging / Aborted", car_id: data.car.id)
 
-    {:next_state, :start, data, {:next_event, :internal, event}}
+    {:next_state, :start, %{data | current_charging_process: nil},
+     {:next_event, :internal, event}}
   end
 
-  def handle_event(:internal, {:update, {:online, vehicle}}, {:charging, cproc}, %Data{} = data) do
+  def handle_event(
+        :internal,
+        {:update, {:online, vehicle}},
+        :charging,
+        %Data{current_charging_process: cproc} = data
+      ) do
     data = %{data | last_used: DateTime.utc_now()}
 
     case vehicle do
@@ -1224,7 +1232,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
           |> Map.get(:charger_power)
           |> determince_interval()
 
-        {:next_state, {:charging, cproc}, %{data | current_charging_process: cproc},
+        {:next_state, :charging, %{data | current_charging_process: cproc},
          [broadcast_summary(), schedule_fetch(interval, data)]}
 
       %Vehicle{charge_state: %Charge{charging_state: state}} ->
@@ -1251,12 +1259,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, :available, drive},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: :available} = data
       ) do
     Logger.warning("Vehicle went offline while driving", car_id: data.car.id)
 
-    {:next_state, {:driving, {:unavailable, 0}, drive},
+    {:next_state, :driving,
      %{data | last_used: DateTime.utc_now(), driving_status: {:unavailable, 0}},
      schedule_fetch(5, data)}
   end
@@ -1264,11 +1272,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, {:unavailable, n}, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:unavailable, n}} = data
       )
       when n < 15 do
-    {:next_state, {:driving, {:unavailable, n + 1}, drv},
+    {:next_state, :driving,
      %{data | last_used: DateTime.utc_now(), driving_status: {:unavailable, n + 1}},
      schedule_fetch(5, data)}
   end
@@ -1276,10 +1284,10 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, {:unavailable, _n}, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:unavailable, _n}} = data
       ) do
-    {:next_state, {:driving, {:offline, data.last_response}, drv},
+    {:next_state, :driving,
      %{data | last_used: DateTime.utc_now(), driving_status: {:offline, data.last_response}},
      [broadcast_summary(), schedule_fetch(30, data)]}
   end
@@ -1287,8 +1295,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, {:offline, _last}, nil},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:offline, _}, current_drive: nil} = data
       ) do
     {:next_state, :start, %Data{data | last_used: DateTime.utc_now(), driving_status: nil},
      schedule_fetch(data)}
@@ -1297,8 +1305,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, {:offline, last}, drive},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:offline, last}, current_drive: drive} = data
       ) do
     offline_since = parse_timestamp(last.drive_state.timestamp)
 
@@ -1306,8 +1314,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
       min when min >= @drive_timeout_min ->
         timeout_drive(drive, data)
 
-        {:next_state, {:driving, {:offline, last}, nil},
-         %{data | last_used: DateTime.utc_now(), current_drive: nil},
+        {:next_state, :driving, %{data | last_used: DateTime.utc_now(), current_drive: nil},
          [broadcast_summary(), schedule_fetch(30, data)]}
 
       _min ->
@@ -1318,8 +1325,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:online, now}},
-        {:driving, {:offline, last}, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:offline, last}, current_drive: drv} = data
       ) do
     offline_start = parse_timestamp(last.drive_state.timestamp)
     offline_end = parse_timestamp(now.drive_state.timestamp)
@@ -1366,7 +1373,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
       not is_nil(drv) ->
         data = maybe_reconnect_stream(data)
 
-        {:next_state, {:driving, :available, drv},
+        {:next_state, :driving,
          %{data | last_used: DateTime.utc_now(), driving_status: :available},
          {:next_event, :internal, {:update, {:online, now}}}}
     end
@@ -1374,7 +1381,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   #### msg: asleep
 
-  def handle_event(:internal, {:update, {:asleep, _vehicle}}, {:driving, _, drv}, data) do
+  def handle_event(
+        :internal,
+        {:update, {:asleep, _vehicle}},
+        :driving,
+        %Data{current_drive: drv} = data
+      ) do
     unless is_nil(drv), do: timeout_drive(drv, data)
     {:next_state, :start, %{data | driving_status: nil}, schedule_fetch(data)}
   end
@@ -1384,14 +1396,14 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:online, _} = e},
-        {:driving, {:unavailable, _}, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:unavailable, _}} = data
       ) do
     Logger.info("Vehicle is back online", car_id: data.car.id)
 
     data = maybe_reconnect_stream(data)
 
-    {:next_state, {:driving, :available, drv},
+    {:next_state, :driving,
      %{data | last_used: DateTime.utc_now(), driving_status: :available},
      {:next_event, :internal, {:update, e}}}
   end
@@ -1399,8 +1411,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:online, vehicle}},
-        {:driving, :available, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: :available, current_drive: drv} = data
       ) do
     interval = if streaming?(data), do: default_interval(), else: driving_interval()
 
@@ -1446,12 +1458,17 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   #### :updating
 
-  def handle_event(:internal, {:update, {:offline, _}}, {:updating, _update_id}, %Data{} = data) do
+  def handle_event(:internal, {:update, {:offline, _}}, :updating, %Data{} = data) do
     Logger.warning("Vehicle went offline while updating", car_id: data.car.id)
     {:keep_state, %{data | last_used: DateTime.utc_now()}, schedule_fetch(data)}
   end
 
-  def handle_event(:internal, {:update, {:online, vehicle}}, {:updating, update}, data) do
+  def handle_event(
+        :internal,
+        {:update, {:online, vehicle}},
+        :updating,
+        %Data{current_update: update} = data
+      ) do
     alias VehicleState.SoftwareUpdate, as: SW
 
     case vehicle.vehicle_state do
@@ -1603,13 +1620,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
             :online ->
               true
 
-            {:driving, _, _} when data.current_drive != nil ->
+            :driving when data.current_drive != nil ->
               true
 
-            {:updating, _} when data.current_update != nil ->
+            :updating when data.current_update != nil ->
               true
 
-            {:charging, _} when data.current_charging_process != nil ->
+            :charging when data.current_charging_process != nil ->
               true
 
             :start ->
@@ -1635,9 +1652,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
         reachable? =
           case expected_state do
             :online -> true
-            {:driving, _, _} when data.current_drive != nil -> true
-            {:updating, _} when data.current_update != nil -> true
-            {:charging, _} when data.current_charging_process != nil -> true
+            :driving when data.current_drive != nil -> true
+            :updating when data.current_update != nil -> true
+            :charging when data.current_charging_process != nil -> true
             :start -> false
             {:offline, _} -> false
             {:asleep, _} -> false

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -24,6 +24,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
               deps: %{},
               task: nil,
               import?: false,
+              # Interval in ms between periodic position inserts while :online / :charging.
+              # Set in init/1; overridable via the :store_position_interval start option (tests).
+              store_position_interval: nil,
               stream_pid: nil,
               # pre_online_check tracks whether an apparent online event is a real wakeup or a brief
               # subsystem check. Some vehicles (especially MCU2-upgraded cars) wake briefly (~2-3 min)
@@ -254,7 +257,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
       last_used: DateTime.utc_now(),
       last_state_change: last_state_change,
       deps: deps,
-      import?: Keyword.get(opts, :import?, false)
+      import?: Keyword.get(opts, :import?, false),
+      store_position_interval: Keyword.get(opts, :store_position_interval, :timer.minutes(5))
     }
 
     fuses = [
@@ -992,13 +996,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
   ### Store Position
 
   def handle_event({:timeout, :store_position}, :store_position, state, data)
-      when state == :online or (is_tuple(state) and elem(state, 0) == :charging) do
+      when state in [:online, :charging] do
     Logger.debug("Storing position ...", car_id: data.car.id)
 
     {:ok, _pos} =
       call(data.deps.log, :insert_position, [data.car, create_position(data.last_response, data)])
 
-    {:keep_state_and_data, schedule_position_storing()}
+    {:keep_state_and_data, schedule_position_storing(data)}
   end
 
   def handle_event({:timeout, :store_position}, :store_position, _state, _data) do
@@ -1081,7 +1085,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
          last_state_change: last_state_change,
          geofence: geofence,
          stream_pid: stream_pid
-     }, [broadcast_summary(), {:next_event, :internal, evt}, schedule_position_storing()]}
+     }, [broadcast_summary(), {:next_event, :internal, evt}, schedule_position_storing(data)]}
   end
 
   #### :online
@@ -1170,7 +1174,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
              last_used: DateTime.utc_now(),
              stream_pid: nil,
              current_charging_process: cproc
-         }, [broadcast_summary(), schedule_fetch(5, data), schedule_position_storing()]}
+         }, [broadcast_summary(), schedule_fetch(5, data), schedule_position_storing(data)]}
 
       _ ->
         try_to_suspend(vehicle, state, data)
@@ -1396,8 +1400,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
     data = maybe_reconnect_stream(data)
 
-    {:next_state, :driving,
-     %{data | last_used: DateTime.utc_now(), driving_status: :available},
+    {:next_state, :driving, %{data | last_used: DateTime.utc_now(), driving_status: :available},
      {:next_event, :internal, {:update, e}}}
   end
 
@@ -2123,8 +2126,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
   defp broadcast_summary, do: {:next_event, :internal, :broadcast_summary}
   defp broadcast_fetch(status), do: {:next_event, :internal, {:broadcast_fetch, status}}
 
-  defp schedule_position_storing do
-    {{:timeout, :store_position}, :timer.minutes(5), :store_position}
+  defp schedule_position_storing(%Data{store_position_interval: interval}) do
+    {{:timeout, :store_position}, interval, :store_position}
   end
 
   defp date_opts(%Vehicle{drive_state: %Drive{timestamp: nil}}), do: []

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -529,7 +529,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
         Logger.info("Vehicle is currently in service", car_id: data.car.id)
 
         case state do
-          {:driving, _, %Log.Drive{} = drive} ->
+          {:driving, _, _} when data.current_drive != nil ->
+            drive = data.current_drive
+
             {:ok, %Log.Drive{distance: km, duration_min: min}} =
               call(data.deps.log, :close_drive, [drive])
 
@@ -539,7 +541,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
               car_id: data.car.id
             )
 
-            {:next_state, :start, %Data{data | last_used: DateTime.utc_now()},
+            {:next_state, :start,
+             %Data{data | last_used: DateTime.utc_now(), driving_status: nil, current_drive: nil},
              [
                broadcast_fetch(false),
                broadcast_summary(),
@@ -586,11 +589,18 @@ defmodule TeslaMate.Vehicles.Vehicle do
         end
 
         interval =
-          case state do
-            {:driving, _, _} -> 10
-            {:charging, _} -> 15
-            :online -> 20
-            _ -> 30
+          case {data.current_drive != nil, data.current_charging_process != nil} do
+            {true, _} ->
+              10
+
+            {_, true} ->
+              15
+
+            _ ->
+              case state do
+                :online -> 20
+                _ -> 30
+              end
           end
 
         {:keep_state, data,
@@ -1280,7 +1290,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {:driving, {:offline, _last}, nil},
         %Data{} = data
       ) do
-    {:next_state, :start, %Data{data | last_used: DateTime.utc_now()}, schedule_fetch(data)}
+    {:next_state, :start, %Data{data | last_used: DateTime.utc_now(), driving_status: nil},
+     schedule_fetch(data)}
   end
 
   def handle_event(
@@ -1343,13 +1354,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         Logger.info("Vehicle was charged while being offline: #{added} kWh", car_id: data.car.id)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now()},
+        {:next_state, :start, %{data | last_used: DateTime.utc_now(), driving_status: nil},
          {:next_event, :internal, {:update, {:online, now}}}}
 
       not has_gained_range? and offline_min >= @drive_timeout_min ->
         unless is_nil(drv), do: timeout_drive(drv, data)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now()},
+        {:next_state, :start, %{data | last_used: DateTime.utc_now(), driving_status: nil},
          {:next_event, :internal, {:update, {:online, now}}}}
 
       not is_nil(drv) ->
@@ -1365,7 +1376,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   def handle_event(:internal, {:update, {:asleep, _vehicle}}, {:driving, _, drv}, data) do
     unless is_nil(drv), do: timeout_drive(drv, data)
-    {:next_state, :start, data, schedule_fetch(data)}
+    {:next_state, :start, %{data | driving_status: nil}, schedule_fetch(data)}
   end
 
   #### msg: :online
@@ -1423,7 +1434,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         Logger.info("End of drive initiated by: #{inspect(vehicle.drive_state)}")
         Logger.info("Driving / Ended / #{km && round(km)} km – #{min} min", car_id: data.car.id)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now(), geofence: geofence},
+        {:next_state, :start,
+         %{data | last_used: DateTime.utc_now(), driving_status: nil, geofence: geofence},
          {:next_event, :internal, {:update, {:online, vehicle}}}}
 
       %Vehicle{drive_state: nil} ->
@@ -1591,13 +1603,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
             :online ->
               true
 
-            {:driving, _, _} ->
+            {:driving, _, _} when data.current_drive != nil ->
               true
 
-            {:updating, _} ->
+            {:updating, _} when data.current_update != nil ->
               true
 
-            {:charging, _} ->
+            {:charging, _} when data.current_charging_process != nil ->
               true
 
             :start ->
@@ -1623,9 +1635,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
         reachable? =
           case expected_state do
             :online -> true
-            {:driving, _, _} -> true
-            {:updating, _} -> true
-            {:charging, _} -> true
+            {:driving, _, _} when data.current_drive != nil -> true
+            {:updating, _} when data.current_update != nil -> true
+            {:charging, _} when data.current_charging_process != nil -> true
             :start -> false
             {:offline, _} -> false
             {:asleep, _} -> false

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -44,8 +44,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
               current_drive: nil,
               current_charging_process: nil,
               current_update: nil,
-              # Sub-state for driving: :available | {:unavailable, n} | {:offline, last_vehicle}
-              driving_status: :available
+              # Sub-state while :driving: :available | {:unavailable, n} | {:offline, last_vehicle}.
+              # nil whenever the vehicle is not in the :driving state (see reset_activity/1).
+              driving_status: nil
   end
 
   @asleep_interval 30
@@ -542,8 +543,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
               car_id: data.car.id
             )
 
-            {:next_state, :start,
-             %Data{data | last_used: DateTime.utc_now(), driving_status: nil, current_drive: nil},
+            {:next_state, :start, reset_activity(%Data{data | last_used: DateTime.utc_now()}),
              [
                broadcast_fetch(false),
                broadcast_summary(),
@@ -560,7 +560,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         :ok = fuse_name(:api_error, data.car.id) |> :fuse.circuit_disable()
 
         # Stop polling
-        {:next_state, :start, data, [broadcast_fetch(false), broadcast_summary()]}
+        {:next_state, :start, reset_activity(data), [broadcast_fetch(false), broadcast_summary()]}
 
       {:error, :vehicle_not_found} ->
         Logger.error("Error / :vehicle_not_found", car_id: data.car.id)
@@ -836,7 +836,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   def handle_event(:info, {_ref, {state, %Vehicle{}} = event}, {:suspended, _}, data)
       when state in [:asleep, :offline] do
-    {:next_state, :start, data, {:next_event, :internal, {:update, event}}}
+    {:next_state, :start, reset_activity(data), {:next_event, :internal, {:update, event}}}
   end
 
   def handle_event(:info, {_ref, {:online, %Vehicle{}}}, {:suspended, _}, _data) do
@@ -1098,7 +1098,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   def handle_event(:internal, {:update, {event, _vehicle}}, :online, data)
       when event in [:offline, :asleep] do
-    {:next_state, :start, data, schedule_fetch(data)}
+    {:next_state, :start, reset_activity(data), schedule_fetch(data)}
   end
 
   def handle_event(:internal, {:update, {:online, vehicle}}, state, %Data{} = data)
@@ -1191,7 +1191,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   def handle_event(:internal, {:update, {state, _}} = event, {:suspended, _}, data)
       when state in [:asleep, :offline] do
-    {:next_state, :start, data, {:next_event, :internal, event}}
+    {:next_state, :start, reset_activity(data), {:next_event, :internal, event}}
   end
 
   #### :charging
@@ -1213,8 +1213,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
     {:ok, _} = call(data.deps.log, :complete_charging_process, [cproc])
     Logger.info("Charging / Aborted", car_id: data.car.id)
 
-    {:next_state, :start, %{data | current_charging_process: nil},
-     {:next_event, :internal, event}}
+    {:next_state, :start, reset_activity(data), {:next_event, :internal, event}}
   end
 
   def handle_event(
@@ -1235,8 +1234,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
           |> Map.get(:charger_power)
           |> determince_interval()
 
-        {:next_state, :charging, %{data | current_charging_process: cproc},
-         [broadcast_summary(), schedule_fetch(interval, data)]}
+        {:next_state, :charging, data, [broadcast_summary(), schedule_fetch(interval, data)]}
 
       %Vehicle{charge_state: %Charge{charging_state: state}} ->
         Repo.transaction(fn ->
@@ -1251,7 +1249,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
           Logger.info("Charging / #{state} / #{added} kWh – #{duration} min", car_id: data.car.id)
         end)
 
-        {:next_state, :start, data, {:next_event, :internal, {:update, {:online, vehicle}}}}
+        {:next_state, :start, reset_activity(data),
+         {:next_event, :internal, {:update, {:online, vehicle}}}}
     end
   end
 
@@ -1301,7 +1300,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         :driving,
         %Data{driving_status: {:offline, _}, current_drive: nil} = data
       ) do
-    {:next_state, :start, %Data{data | last_used: DateTime.utc_now(), driving_status: nil},
+    {:next_state, :start, reset_activity(%Data{data | last_used: DateTime.utc_now()}),
      schedule_fetch(data)}
   end
 
@@ -1364,13 +1363,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         Logger.info("Vehicle was charged while being offline: #{added} kWh", car_id: data.car.id)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now(), driving_status: nil},
+        {:next_state, :start, reset_activity(%{data | last_used: DateTime.utc_now()}),
          {:next_event, :internal, {:update, {:online, now}}}}
 
       not has_gained_range? and offline_min >= @drive_timeout_min ->
         unless is_nil(drv), do: timeout_drive(drv, data)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now(), driving_status: nil},
+        {:next_state, :start, reset_activity(%{data | last_used: DateTime.utc_now()}),
          {:next_event, :internal, {:update, {:online, now}}}}
 
       not is_nil(drv) ->
@@ -1391,7 +1390,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         %Data{current_drive: drv} = data
       ) do
     unless is_nil(drv), do: timeout_drive(drv, data)
-    {:next_state, :start, %{data | driving_status: nil}, schedule_fetch(data)}
+    {:next_state, :start, reset_activity(data), schedule_fetch(data)}
   end
 
   #### msg: :online
@@ -1449,7 +1448,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         Logger.info("Driving / Ended / #{km && round(km)} km – #{min} min", car_id: data.car.id)
 
         {:next_state, :start,
-         %{data | last_used: DateTime.utc_now(), driving_status: nil, geofence: geofence},
+         reset_activity(%{data | last_used: DateTime.utc_now(), geofence: geofence}),
          {:next_event, :internal, {:update, {:online, vehicle}}}}
 
       %Vehicle{drive_state: nil} ->
@@ -1496,7 +1495,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
           car_id: data.car.id
         )
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now()},
+        {:next_state, :start, reset_activity(%{data | last_used: DateTime.utc_now()}),
          {:next_event, :internal, {:update, {:online, vehicle}}}}
 
       %VehicleState{timestamp: ts, car_version: vsn, software_update: %SW{} = software_update} ->
@@ -1517,7 +1516,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         Logger.info("Update / Installed #{vsn}", car_id: data.car.id)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now()},
+        {:next_state, :start, reset_activity(%{data | last_used: DateTime.utc_now()}),
          {:next_event, :internal, {:update, {:online, vehicle}}}}
     end
   end
@@ -1536,16 +1535,16 @@ defmodule TeslaMate.Vehicles.Vehicle do
   end
 
   def handle_event(:internal, {:update, {:offline, _}}, {:asleep, _interval}, data) do
-    {:next_state, :start, data, schedule_fetch(data)}
+    {:next_state, :start, reset_activity(data), schedule_fetch(data)}
   end
 
   def handle_event(:internal, {:update, {:asleep, _}}, {:offline, _interval}, data) do
-    {:next_state, :start, data, schedule_fetch(data)}
+    {:next_state, :start, reset_activity(data), schedule_fetch(data)}
   end
 
   def handle_event(:internal, {:update, {:online, _}} = event, {state, _interval}, %Data{} = data)
       when state in [:asleep, :offline] do
-    {:next_state, :start, %{data | last_used: DateTime.utc_now()},
+    {:next_state, :start, reset_activity(%{data | last_used: DateTime.utc_now()}),
      {:next_event, :internal, event}}
   end
 
@@ -1973,6 +1972,18 @@ defmodule TeslaMate.Vehicles.Vehicle do
     data = %Data{data | last_state_change: now, last_used: now, geofence: geofence}
 
     {drive, data}
+  end
+
+  # The DB records and the driving sub-state must not outlive their state:
+  # every transition to :start leaves any activity-specific data behind.
+  defp reset_activity(%Data{} = data) do
+    %Data{
+      data
+      | current_drive: nil,
+        current_charging_process: nil,
+        current_update: nil,
+        driving_status: nil
+    }
   end
 
   defp timeout_drive(drive, %Data{} = data) do

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -586,18 +586,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
         end
 
         interval =
-          case {data.current_drive != nil, data.current_charging_process != nil} do
-            {true, _} ->
-              10
-
-            {_, true} ->
-              15
-
-            _ ->
-              case state do
-                :online -> 20
-                _ -> 30
-              end
+          case state do
+            :driving -> 10
+            :charging -> 15
+            :online -> 20
+            _ -> 30
           end
 
         {:keep_state, data,

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -693,8 +693,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
         vehicle = merge(data.last_response, stream_data, time: true)
 
         {:next_state, {:driving, :available, drive},
-         %Data{data | last_response: vehicle, elevation: elevation},
-         [broadcast_summary(), schedule_fetch(0, data)]}
+         %Data{
+           data
+           | last_response: vehicle,
+             elevation: elevation,
+             current_drive: drive,
+             driving_status: :available
+         }, [broadcast_summary(), schedule_fetch(0, data)]}
 
       %Stream.Data{shift_state: nil, power: power} when is_number(power) and power < 0 ->
         vehicle = merge(data.last_response, stream_data, time: true)
@@ -782,8 +787,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
         vehicle = merge(data.last_response, stream_data, time: true)
 
         {:next_state, {:driving, :available, drive},
-         %Data{data | last_response: vehicle, elevation: elevation},
-         [broadcast_summary(), schedule_fetch(0, data)]}
+         %Data{
+           data
+           | last_response: vehicle,
+             elevation: elevation,
+             current_drive: drive,
+             driving_status: :available
+         }, [broadcast_summary(), schedule_fetch(0, data)]}
 
       %Stream.Data{shift_state: s, power: power}
       when s in [nil, "P"] and is_number(power) and power < 0 ->
@@ -1111,7 +1121,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
            data
            | last_state_change: DateTime.utc_now(),
              last_used: DateTime.utc_now(),
-             stream_pid: nil
+             stream_pid: nil,
+             current_update: update
          }, [broadcast_summary(), schedule_fetch(15, data)]}
 
       %V{drive_state: %Drive{shift_state: shift_state}} when shift_state in ~w(D N R) ->
@@ -1120,7 +1131,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {drive, data} = start_drive(create_position(vehicle, data), data)
         interval = if streaming?(data), do: default_interval(), else: driving_interval()
 
-        {:next_state, {:driving, :available, drive}, data,
+        {:next_state, {:driving, :available, drive},
+         %{data | current_drive: drive, driving_status: :available},
          [
            broadcast_summary(),
            schedule_fetch(interval, data)
@@ -1156,7 +1168,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
            data
            | last_state_change: DateTime.utc_now(),
              last_used: DateTime.utc_now(),
-             stream_pid: nil
+             stream_pid: nil,
+             current_charging_process: cproc
          }, [broadcast_summary(), schedule_fetch(5, data), schedule_position_storing()]}
 
       _ ->
@@ -1201,7 +1214,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
           |> Map.get(:charger_power)
           |> determince_interval()
 
-        {:next_state, {:charging, cproc}, data,
+        {:next_state, {:charging, cproc}, %{data | current_charging_process: cproc},
          [broadcast_summary(), schedule_fetch(interval, data)]}
 
       %Vehicle{charge_state: %Charge{charging_state: state}} ->
@@ -1233,7 +1246,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
       ) do
     Logger.warning("Vehicle went offline while driving", car_id: data.car.id)
 
-    {:next_state, {:driving, {:unavailable, 0}, drive}, %{data | last_used: DateTime.utc_now()},
+    {:next_state, {:driving, {:unavailable, 0}, drive},
+     %{data | last_used: DateTime.utc_now(), driving_status: {:unavailable, 0}},
      schedule_fetch(5, data)}
   end
 
@@ -1244,7 +1258,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         %Data{} = data
       )
       when n < 15 do
-    {:next_state, {:driving, {:unavailable, n + 1}, drv}, %{data | last_used: DateTime.utc_now()},
+    {:next_state, {:driving, {:unavailable, n + 1}, drv},
+     %{data | last_used: DateTime.utc_now(), driving_status: {:unavailable, n + 1}},
      schedule_fetch(5, data)}
   end
 
@@ -1255,7 +1270,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         %Data{} = data
       ) do
     {:next_state, {:driving, {:offline, data.last_response}, drv},
-     %{data | last_used: DateTime.utc_now()}, [broadcast_summary(), schedule_fetch(30, data)]}
+     %{data | last_used: DateTime.utc_now(), driving_status: {:offline, data.last_response}},
+     [broadcast_summary(), schedule_fetch(30, data)]}
   end
 
   def handle_event(
@@ -1279,7 +1295,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
       min when min >= @drive_timeout_min ->
         timeout_drive(drive, data)
 
-        {:next_state, {:driving, {:offline, last}, nil}, %{data | last_used: DateTime.utc_now()},
+        {:next_state, {:driving, {:offline, last}, nil},
+         %{data | last_used: DateTime.utc_now(), current_drive: nil},
          [broadcast_summary(), schedule_fetch(30, data)]}
 
       _min ->
@@ -1338,7 +1355,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
       not is_nil(drv) ->
         data = maybe_reconnect_stream(data)
 
-        {:next_state, {:driving, :available, drv}, %{data | last_used: DateTime.utc_now()},
+        {:next_state, {:driving, :available, drv},
+         %{data | last_used: DateTime.utc_now(), driving_status: :available},
          {:next_event, :internal, {:update, {:online, now}}}}
     end
   end
@@ -1362,7 +1380,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
     data = maybe_reconnect_stream(data)
 
-    {:next_state, {:driving, :available, drv}, %{data | last_used: DateTime.utc_now()},
+    {:next_state, {:driving, :available, drv},
+     %{data | last_used: DateTime.utc_now(), driving_status: :available},
      {:next_event, :internal, {:update, e}}}
   end
 

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1613,13 +1613,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
             :online ->
               true
 
-            :driving when data.current_drive != nil ->
+            :driving ->
               true
 
-            :updating when data.current_update != nil ->
+            :updating ->
               true
 
-            :charging when data.current_charging_process != nil ->
+            :charging ->
               true
 
             :start ->
@@ -1645,9 +1645,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
         reachable? =
           case expected_state do
             :online -> true
-            :driving when data.current_drive != nil -> true
-            :updating when data.current_update != nil -> true
-            :charging when data.current_charging_process != nil -> true
+            :driving -> true
+            :updating -> true
+            :charging -> true
             :start -> false
             {:offline, _} -> false
             {:asleep, _} -> false

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -764,6 +764,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
     end
   end
 
+  # driving_status is {:unavailable, _} or {:offline, _} here (the :available
+  # clause matched above): the stream shows life, so fetch immediately to recover.
+  def handle_event(:info, {:stream, %Stream.Data{}}, :driving, %Data{} = data) do
+    {:keep_state_and_data, schedule_fetch(0, data)}
+  end
+
   #### Suspended
 
   def handle_event(

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -41,12 +41,13 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       healthy?: healthy?,
       car: car,
       elevation: elevation,
-      geofence: gf
+      geofence: gf,
+      driving_status: driving_status
     } = attrs
 
     %__MODULE__{
       format_vehicle(vehicle)
-      | state: format_state(state),
+      | state: format_state(state, driving_status),
         since: since,
         healthy: healthy?,
         elevation: elevation,
@@ -60,11 +61,9 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     }
   end
 
-  defp format_state({:driving, {:offline, _}, _id}), do: :offline
-  defp format_state({:driving, _state, _id}), do: :driving
-  defp format_state({state, _, _}) when is_atom(state), do: state
-  defp format_state({state, _}) when is_atom(state), do: state
-  defp format_state(state) when is_atom(state), do: state
+  defp format_state(:driving, {:offline, _}), do: :offline
+  defp format_state({state, _}, _driving_status) when is_atom(state), do: state
+  defp format_state(state, _driving_status) when is_atom(state), do: state
 
   defp get_car_attr(%Car{exterior_color: v}, :exterior_color), do: v
   defp get_car_attr(%Car{spoiler_type: v}, :spoiler_type), do: v

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -120,12 +120,13 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       healthy?: healthy?,
       car: car,
       elevation: elevation,
-      geofence: gf
+      geofence: gf,
+      driving_status: driving_status
     } = attrs
 
     %__MODULE__{
       format_vehicle(vehicle)
-      | state: format_state(state),
+      | state: format_state(state, driving_status),
         since: since,
         healthy: healthy?,
         elevation: elevation,
@@ -139,11 +140,9 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     }
   end
 
-  defp format_state({:driving, {:offline, _}, _id}), do: :offline
-  defp format_state({:driving, _state, _id}), do: :driving
-  defp format_state({state, _, _}) when is_atom(state), do: state
-  defp format_state({state, _}) when is_atom(state), do: state
-  defp format_state(state) when is_atom(state), do: state
+  defp format_state(:driving, {:offline, _}), do: :offline
+  defp format_state({state, _}, _driving_status) when is_atom(state), do: state
+  defp format_state(state, _driving_status) when is_atom(state), do: state
 
   defp get_car_attr(%Car{exterior_color: v}, :exterior_color), do: v
   defp get_car_attr(%Car{spoiler_type: v}, :spoiler_type), do: v

--- a/test/teslamate/vehicles/vehicle/charging_test.exs
+++ b/test/teslamate/vehicles/vehicle/charging_test.exs
@@ -96,6 +96,10 @@ defmodule TeslaMate.Vehicles.Vehicle.ChargingTest do
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online, since: ^s2}}}
 
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
+
+    # the charging record must not outlive the :charging state
+    assert {:online, %{current_charging_process: nil}} = :sys.get_state(name)
+
     refute_receive _
   end
 

--- a/test/teslamate/vehicles/vehicle/charging_test.exs
+++ b/test/teslamate/vehicles/vehicle/charging_test.exs
@@ -283,4 +283,37 @@ defmodule TeslaMate.Vehicles.Vehicle.ChargingTest do
 
     refute_receive _
   end
+
+  test "keeps storing positions periodically while charging", %{test: name} do
+    now_ts = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+
+    events = [
+      {:ok, online_event(now_ts)},
+      {:ok,
+       online_event(now_ts, drive_state: %{timestamp: now_ts, latitude: +0.0, longitude: +0.0})},
+      {:ok, charging_event(now_ts + 1, "Charging", 0.1, range: 1)},
+      fn -> Process.sleep(10_000) end
+    ]
+
+    :ok = start_vehicle(name, events, store_position_interval: 50)
+
+    assert_receive {:start_state, car, :online, date: _}, 400
+    assert_receive {:start_charging_process, ^car, %{latitude: +0.0, longitude: +0.0}, _opts}
+    assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :charging}}}
+
+    # discard positions stored before/while entering :charging
+    flush_positions()
+
+    # the periodic store_position timeout must keep firing in the :charging state
+    assert_receive {:insert_position, ^car, %{}}, 400
+    assert_receive {:insert_position, ^car, %{}}, 400
+  end
+
+  defp flush_positions do
+    receive do
+      {:insert_position, _car_or_drive, _attrs} -> flush_positions()
+    after
+      0 -> :ok
+    end
+  end
 end

--- a/test/teslamate/vehicles/vehicle/driving_test.exs
+++ b/test/teslamate/vehicles/vehicle/driving_test.exs
@@ -45,6 +45,9 @@ defmodule TeslaMate.Vehicles.Vehicle.DrivingTest do
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online, since: s2}}}
     assert DateTime.diff(s1, s2, :nanosecond) < 0
 
+    # the drive record and sub-state must not outlive the :driving state
+    assert {:online, %{current_drive: nil, driving_status: nil}} = :sys.get_state(name)
+
     refute_receive _
   end
 

--- a/test/teslamate/vehicles/vehicle/summary_test.exs
+++ b/test/teslamate/vehicles/vehicle/summary_test.exs
@@ -8,7 +8,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SummaryTest do
 
   defp attrs do
     %{
-      state: {:online, nil},
+      state: :online,
       since: DateTime.utc_now(),
       healthy?: true,
       car: nil,

--- a/test/teslamate/vehicles/vehicle/summary_test.exs
+++ b/test/teslamate/vehicles/vehicle/summary_test.exs
@@ -13,7 +13,8 @@ defmodule TeslaMate.Vehicles.Vehicle.SummaryTest do
       healthy?: true,
       car: nil,
       elevation: nil,
-      geofence: nil
+      geofence: nil,
+      driving_status: nil
     }
   end
 

--- a/test/teslamate/vehicles/vehicle/updating_test.exs
+++ b/test/teslamate/vehicles/vehicle/updating_test.exs
@@ -59,6 +59,9 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
 
     assert DateTime.diff(s1, s2, :nanosecond) < 0
 
+    # the update record must not outlive the :updating state
+    assert {:online, %{current_update: nil}} = :sys.get_state(name)
+
     refute_receive _
   end
 


### PR DESCRIPTION
## Summary

This PR completes the state machine simplification by replacing compound state tuples like `{:driving, status, %Log.Drive{}}`, `{:charging, %Log.ChargingProcess{}}`, and `{:updating, %Log.Update{}}` with simple atoms (`:driving`, `:charging`, `:updating`). DB records and sub-states are stored in `Data` struct fields.

## Changes (4 commits)

### Commit 1: Add preparatory fields to Data struct
Adds `current_drive`, `current_charging_process`, `current_update`, and `driving_status` fields.

### Commit 2: Populate Data struct fields in parallel with compound state tuples
Every transition into a compound state now also updates the corresponding struct fields.

### Commit 3: Migrate compound state reads to struct field guards
Replaces pattern-match reads with guards on the struct fields.

### Commit 4: Replace compound state tuples with simple atoms throughout state machine
**This is the main simplification commit.** After this:
- The GenState state is always a simple atom
- `{:driving, status, drive}` → `:driving` (status in `data.driving_status`, drive in `data.current_drive`)
- `{:charging, cproc}` → `:charging` (cproc in `data.current_charging_process`)
- `{:updating, update}` → `:updating` (update in `data.current_update`)

Key changes in this commit:
- All 12 `next_state` positions now use simple atoms
- Driving sub-state machine (available → unavailable → offline) is tracked in `data.driving_status` instead of the state tuple's second element
- All driving handlers match `:driving` with guards on `driving_status`
- `suspend_logging`, `fetch/can_fall_asleep`, and `fetch/reachable` all use simple atom matching
- `Summary` module updated to handle the new state format

## Refactoring sequence (complete!)

1. ✅ Replace `fake_online_state` integers with `pre_online_check` atoms
2. ✅ Add struct fields + populate them + migrate reads
3. ✅ **This PR**: Replace compound states with simple atoms

## Before vs After

**Before (hard to read):**
```elixir
def handle_event(:internal, {:update, {:offline, _}}, {:driving, {:unavailable, n}, drv}, ...)
def handle_event(:internal, {:update, {:offline, _}}, {:driving, {:offline, last}, drive}, ...)
def handle_event(:info, {:stream, %Stream.Data{} = stream_data}, {:driving, status, drv}, ...)
```

**After (clean):**
```elixir
def handle_event(:internal, {:update, {:offline, _}}, :driving, %Data{driving_status: {:unavailable, n}}) do ...
def handle_event(:internal, {:update, {:offline, _}}, :driving, %Data{driving_status: {:offline, last}}) do ...
def handle_event(:info, {:stream, %Stream.Data{}}, :driving, %Data{driving_status: :available, current_drive: drv}) do ...
```

## Testing
All commits are no-behaviour-change mechanical refactors. Existing tests pass.