### PR TITLE
build(deps): bump leaflet-geoman-free from 2.19.2 to 2.19.3 in /assets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/assets"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     ignore:
       # ignore the path based dependencies to prevent "Dependabot couldn't fetch all your path-based dependencies"
       - dependency-name: phoenix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - refactor: replace fake_online_state integer with typed mcu2_online_check atom (#5245 - @brianmay)
 - fix: update GitHub Actions configuration for Dependabot to include action directories (#5316 - @swiffer)
 - build(deps): bump docker/login-action from 4.0.0 to 4.1.0, docker/build-push-action from 7.0.0 to 7.1.0, actions/upload-artifact from 7.0.0 to 7.0.1, actions/upload-artifact/merge from 7.0.0 to 7.0.1, erlef/setup-beam from 1.18.1 to 1.24.0, actions/cache from 5.0.4 to 5.0.5, actions/cache/restore from 5.0.4 to 5.0.5, actions/cache/save from 5.0.4 to 5.0.5 and crate-ci/typos from 1.45.0 to 1.46.0 (#5317)
+- build(deps): bump leaflet-geoman-free from 2.19.2 to 2.19.3 in /assets (#5301 - @swiffer)
 
 #### Dashboards
 

--- a/assets/.npmrc
+++ b/assets/.npmrc
@@ -1,0 +1,1 @@
+ min-release-age=7

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@creativebulma/bulma-divider": "^1.1.0",
         "@creativebulma/bulma-tooltip": "^1.2.0",
-        "@geoman-io/leaflet-geoman-free": "^2.19.2",
+        "@geoman-io/leaflet-geoman-free": "^2.19.3",
         "@mdi/font": "^7.4.47",
         "bulma-switch": "^2.0.4",
         "leaflet": "^1.9.4",
@@ -20,9 +20,9 @@
       },
       "devDependencies": {
         "bulma": "^1.0.4",
-        "esbuild": "^0.27.3",
-        "esbuild-sass-plugin": "^3.6.0",
-        "sass": "^1.97.3"
+        "esbuild": "^0.27.7",
+        "esbuild-sass-plugin": "^3.7.0",
+        "sass": "^1.99.0"
       }
     },
     "../deps/phoenix": {
@@ -45,7 +45,8 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
       "dev": true,
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@creativebulma/bulma-divider": {
       "version": "1.1.0",
@@ -502,16 +503,16 @@
       }
     },
     "node_modules/@geoman-io/leaflet-geoman-free": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@geoman-io/leaflet-geoman-free/-/leaflet-geoman-free-2.19.2.tgz",
-      "integrity": "sha512-FYqLCFjCWLc1c5vel83i2ON77zPugH9qfxzLxTt+SiFiMgHjO1dSS59qz23aLLQ0hRWTQdycnxXGNmT+4OC9sg==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/@geoman-io/leaflet-geoman-free/-/leaflet-geoman-free-2.19.3.tgz",
+      "integrity": "sha512-HjbEpfAEUs0NyI1Dhvz3SMVG6m0pAN/1Eo0tRKsz9cpaROTrFtmJGY22swEir1Uj/8IeGF1NJId38C5Fu+nZGQ==",
       "license": "MIT",
       "dependencies": {
         "@turf/boolean-contains": "^7.3.3",
         "@turf/kinks": "^7.3.3",
         "@turf/line-intersect": "^7.3.3",
         "@turf/line-split": "^7.3.3",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "polyclip-ts": "^0.16.8"
       },
       "engines": {
@@ -656,6 +657,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -677,6 +681,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -698,6 +705,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -719,6 +729,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -740,6 +753,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -761,6 +777,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -838,13 +857,13 @@
       }
     },
     "node_modules/@turf/bbox": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.4.tgz",
-      "integrity": "sha512-D5ErVWtfQbEPh11yzI69uxqrcJmbPU/9Y59f1uTapgwAwQHQztDWgsYpnL3ns8r1GmPWLP8sGJLVTIk2TZSiYA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.5.tgz",
+      "integrity": "sha512-oG1ya/HtBjAIg4TimbWx+nOYPbY0bCvt82Bq8tm6sBw3qqtbOyRSfDz79Sq90TnH7DXJprJ1qnVGKNtZ6jemfw==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -853,17 +872,17 @@
       }
     },
     "node_modules/@turf/boolean-contains": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-7.3.4.tgz",
