### PR TITLE
fix: restore vehicle_unavailable fallback for streaming fetches to prevent unwanted vehicle online state

### DIFF
--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1507,7 +1507,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
           end
 
         if allow_vehicle_data? do
-          call(deps.api, :get_vehicle_with_state, [car.eid])
+          fetch_with_reachable_assumption(car.eid, deps)
         else
           call(deps.api, :get_vehicle, [car.eid])
         end

--- a/test/support/mocks/api.ex
+++ b/test/support/mocks/api.ex
@@ -32,12 +32,12 @@ defmodule ApiMock do
   @impl true
   def handle_call({action, _id}, _from, %State{events: [event | []]} = state)
       when action in [:get_vehicle, :get_vehicle_with_state] do
-    {:reply, exec(event), state}
+    {:reply, exec(event, action), state}
   end
 
   def handle_call({action, _id}, _from, %State{events: [event | events]} = state)
       when action in [:get_vehicle, :get_vehicle_with_state] do
-    {:reply, exec(event), %State{state | events: events}}
+    {:reply, exec(event, action), %State{state | events: events}}
   end
 
   def handle_call({:sign_in, _tokens} = event, _from, %State{pid: pid} = state) do
@@ -50,6 +50,17 @@ defmodule ApiMock do
     {:reply, {:ok, pid}, state}
   end
 
-  defp exec(event) when is_function(event), do: event.()
-  defp exec(event), do: event
+  # Events tagged with :get_vehicle or :get_vehicle_with_state may only be
+  # consumed by that API call, allowing tests to pin which endpoint was used.
+  defp exec({expected_action, event}, action)
+       when expected_action in [:get_vehicle, :get_vehicle_with_state] do
+    if expected_action != action do
+      raise "expected #{inspect(expected_action)} to be called, but got #{inspect(action)}"
+    end
+
+    exec(event, action)
+  end
+
+  defp exec(event, _action) when is_function(event), do: event.()
+  defp exec(event, _action), do: event
 end

--- a/test/teslamate/vehicles/vehicle_test.exs
+++ b/test/teslamate/vehicles/vehicle_test.exs
@@ -241,6 +241,32 @@ defmodule TeslaMate.Vehicles.VehicleTest do
     end
 
     @tag :capture_log
+    test "falls back to vehicle state when vehicle data is unavailable while streaming", %{
+      test: name
+    } do
+      now_ts = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+
+      events = [
+        {:ok, online_event(now_ts)},
+        {:error, :vehicle_unavailable},
+        {:ok, %TeslaApi.Vehicle{state: "asleep"}}
+      ]
+
+      :ok = start_vehicle(name, events)
+
+      assert_receive {:start_state, car, :online, date: _}
+      assert_receive {ApiMock, {:stream, 1000, _}}
+      assert_receive {:insert_position, ^car, %{}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
+
+      assert_receive {:start_state, ^car, :asleep, []}
+      assert_receive {:"$websockex_cast", :disconnect}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :asleep}}}
+
+      refute_receive _
+    end
+
+    @tag :capture_log
     test "handles timeout errors", %{test: name} do
       now_ts = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
 

--- a/test/teslamate/vehicles/vehicle_test.exs
+++ b/test/teslamate/vehicles/vehicle_test.exs
@@ -249,7 +249,7 @@ defmodule TeslaMate.Vehicles.VehicleTest do
       events = [
         {:ok, online_event(now_ts)},
         {:error, :vehicle_unavailable},
-        {:ok, %TeslaApi.Vehicle{state: "asleep"}}
+        {:get_vehicle, {:ok, %TeslaApi.Vehicle{state: "asleep"}}}
       ]
 
       :ok = start_vehicle(name, events)


### PR DESCRIPTION
## Summary

This restores the existing `fetch_with_reachable_assumption/2` fallback for `use_streaming_api: true` fetches when vehicle data is allowed.

Before v3.1.0, reachable states used `fetch_with_reachable_assumption/2`, so `get_vehicle_with_state` returning `:vehicle_unavailable` would fall back to `get_vehicle`. After the MCU2/fake-online streaming changes, the streaming branch calls `get_vehicle_with_state` directly and no longer falls back.

This can leave a vehicle stuck in `:online` while `/vehicle_data` keeps returning 408, even though the lightweight vehicle endpoint reports `asleep` or `offline`.

## Change

Use `fetch_with_reachable_assumption/2` in the streaming branch whenever `allow_vehicle_data?` is true.

## Test

Added a regression test covering:

`online -> vehicle_data unavailable -> lightweight vehicle state asleep -> state transitions to asleep`