### PR TITLE
fix: update GitHub Actions configuration for Dependabot to include action directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,12 @@ updates:
       interval: "monthly"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
     schedule:
       interval: "monthly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - build(deps): update flake.lock (#5288)
 - build(deps): bump docusaurus from 3.9.2 to 3.10.0 in /website (#5302 - @swiffer)
 - refactor: replace fake_online_state integer with typed mcu2_online_check atom (#5245 - @brianmay)
+- fix: update GitHub Actions configuration for Dependabot to include action directories
 
 #### Dashboards
 


### PR DESCRIPTION
the current depenabot config for github actions is not bumping actions reused in local actions

add the actions folder and group the updates per action

e.g. see #5307 (not covering the build action)