### PR TITLE
fix: improve brin indexes (autosummarize + timestamp_minmax_multi_ops)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - feat(webview): Make icons inherit text color for better contrast in dark mode (#5193 - @olsoybakk)
 - feat(webview): Add dark mode support for background and buttons in the map (#5240 - @olsoybakk and @swiffer)
 - fix(webview): Prevent rounding of map tiles via Bulma CSS (#5265 - @swiffer)
+- perf: ensure BRIN indexes don't degrade over time (#5276 - @swiffer)
 
 #### Build, CI, internal
 

--- a/priv/repo/migrations/20260411070212_improve_brin_indexes_on_positions.exs
+++ b/priv/repo/migrations/20260411070212_improve_brin_indexes_on_positions.exs
@@ -1,0 +1,24 @@
+defmodule TeslaMate.Repo.Migrations.ImproveBrinIndexesOnPositions do
+  use Ecto.Migration
+
+  def change do
+    # Drop existing BRIN indexes
+    drop_if_exists(index(:positions, [:drive_id, :date]))
+    drop_if_exists(index(:positions, [:date]))
+
+    # Create new BRIN indexes with optimized options
+    create(
+      index(:positions, ["date timestamp_minmax_multi_ops"],
+        using: "brin",
+        options: "autosummarize = true, pages_per_range = 64"
+      )
+    )
+
+    create(
+      index(:positions, [:drive_id, "date timestamp_minmax_multi_ops"],
+        using: "brin",
+        options: "autosummarize = true, pages_per_range = 64"
+      )
+    )
+  end
+end


### PR DESCRIPTION
# Tune BRIN indexes on `positions` table for better long-term performance

## Related Issues / PRs

- Replaces indexes changed in #5075 (BTREE → BRIN on `positions` table)
- Addresses performance degradation reported in #5231

## Description

In #5075 we switched two indexes on the `positions` table from BTREE to BRIN to achieve significant storage savings. While this worked well initially, BRIN indexes can degrade over time as new data is inserted (especially with unsummarized ranges), leading to slower query performance.

This PR tunes the BRIN indexes to improve resilience against degradation:

- **Enable `autosummarize = true`**: New ranges at the end of the table are automatically summarized by autovacuum, keeping the index effective without manual intervention.
- **Use `timestamp_minmax_multi_ops` for date column**: Stores multiple min/max values per block instead of a single pair. This helps handle outliers better while still benefiting from the extremely high correlation observed on the date column. The index remains very small, so the modest size increase is acceptable.
- **Set `pages_per_range = 64`**: Reduces the number of rows per range (roughly from ~10,000 to ~5,000 on typical instances), providing a better balance between index precision and size.

### Impact on index size
On a test instance with ~10 million rows, the index grew from ~54 KB to ~568 KB. This is still negligible and considered a worthwhile trade-off for sustained query performance.

The goal of these changes is to prevent the indexes from degrading as quickly as they did before, while preserving most of the storage benefits of BRIN.

## Changes

- Updated the index definition via migration with the new storage parameters.
- No changes to application code or queries.

## How to Test / Review

1. On your current TeslaMate instance (before switching to this PR's image), run the following queries and note the execution times:

```sql
SELECT d0."id" FROM "drives" AS d0 
WHERE (((d0."start_date" > '2026-04-01') 
AND EXISTS((SELECT 1 FROM "positions" AS sp0 
WHERE (sp0."drive_id" = d0."id") AND (sp0."id" > 0))))
AND NOT (EXISTS((SELECT 1 FROM "positions" AS sp0 
WHERE ((sp0."drive_id" = d0."id") AND (sp0."id" > 0)) 
AND (sp0."odometer" IS NOT NULL) 
AND (sp0."ideal_battery_range_km" IS NULL)))));
```

```sql
SELECT attname, correlation, n_distinct
FROM pg_stats
WHERE tablename = 'positions'
  AND attname IN ('drive_id', 'date')
ORDER BY attname;
```
2. Switch to the Docker image built from this PR (or apply the migration).
3. Let the database migration run (it will recreate/rebuild the affected indexes).
4. Re-run the queries above and compare execution times.

**Note:** Recreating the indexes should immediately improve performance (observed improvement from ~2.5s to ~0.04s on one instance). The new settings are designed to maintain that performance longer as data grows.
You can also manually trigger summarization for testing:

```sql
SELECT brin_summarize_new_values('positions_drive_id_date_index'::regclass)
       AS unsummarized_ranges_summarized;
```

## Review Request

@ilya-y-synth — as the original author of #5075, could you please take a look?

## Checklist

- [x] Migration successfully applies and rebuilds the indexes
- [x] Queries show improved or stable performance after migration
- [x] Index size remains reasonable for large tables (~10M+ rows)
- [x] No unintended impact on insert/update performance

Feel free to share your before/after timings and any observations!