-      "integrity": "sha512-AJMGbtC6HiXgHvq0RNlTfsDB58Qf9Js45MP/APbhGTH4AiLZ8VMDISywVFNd7qN6oppNlDd3xApVR28+ti8bNg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-7.3.5.tgz",
+      "integrity": "sha512-P4JUAHgvJkD+8ybQ6d1OHp9TBsGsjJxF5lWeXJgp0k4+Hd/D0CVy4/mhLkZdNa6QdljVdwNcfU0CTqy1WsSQig==",
       "license": "MIT",
       "dependencies": {
-        "@turf/bbox": "7.3.4",
-        "@turf/boolean-point-in-polygon": "7.3.4",
-        "@turf/boolean-point-on-line": "7.3.4",
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
-        "@turf/line-split": "7.3.4",
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-split": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -872,13 +891,13 @@
       }
     },
     "node_modules/@turf/boolean-point-in-polygon": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.4.tgz",
-      "integrity": "sha512-v/4hfyY90Vz9cDgs2GwjQf+Lft8o7mNCLJOTz/iv8SHAIgMMX0czEoIaNVOJr7tBqPqwin1CGwsncrkf5C9n8Q==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.5.tgz",
+      "integrity": "sha512-ba7+B0wzaS9GtERZOoXUZ6oW8IcIJHNQZf3c+tiD9ESjcsPO1Q/4qIJGTKl92nBLhhracHJxMWBM/U6hAVkaRg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "point-in-polygon-hao": "^1.1.0",
         "tslib": "^2.8.1"
@@ -888,13 +907,13 @@
       }
     },
     "node_modules/@turf/boolean-point-on-line": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.3.4.tgz",
-      "integrity": "sha512-70gm5x6YQOZKcw0b/O4jjMwVWnFj+Zb6TXozLgZFDZShc8pgTQtZku7K+HKZ7Eya+7usHIB4IimZauomOMa+iw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-TuWfrAT63W43BDzgYc94UzQ5/PjF1aTnh4AIzmQwez1YnimShYcOTwo8OIHzDaB6gbbvFsfxYMuOA5JOp942Kg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -903,13 +922,13 @@
       }
     },
     "node_modules/@turf/distance": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.4.tgz",
-      "integrity": "sha512-9drWgd46uHPPyzgrcRQLgSvdS/SjVlQ6ZIBoRQagS5P2kSjUbcOXHIMeOSPwfxwlKhEtobLyr+IiR2ns1TfF8w==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
+      "integrity": "sha512-uQAC63zg/l91KUxzfhqio7Ii3+UXTrPOVJScIdRj6EO6+9XHI4kC+AdyIS4cPAv14sZfJLIBxzMnzcGrss+kEA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -918,14 +937,14 @@
       }
     },
     "node_modules/@turf/geojson-rbush": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.3.4.tgz",
-      "integrity": "sha512-aDG/5mMCgKduqBwZ3XpLOdlE2hizV3fM+5dHCWyrBepCQLeM/QRvvpBDCdQKDWKpoIBmrGGYDNiOofnf3QmGhg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.3.5.tgz",
+      "integrity": "sha512-30/hQqc+ErnlcavvDdxGfgm8VtsJDEzSYpf3mPqYxOyI976l49T6+1jCQD5xKswml6o8zZAaTSe6ZcSKF+SCNw==",
       "license": "MIT",
       "dependencies": {
-        "@turf/bbox": "7.3.4",
-        "@turf/helpers": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "rbush": "^3.0.1",
         "tslib": "^2.8.1"
@@ -935,9 +954,9 @@
       }
     },
     "node_modules/@turf/helpers": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.4.tgz",
-      "integrity": "sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.10",
@@ -948,12 +967,12 @@
       }
     },
     "node_modules/@turf/invariant": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.4.tgz",
