### PR TITLE
fix(nix): correct URL format for PostgreSQL connection in Grafana 13+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - build(deps): bump webpack-dev-server from 5.2.3 to 5.2.4 in /website (#5343)
 - sec(deps): add ws override to version 8.20.1 in /website (#5344 - @JakobLichterfeld)
 - feat(nix): update NixOS version to 26.05 (#5350 - @JakobLichterfeld)
+- fix(nix): correct URL format for PostgreSQL connection(#5351 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -294,7 +294,7 @@ in
             {
               name = "TeslaMate";
               type = "postgres";
-              url = "http://${cfg.postgres.host}:${toString cfg.postgres.port}";
+              url = "${cfg.postgres.host}:${toString cfg.postgres.port}";
               user = cfg.postgres.user;
               access = "proxy";
               basicAuth = false;


### PR DESCRIPTION
Update the PostgreSQL connection URL to remove the HTTP scheme, ensuring proper formatting for the connection string with Grafana 13 in NixOS 26.05.