### PR TITLE
refactor(nix,postgres): provision database declaratively, connect via socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - fix(nix,maintenance): read RELEASE_COOKIE without sourcing the env file (#5337 - @JakobLichterfeld)
 - fix(nix,postgres): set role password safely for any value (#5337 - @JakobLichterfeld)
 - fix(nix): drop schemas in the configured database during restore (#5337 - @JakobLichterfeld)
+- fix(nix,grafana): disable the periodic plugin update check (#5337 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fix: reconnect stream when a drive resumes after mid-drive offline phase to avoid missing elevation (#5535 - @JakobLichterfeld)
 - refactor(nix,postgres): provision database declaratively, connect via socket (#5337 - @JakobLichterfeld)
 - fix(nix,maintenance): read RELEASE_COOKIE without sourcing the env file (#5337 - @JakobLichterfeld)
+- fix(nix,postgres): set role password safely for any value (#5337 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - fix(mqtt): return publish errors without crashing (#5514 - @magrathean-uk)
 - fix(geofences): increase cost precision (#5508 - @magrathean-uk)
 - fix: reconnect stream when a drive resumes after mid-drive offline phase to avoid missing elevation (#5535 - @JakobLichterfeld)
+- refactor(nix,postgres): provision database declaratively, connect via socket (#5337 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - fix(geofences): increase cost precision (#5508 - @magrathean-uk)
 - fix: reconnect stream when a drive resumes after mid-drive offline phase to avoid missing elevation (#5535 - @JakobLichterfeld)
 - refactor(nix,postgres): provision database declaratively, connect via socket (#5337 - @JakobLichterfeld)
+- fix(nix,maintenance): read RELEASE_COOKIE without sourcing the env file (#5337 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - refactor(nix,postgres): provision database declaratively, connect via socket (#5337 - @JakobLichterfeld)
 - fix(nix,maintenance): read RELEASE_COOKIE without sourcing the env file (#5337 - @JakobLichterfeld)
 - fix(nix,postgres): set role password safely for any value (#5337 - @JakobLichterfeld)
+- fix(nix): drop schemas in the configured database during restore (#5337 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/lib/teslamate/database_check.ex
+++ b/lib/teslamate/database_check.ex
@@ -8,6 +8,8 @@ defmodule TeslaMate.DatabaseCheck do
     defstruct [:version_string, :version_num, :major]
   end
 
+  # When changing these requirements, also update the eval-time assertion in
+  # nix/module.nix (services.teslamate.postgres.package), which mirrors them.
   @version_requirements %{
     1600 => %{min_version: "16.7", min_version_num: 160_007},
     1700 => %{min_version: "17.3", min_version_num: 170_003},

--- a/nix/backup_and_restore.nix
+++ b/nix/backup_and_restore.nix
@@ -20,7 +20,7 @@ let
     systemctl stop teslamate.service
 
     # Drop existing data and reinitialize
-    sudo -u teslamate psql -U ${databaseUser} << .
+    sudo -u teslamate psql -U ${databaseUser} -d ${databaseName} << .
       DROP SCHEMA IF EXISTS public cascade;
       DROP SCHEMA IF EXISTS private CASCADE;
       CREATE SCHEMA public;

--- a/nix/flake-modules/package.nix
+++ b/nix/flake-modules/package.nix
@@ -27,7 +27,7 @@
       nodePackages = pkgs.buildNpmPackage {
         name = "${pname}-assets";
         src = "${src}/assets";
-        npmDepsHash = "sha256-b3b5yEVM3E3X9Gl7FheXTnNgs2U9Vwtr9O8IjKro5hA="; # if you change the npm deps, you need to update this hash
+        npmDepsHash = "sha256-x0/2/j1nsWhJHo1f+7KDdI2ks4rB3th1Ty/ad76cRts="; # if you change the npm deps, you need to update this hash
         # npmDepsHash = pkgs.lib.fakeHash;
         dontNpmBuild = true;
         inherit nodejs;

--- a/nix/maintenance.nix
+++ b/nix/maintenance.nix
@@ -42,7 +42,7 @@ let
 
     # load RELEASE_COOKIE from the env file
     ${loadFromEnvFile "RELEASE_COOKIE"}
-    : ''${RELEASE_COOKIE?'RELEASE_COOKIE must be set in the environment file'}
+    : ''${RELEASE_COOKIE:?'RELEASE_COOKIE must be set in the environment file'}
 
     echo "Attempt to close the drive with ID ''${1}."
     ${getExe teslamate} rpc "TeslaMate.Repo.get!(TeslaMate.Log.Drive, ''${1}) |> TeslaMate.Log.close_drive()"
@@ -59,7 +59,7 @@ let
 
     # load RELEASE_COOKIE from the env file
     ${loadFromEnvFile "RELEASE_COOKIE"}
-    : ''${RELEASE_COOKIE?'RELEASE_COOKIE must be set in the environment file'}
+    : ''${RELEASE_COOKIE:?'RELEASE_COOKIE must be set in the environment file'}
 
     echo "Attempt to close the charge with ID ''${1}."
     ${getExe teslamate} rpc "TeslaMate.Repo.get!(TeslaMate.Log.ChargingProcess, ''${1}) |> TeslaMate.Log.complete_charging_process()"

--- a/nix/maintenance.nix
+++ b/nix/maintenance.nix
@@ -10,6 +10,27 @@
 , ...
 }:
 let
+  # Extract a single KEY=value from the environment file literally, without
+  # sourcing it. Sourcing would execute the file as a shell script (arbitrary
+  # code execution if a secret contains e.g. $(...) or backticks) and break on
+  # values containing quotes. sed prints everything after the first '=' as-is,
+  # so the value may contain any character (single quotes, spaces, $, ...).
+  # tail -n1 mirrors systemd's "last assignment wins" for duplicate keys.
+  #
+  # The env file wraps values in double quotes (e.g. RELEASE_COOKIE="..."), so
+  # we strip one optional surrounding pair afterwards. The inner value is left
+  # untouched and may still contain anything.
+  loadFromEnvFile = key: ''
+    if [ ! -f ${environmentFilePath} ]; then
+      echo "Environment file ${environmentFilePath} not found!" >&2
+      exit 1
+    fi
+    ${key}="$(sed -n 's/^${key}=//p' ${environmentFilePath} | tail -n1)"
+    ${key}="''${${key}#\"}"
+    ${key}="''${${key}%\"}"
+    export ${key}
+  '';
+
   closeDrive = writeShellScript "teslamate-close-drive" ''
     set -euo pipefail
     : ''${1?'Please provide a drive ID to close'}
@@ -19,14 +40,8 @@ let
       exit 1
     fi
 
-    # load env file to have RELEASE_COOKIE set
-    if [ -f ${environmentFilePath} ]; then
-      source ${environmentFilePath}
-      export RELEASE_COOKIE
-    else
-      echo "Environment file ${environmentFilePath} not found!" >&2
-      exit 1
-    fi
+    # load RELEASE_COOKIE from the env file
+    ${loadFromEnvFile "RELEASE_COOKIE"}
     : ''${RELEASE_COOKIE?'RELEASE_COOKIE must be set in the environment file'}
 
     echo "Attempt to close the drive with ID ''${1}."
@@ -42,14 +57,8 @@ let
       exit 1
     fi
 
-    # load env file to have RELEASE_COOKIE set
-    if [ -f ${environmentFilePath} ]; then
-      source ${environmentFilePath}
-      export RELEASE_COOKIE
-    else
-      echo "Environment file ${environmentFilePath} not found!" >&2
-      exit 1
-    fi
+    # load RELEASE_COOKIE from the env file
+    ${loadFromEnvFile "RELEASE_COOKIE"}
     : ''${RELEASE_COOKIE?'RELEASE_COOKIE must be set in the environment file'}
 
     echo "Attempt to close the charge with ID ''${1}."

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -29,6 +29,9 @@ in
       description = lib.mdDoc ''
         Path to an env file containing the secrets used by TeslaMate.
 
+        The file uses systemd `EnvironmentFile` syntax (`KEY="value"` lines,
+        values may be wrapped in one pair of double quotes).
+
         Must contain at least:
         - `ENCRYPTION_KEY` - encryption key used to encrypt database
         - `DATABASE_PASS` - password used to authenticate to database
@@ -283,6 +286,10 @@ in
         # This is safe for any password, including ones containing single
         # quotes. Requires PostgreSQL >= 14 for \getenv.
         postStart = ''
+          if [ -z "''${DATABASE_PASS:-}" ]; then
+            echo "DATABASE_PASS must be set in ${cfg.secretsFile} (services.teslamate.secretsFile)" >&2
+            exit 1
+          fi
           psql -v ON_ERROR_STOP=1 -d postgres \
             -c '\getenv password DATABASE_PASS' \
             -c "ALTER USER \"${cfg.postgres.user}\" WITH ENCRYPTED PASSWORD :'password'"

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -184,6 +184,9 @@ in
         after = [
           "network.target"
           "postgresql.service"
+          # Database, role and password are provisioned here (no-op when using
+          # an external database server, where the unit is absent).
+          "postgresql-setup.service"
           "mosquitto.service"
         ];
         wantedBy = mkIf cfg.autoStart [ "multi-user.target" ];
@@ -212,6 +215,13 @@ in
             HTTP_BINDING_ADDRESS = mkIf (cfg.listenAddress != null) cfg.listenAddress;
             DISABLE_MQTT = mkIf (!cfg.mqtt.enable) "true";
           }
+          # When PostgreSQL runs on the same host, connect via the local socket
+          # using peer authentication instead of TCP with a password. This only
+          # works for the default role name, since the socket branch in
+          # runtime.exs authenticates as the systemd unit's OS user (teslamate).
+          (mkIf (cfg.postgres.enable_server && cfg.postgres.user == "teslamate") {
+            DATABASE_SOCKET_DIR = "/run/postgresql";
+          })
           (mkIf cfg.mqtt.enable {
             MQTT_HOST = cfg.mqtt.host;
             MQTT_PORT = mkIf (cfg.mqtt.port != null) (toString cfg.mqtt.port);
@@ -243,20 +253,33 @@ in
           inherit (cfg.postgres) port;
         };
 
-        initialScript = pkgs.writeText "teslamate-psql-init" ''
-          \set password `echo $DATABASE_PASS`
-          CREATE DATABASE ${cfg.postgres.database};
-          CREATE USER ${cfg.postgres.user} with encrypted password :'password';
-          GRANT ALL PRIVILEGES ON DATABASE ${cfg.postgres.database} TO ${cfg.postgres.user};
-          ALTER USER ${cfg.postgres.user} WITH SUPERUSER;
-        '';
+        ensureDatabases = [ cfg.postgres.database ];
+        ensureUsers = [
+          {
+            name = cfg.postgres.user;
+            ensureDBOwnership = cfg.postgres.user == cfg.postgres.database;
+            # TeslaMate's migrations create the cube and earthdistance
+            # extensions (see priv/repo/migrations/20190925152807_create_geo_extensions.exs).
+            # These are not trusted extensions, so CREATE EXTENSION requires a
+            # database superuser.
+            ensureClauses.superuser = true;
+          }
+        ];
       };
 
-      # Include secrets in postgres as well
-      systemd.services.postgresql = {
-        serviceConfig = {
-          EnvironmentFile = cfg.secretsFile;
-        };
+      # ensureUsers creates the role without a password. Apply it out-of-band
+      # from DATABASE_PASS so the secret never lands in the world-readable Nix
+      # store (ensureUsers cannot set passwords). It is still required for
+      # Grafana and for the TCP fallback (remote DB or a non-default role name),
+      # even though TeslaMate itself connects via the socket with peer auth.
+      #
+      # ensureDatabases/ensureUsers run inside postgresql-setup.service, so we
+      # hook there (after the role exists) and scope the secret to that unit.
+      systemd.services.postgresql-setup = {
+        serviceConfig.EnvironmentFile = cfg.secretsFile;
+        postStart = ''
+          psql -tAc "ALTER USER \"${cfg.postgres.user}\" WITH ENCRYPTED PASSWORD '$DATABASE_PASS'"
+        '';
       };
     })
     (mkIf cfg.grafana.enable {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -277,8 +277,15 @@ in
       # hook there (after the role exists) and scope the secret to that unit.
       systemd.services.postgresql-setup = {
         serviceConfig.EnvironmentFile = cfg.secretsFile;
+        # Read the password from the environment with psql's \getenv (so it is
+        # never placed on the command line or shell-expanded) and quote it with
+        # :'password', which produces a correctly escaped SQL string literal.
+        # This is safe for any password, including ones containing single
+        # quotes. Requires PostgreSQL >= 14 for \getenv.
         postStart = ''
-          psql -tAc "ALTER USER \"${cfg.postgres.user}\" WITH ENCRYPTED PASSWORD '$DATABASE_PASS'"
+          psql -v ON_ERROR_STOP=1 -d postgres \
+            -c '\getenv password DATABASE_PASS' \
+            -c "ALTER USER \"${cfg.postgres.user}\" WITH ENCRYPTED PASSWORD :'password'"
         '';
       };
     })

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -346,6 +346,11 @@ in
           "auth.anonymous".enabled = false;
           "auth.basic".enabled = false;
           analytics.reporting_enabled = false;
+          # The NixOS module disables the Grafana and plugin update checks by
+          # default -- except the plugin check when declarativePlugins is unset.
+          # Plugins only ever change through nixpkgs here, so the 10-minute check
+          # is pure log noise and an unnecessary call to grafana.com.
+          analytics.check_for_plugin_updates = false;
           dashboards.default_home_dashboard_path = mkIf cfg.grafana.setDefaultDashboard "${pkgs.lib.sources.sourceFilesBySuffices ../grafana/dashboards/internal [".json"]}/home.json";
           date_formats.use_browser_locale = true;
           plugins.preinstall_disabled = true;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -248,6 +248,22 @@ in
       ];
     }
     (mkIf cfg.postgres.enable_server {
+      assertions = [
+        {
+          # Mirror TeslaMate's runtime requirement (see
+          # lib/teslamate/database_check.ex): >= 16.7 for 16.x, >= 17.3 for
+          # 17.x, or >= 18. Newer majors only produce a runtime warning there,
+          # so they are allowed here as well. This also covers the psql
+          # \getenv used in postStart, which needs PostgreSQL >= 14.
+          assertion =
+            let v = cfg.postgres.package.version; in
+            lib.versionAtLeast v "18"
+            || (lib.versionAtLeast v "17.3" && lib.versionOlder v "18")
+            || (lib.versionAtLeast v "16.7" && lib.versionOlder v "17");
+          message = "services.teslamate.postgres.package (${cfg.postgres.package.version}) is not supported by TeslaMate: required is PostgreSQL >= 16.7 (16.x), >= 17.3 (17.x), or >= 18 (see lib/teslamate/database_check.ex).";
+        }
+      ];
+
       services.postgresql = {
         enable = true;
         inherit (cfg.postgres) package;
@@ -286,6 +302,12 @@ in
         # This is safe for any password, including ones containing single
         # quotes. Requires PostgreSQL >= 14 for \getenv.
         postStart = ''
+          # A read-only standby cannot execute ALTER USER; the password is
+          # replicated from the primary anyway.
+          if [ "$(psql -d postgres -tAc 'SELECT pg_is_in_recovery()')" = "t" ]; then
+            echo "PostgreSQL is in recovery (standby); skipping role password setup."
+            exit 0
+          fi
           if [ -z "''${DATABASE_PASS:-}" ]; then
             echo "DATABASE_PASS must be set in ${cfg.secretsFile} (services.teslamate.secretsFile)" >&2
             exit 1

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -301,6 +301,19 @@ in
         # :'password', which produces a correctly escaped SQL string literal.
         # This is safe for any password, including ones containing single
         # quotes. Requires PostgreSQL >= 14 for \getenv.
+        #
+        # Both commands must be fed through a single stdin stream, not two
+        # separate -c options: psql only performs :'var' interpolation when
+        # reading from stdin/a file, and a \getenv variable set in one -c is not
+        # available for interpolation in a following -c (it is sent verbatim,
+        # producing a `syntax error at or near ":"`).
+        #
+        # The interpolated ALTER USER contains the cleartext password, which
+        # would land in the PostgreSQL server log if the operator enabled
+        # statement logging (log_statement, log_min_duration_statement) or
+        # error-statement logging. Turn all three off for this session first
+        # (allowed since we connect as the postgres superuser) so the secret is
+        # never written to the log regardless of the server configuration.
         postStart = ''
           # A read-only standby cannot execute ALTER USER; the password is
           # replicated from the primary anyway.
@@ -312,9 +325,13 @@ in
             echo "DATABASE_PASS must be set in ${cfg.secretsFile} (services.teslamate.secretsFile)" >&2
             exit 1
           fi
-          psql -v ON_ERROR_STOP=1 -d postgres \
-            -c '\getenv password DATABASE_PASS' \
-            -c "ALTER USER \"${cfg.postgres.user}\" WITH ENCRYPTED PASSWORD :'password'"
+          printf '%s\n' \
+            "SET log_statement = 'none';" \
+            "SET log_min_duration_statement = -1;" \
+            "SET log_min_error_statement = 'panic';" \
+            '\getenv password DATABASE_PASS' \
+            "ALTER USER \"${cfg.postgres.user}\" WITH ENCRYPTED PASSWORD :'password'" \
+            | psql -v ON_ERROR_STOP=1 -d postgres
         '';
       };
     })


### PR DESCRIPTION
Replace the single `initialScript` with declarative `ensureDatabases` and `ensureUsers`, freeing the `services.postgresql.initialScript` option, which is single-valued and could not be combined with other modules that need it (e.g. to `CREATE EXTENSION`).

TeslaMate now connects to a local PostgreSQL via the unix socket using peer authentication, so no password is sent over TCP and startup no longer depends on the password being set first. The role password is still applied at runtime from DATABASE_PASS via `postStart` (kept out of the Nix store) because Grafana and the TCP fallback still require it.

Additionally read `RELEASE_COOKIE` without sourcing the env file 
Sourcing the environment file executed it as a shell script (arbitrary code execution if a secret contained $(...) or backticks) and broke on values containing quotes. Extract RELEASE_COOKIE literally with sed
instead and strip one optional surrounding pair of double quotes, so the value is handled safely whether or not it is quoted in the file.
This closes #4904