### PR TITLE
fix(nix): make grafana.secretKeyFile optional with old insecure grafana default fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,8 @@
 - build(deps): bump webpack-dev-server from 5.2.3 to 5.2.4 in /website (#5343)
 - sec(deps): add ws override to version 8.20.1 in /website (#5344 - @JakobLichterfeld)
 - feat(nix): update NixOS version to 26.05 (#5350 - @JakobLichterfeld)
-- fix(nix): correct URL format for PostgreSQL connection(#5351 - @JakobLichterfeld)
+- fix(nix): correct URL format for PostgreSQL connection in Grafana 13+ (#5351 - @JakobLichterfeld)
+- fix(nix): make grafana.secretKeyFile optional with old insecure grafana default fallback (#5352 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -147,7 +147,7 @@ in
       secretKeyFile = lib.mkOption {
         type = lib.types.path;
         description = "File with the Grafana secret_key for signing data source settings like secrets and passwords";
-        default = "/run/secrets/grafanaSecretKeyFile.env"; # default as otherwise nix flake check fails as it is accessed with $__file
+        default = /dev/null; # default as otherwise nix flake check fails as it is accessed with $__file
       };
     };
 
@@ -260,6 +260,8 @@ in
       };
     })
     (mkIf cfg.grafana.enable {
+      warnings = lib.optional (cfg.grafana.secretKeyFile == /dev/null)
+        "teslamate: grafana.secretKeyFile is not set. Using the insecure default secret_key. Set grafana.secretKeyFile to a file containing a secure random key.";
       services.grafana = {
         enable = true;
         settings = {
@@ -273,7 +275,10 @@ in
           security = {
             allow_embedding = true;
             disable_gravatar = true;
-            secret_key = "$__file{${cfg.grafana.secretKeyFile}}";
+            secret_key =
+              if cfg.grafana.secretKeyFile == /dev/null
+              then "SW2YcwTIb9zpOOhoPsMm" # old default value, see https://github.com/grafana/grafana/blob/0920e8bcc69f555a34462d0d2029a882272a0184/conf/defaults.ini#L334
+              else "$__file{${cfg.grafana.secretKeyFile}}";
           };
           users = {
             allow_sign_up = false;


### PR DESCRIPTION
Add a warning when secretKeyFile is not set to inform users that the insecure grafana built-in default key is being used. This avoids a breaking change for existing installations while encouraging users to set a secure key.