### PR TITLE
refactor: use frame key when specifying window to improve readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - sec(deps): fix OSV vulnerabilities - update cowlib, decimal, and phoenix to patched versions (#5332 - @brianmay)
 - ci: add osv scanner to scan for vulnerabilities (#5332 - @brianmay and @JakobLichterfeld)
 - build(deps): update flake.lock (#5338)
+- refactor: use frame key when specifying window to improve readability (#5339 - @swiffer)
 
 #### Dashboards
 

--- a/lib/teslamate/log.ex
+++ b/lib/teslamate/log.ex
@@ -274,8 +274,8 @@ defmodule TeslaMate.Log do
         },
         windows: [
           w: [
-            order_by:
-              fragment("? RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING", p.date)
+            order_by: p.date,
+            frame: fragment("RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING")
           ]
         ],
         where: p.drive_id == ^id,
@@ -291,8 +291,8 @@ defmodule TeslaMate.Log do
         },
         windows: [
           w: [
-            order_by:
-              fragment("? RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING", p.date)
+            order_by: p.date,
+            frame: fragment("RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING")
           ]
         ],
         where:
@@ -480,8 +480,8 @@ defmodule TeslaMate.Log do
         },
         windows: [
           w: [
-            order_by:
-              fragment("? RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING", c.date)
+            order_by: c.date,
+            frame: fragment("RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING")
           ]
         ],
         where: [charging_process_id: ^charging_process.id],


### PR DESCRIPTION
both work, but as a frame key exists let's use that for better readability?

https://hexdocs.pm/ecto/Ecto.Query.html#windows/3-frame