-      "integrity": "sha512-88Eo4va4rce9sNZs6XiMJowWkikM3cS2TBhaCKlU+GFHdNf8PFEpiU42VDU8q5tOF6/fu21Rvlke5odgOGW4AQ==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
+        "@turf/helpers": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -962,12 +981,12 @@
       }
     },
     "node_modules/@turf/kinks": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.3.4.tgz",
-      "integrity": "sha512-LZTKELWxvXl0vc9ZxVgi0v07fO9+2FrZOam2B10fz/eGjy3oKNazU5gjggbnc499wEIcJS4hN+VyjQZrmsJAdQ==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.3.5.tgz",
+      "integrity": "sha512-dPW8d4vs1v8WMobjyq/TVqajjPwkMsl94IF58yp1UYlmJDQrW4iNRUmI9fFzww+fl7epCKNwY+jZhXf1DRi93w==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
+        "@turf/helpers": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -976,12 +995,12 @@
       }
     },
     "node_modules/@turf/line-intersect": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.4.tgz",
-      "integrity": "sha512-XygbTvHa6A+v6l2ZKYtS8AAWxwmrPxKxfBbdH75uED1JvdytSLWYTKGlcU3soxd9sYb4x/g9sDvRIVyU6Lucrg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.5.tgz",
+      "integrity": "sha512-2Cl4oPsjaDdfIwz/5IRDdG2fNdfp3W6atICm81vnzl/GwURoVP+CLjXJ64QWWzpzIbgX2XprJQTmamByDt5MDw==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
+        "@turf/helpers": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "sweepline-intersections": "^1.5.0",
         "tslib": "^2.8.1"
@@ -991,14 +1010,14 @@
       }
     },
     "node_modules/@turf/line-segment": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.3.4.tgz",
-      "integrity": "sha512-UeISzf/JHoWEY5yeoyvKwA5epWcvJMCpCwbIMolvfTC5pp+IVozjHPVCRvRWuzmbmAvetcW0unL5bjqi0ADmuQ==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.3.5.tgz",
+      "integrity": "sha512-TM1aCu7utM6fllAEHO8PNqBJZ/uoFJVNp2A0YI7FyWN928hPbacsvNtLeVz/Kq1ZbeqQ1ZIKRxo9FdVjaj8hGg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1007,20 +1026,20 @@
       }
     },
     "node_modules/@turf/line-split": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.3.4.tgz",
-      "integrity": "sha512-l1zmCSUnGsiN4gf22Aw91a2VnYs5DZS67FdkYqKgr+wPEAL/gpQgIBBWSTmhwY8zb3NEqty+f/gMEe8EJAWYng==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.3.5.tgz",
+      "integrity": "sha512-GEuy+LdbbaqtYjHk/i1G8sK51wfCdPqTO8uH0dJZ6WlcIcZQfRcKKI4ksFm7NkVyfmw8gXWbpMJD8lO380GFBQ==",
       "license": "MIT",
       "dependencies": {
-        "@turf/bbox": "7.3.4",
-        "@turf/geojson-rbush": "7.3.4",
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
-        "@turf/line-intersect": "7.3.4",
-        "@turf/line-segment": "7.3.4",
-        "@turf/meta": "7.3.4",
-        "@turf/nearest-point-on-line": "7.3.4",
-        "@turf/truncate": "7.3.4",
+        "@turf/bbox": "7.3.5",
+        "@turf/geojson-rbush": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@turf/truncate": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1029,12 +1048,12 @@
       }
     },
     "node_modules/@turf/meta": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.4.tgz",
-      "integrity": "sha512-tlmw9/Hs1p2n0uoHVm1w3ugw1I6L8jv9YZrcdQa4SH5FX5UY0ATrKeIvfA55FlL//PGuYppJp+eyg/0eb4goqw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
+        "@turf/helpers": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1043,15 +1062,15 @@
       }
     },
     "node_modules/@turf/nearest-point-on-line": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.4.tgz",
-      "integrity": "sha512-DQrP3lRju83rIXFN68tUEpc7ki/eRwdwBkK2CTT4RAcyCxbcH2NGJPQv8dYiww/Ar77u1WLVn+aINXZH904dWw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-MZn6OkEFZpjS6BNUANfqiHMIbQSivu7TNji3a+OAIrnPJ71vp8cbz0N2aVEa5M7I8ipvxoxAPIV3eqg3h280Vg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/distance": "7.3.4",
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1060,13 +1079,13 @@
       }
     },
     "node_modules/@turf/truncate": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.4.tgz",
