### PR TITLE
fix: properly clean up state and delete tokens on sign out

### DIFF
--- a/lib/teslamate/api.ex
+++ b/lib/teslamate/api.ex
@@ -81,10 +81,10 @@ defmodule TeslaMate.Api do
   end
 
   def sign_out(name \\ @name) do
-    true = :ets.delete(name, :auth)
-    :ok
-  rescue
-    _ in ArgumentError -> {:error, :not_signed_in}
+    case fetch_auth(name) do
+      {:error, :not_signed_in} -> {:error, :not_signed_in}
+      {:ok, %Auth{}} -> GenServer.call(name, :sign_out, @timeout)
+    end
   end
 
   # Callbacks
@@ -171,6 +171,14 @@ defmodule TeslaMate.Api do
       {:error, %TeslaApi.Error{} = e} ->
         {:reply, {:error, e}, state}
     end
+  end
+
+  def handle_call(:sign_out, _from, %State{name: name} = state) do
+    :ets.delete(name, :auth)
+    if is_reference(state.refresh_timer), do: Process.cancel_timer(state.refresh_timer)
+    :ok = call(state.deps.auth, :delete_tokens)
+    :ok = call(state.deps.vehicles, :restart)
+    {:reply, :ok, %State{state | refresh_timer: nil}}
   end
 
   @impl true

--- a/lib/teslamate/auth.ex
+++ b/lib/teslamate/auth.ex
@@ -57,6 +57,11 @@ defmodule TeslaMate.Auth do
     end
   end
 
+  def delete_tokens do
+    Repo.delete_all(Tokens)
+    :ok
+  end
+
   defp create_tokens(attrs) do
     %Tokens{}
     |> Tokens.changeset(attrs)

--- a/test/support/mocks/auth.ex
+++ b/test/support/mocks/auth.ex
@@ -12,6 +12,7 @@ defmodule AuthMock do
 
   def get_tokens(name), do: GenServer.call(name, :get_tokens)
   def save(name, auth), do: GenServer.call(name, {:save, auth})
+  def delete_tokens(name), do: GenServer.call(name, :delete_tokens)
 
   # Callbacks
 
@@ -32,5 +33,10 @@ defmodule AuthMock do
   def handle_call({:save, _auth} = event, _from, %State{pid: pid} = state) do
     send(pid, {AuthMock, event})
     {:reply, :ok, state}
+  end
+
+  def handle_call(:delete_tokens = event, _from, %State{pid: pid} = state) do
+    send(pid, {AuthMock, event})
+    {:reply, :ok, %State{state | tokens: nil}}
   end
 end

--- a/test/teslamate/api_test.exs
+++ b/test/teslamate/api_test.exs
@@ -165,6 +165,37 @@ defmodule TeslaMate.ApiTest do
     end
   end
 
+  describe "sign out" do
+    test "deletes the tokens and restarts the vehicles", %{test: name} do
+      with_mocks [auth_mock(self()), vehicle_mock(self())] do
+        :ok = start_api(name, tokens: @valid_tokens)
+
+        assert_receive {TeslaApi.Auth, {:refresh, %TeslaApi.Auth{}}}
+        assert_receive {AuthMock, {:save, %TeslaApi.Auth{}}}
+        assert true == Api.signed_in?(name)
+
+        assert :ok = Api.sign_out(name)
+
+        assert_receive {AuthMock, :delete_tokens}
+        assert_receive {VehiclesMock, :restart}
+        assert false == Api.signed_in?(name)
+
+        refute_receive _
+      end
+    end
+
+    test "fails if not signed in", %{test: name} do
+      with_mocks [auth_mock(self()), vehicle_mock(self())] do
+        :ok = start_api(name, tokens: nil)
+
+        assert false == Api.signed_in?(name)
+        assert {:error, :not_signed_in} = Api.sign_out(name)
+
+        refute_receive _
+      end
+    end
+  end
+
   describe "refresh" do
     test "refreshes tokens", %{test: name} do
       with_mocks [auth_mock(self()), vehicle_mock(self())] do

--- a/test/teslamate/auth_test.exs
+++ b/test/teslamate/auth_test.exs
@@ -36,5 +36,19 @@ defmodule TeslaMate.AuthTest do
       assert %{refresh: ["can't be blank"], access: ["can't be blank"]} ==
                errors_on(changeset)
     end
+
+    test "delete_tokens/0 removes the stored tokens" do
+      assert :ok = Auth.save(@valid_attrs)
+      assert Auth.get_tokens()
+
+      assert :ok = Auth.delete_tokens()
+      assert Auth.get_tokens() == nil
+    end
+
+    test "delete_tokens/0 is a no-op when there are no tokens" do
+      assert Auth.get_tokens() == nil
+      assert :ok = Auth.delete_tokens()
+      assert Auth.get_tokens() == nil
+    end
   end
 end


### PR DESCRIPTION
When you sign out via the Settings page, the Tesla API tokens are only removed from the in-memory cache (ETS), but they remain stored in the private.tokens database table. As a result, if your application restarts the tokens are read back from the DB, refreshed, and vehicle logging resumes automatically (effectively logging you back in even though you explicitly signed out).

**To reproduce**
Sign in with your Tesla account.
Confirm a token pair exists: SELECT count(*) FROM private.tokens; → returns 1.
Go to Settings and click Sign out.
Check again: SELECT count(*) FROM private.tokens; → still returns 1 ❌.
Restart TeslaMate.
The app boots already signed in and resumes recording, instead of showing the sign-in screen.

**Expected behavior**
After signing out, the tokens should be removed from the database (and recording should stop). A restart should land on the sign-in screen, with no recording resuming.

**Root cause**
TeslaMate.Api.sign_out/1 only calls :ets.delete(name, :auth) and it never touches the database.
TeslaMate.Auth has no token-deletion function (get and save only).
On boot, TeslaMate.Api.init/1 restores the tokens from private.tokens, refreshes them, and restarts the vehicle loggers.