### PR TITLE
docs: remove references to mcu2-upgraded-cars branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 #### Documentation
 
 - docs: drop private schema before restore (#5190 - @brianmay)
+- docs: remove references to mcu2-upgraded-cars branch (#5371- @brianmay)
 
 ## [3.0.0] - 2026-02-28
 

--- a/website/docs/installation/docker.md
+++ b/website/docs/installation/docker.md
@@ -87,10 +87,6 @@ Alternatively, you can use a reverse proxy (such as Traefik, Apache2 or Caddy) w
    docker compose up -d
    ```
 
-### MCU2 upgraded car
-
-If you have a MCU2 upgraded car, you can replace `image: teslamate/teslamate:latest` with `image: ghcr.io/teslamate-org/teslamate:pr-4453` to get the latest version of TeslaMate that supports MCU2 upgraded cars (improved sleeping behavior for MCU2 upgraded cars).
-
 ## Usage
 
 1. Open the web interface [http://your-ip-address:4000](http://localhost:4000)

--- a/website/docs/installation/nixos.md
+++ b/website/docs/installation/nixos.md
@@ -35,12 +35,6 @@ If you would like to pin to a specific version, you can do so for example like t
 teslamate.url = "github:teslamate-org/teslamate?rev=c37638b320e0beea97c5d51fea51cd9fdbd07ce0"; # v2.0.0
 ```
 
-If you have a MCU2 upgraded car, you can use the following URL instead to get the latest version of TeslaMate that supports MCU2 upgraded cars (improved sleeping behavior for MCU2 upgraded cars):
-
-```nix
-teslamate.url = "github:teslamate-org/teslamate/mcu2-upgraded-cars";
-```
-
 To enable the TeslaMate service, your config could look like this (note: this will conflict with any existing PostgreSQL/Grafana servers, because NixOS modules do not support multiple instances).
 
 ```nix


### PR DESCRIPTION
Since this branch was merged we no longer require
references to it in the documentation.