-      "integrity": "sha512-VPXdae9+RLLM19FMrJgt7QANBikm7DxPbfp/dXgzE4Ca7v+mJ4T1fYc7gCZDaqOrWMccHKbvv4iSuW7YZWdIIA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.5.tgz",
+      "integrity": "sha512-Qx2iv3KIqKuDAUduMfaJ5fFegEWBeRve5zePalRevS16bMUqEX+jnKPK9fWGyUuPqT61qP1Kybz0PTWPbUbljQ==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1123,7 +1142,8 @@
       "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
       "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1136,6 +1156,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -1143,7 +1173,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1210,14 +1239,15 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1279,8 +1309,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/leaflet-control-geocoder": {
       "version": "3.3.1",
@@ -1295,9 +1324,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/node-addon-api": {
@@ -1397,12 +1426,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -1429,6 +1459,7 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1510,6 +1541,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "sass": "1.99.0"
       }
@@ -1527,6 +1559,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1544,6 +1577,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1561,6 +1595,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1578,6 +1613,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1595,6 +1631,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1612,6 +1649,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1624,11 +1662,13 @@
         "arm"
       ],
       "dev": true,
+      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1641,11 +1681,13 @@
         "arm64"
       ],
       "dev": true,
+      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1658,11 +1700,13 @@
         "arm"
       ],
       "dev": true,
+      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1675,11 +1719,13 @@
         "arm64"
       ],
       "dev": true,
+      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1692,11 +1738,13 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1709,11 +1757,13 @@
         "x64"
       ],
       "dev": true,
+      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1726,11 +1776,13 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1743,11 +1795,13 @@
         "x64"
       ],
       "dev": true,
+      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1765,6 +1819,7 @@
         "!linux",
         "!win32"
       ],
+      "peer": true,
       "dependencies": {
         "sass": "1.99.0"
       }
@@ -1782,6 +1837,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1799,6 +1855,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1825,6 +1882,7 @@
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -1863,6 +1921,7 @@
       "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sync-message-port": "^1.0.0"
       },
@@ -1876,6 +1935,7 @@
       "integrity": "sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.0.0"
       }
@@ -1897,7 +1957,8 @@
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/assets/package.json
+++ b/assets/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@creativebulma/bulma-divider": "^1.1.0",
     "@creativebulma/bulma-tooltip": "^1.2.0",
-    "@geoman-io/leaflet-geoman-free": "^2.19.2",
+    "@geoman-io/leaflet-geoman-free": "^2.19.3",
     "@mdi/font": "^7.4.47",
     "bulma-switch": "^2.0.4",
     "leaflet": "^1.9.4",

--- a/nix/flake-modules/package.nix
+++ b/nix/flake-modules/package.nix
@@ -26,7 +26,7 @@
       nodePackages = pkgs.buildNpmPackage {
         name = "${pname}-assets";
         src = "${src}/assets";
-        npmDepsHash = "sha256-gwI+LAlBTuBUMIyyCzqoheLkJ1jrPilHFLXaauLt18k="; # if you change the npm deps, you need to update this hash
+        npmDepsHash = "sha256-k0i7iSOA4gcDSCi9S5YZMCoO+HIgZ56ZlWiFIa24TEY="; # if you change the npm deps, you need to update this hash
         # npmDepsHash = pkgs.lib.fakeHash;
         dontNpmBuild = true;
         inherit nodejs;


### PR DESCRIPTION
leaflet-geoman-free 2.19.3 bumps lodash to 4.18.1 closing known security vulnerabilities:

- https://github.com/teslamate-org/teslamate/security/dependabot?q=is%3Aopen+package%3Alodash

in addition this PR sets:

Cooldown for Dependabot / Min-Release-Age for NPM (considering this as best-practice against supply-chain attacks and [recommended by Docusaurus](https://docusaurus.io/blog/releases/3.10#secure-your-site)).
- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
- https://docs.npmjs.com/cli/v11/commands/npm-install#min-release-age