### PR TITLE
ci: sign published images with SLSA provenance + SBOM attestations

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -68,11 +68,62 @@ runs:
         platforms: ${{ matrix.platform }}
         labels: ${{ steps.meta.outputs.labels }}
         tags: ${{ steps.docker_meta.outputs.tags }}
+        # Disable BuildKit-side attestations so outputs.digest is the bare image
+        # manifest digest. With provenance enabled, BuildKit wraps the image in
+        # an OCI index whose digest does NOT appear in the multi-arch manifest
+        # list produced by `imagetools create`, which would make tag-based
+        # attestation verification fail. Signed SLSA provenance is added by
+        # actions/attest-build-provenance below.
+        provenance: false
+        sbom: false
         cache-from: |
           type=registry,ref=ghcr.io/${{ inputs.repository }}:buildcache-${{ matrix.cache_id }}-${{ steps.normalize_version.outputs.normalized_version }}
           type=registry,ref=ghcr.io/${{ inputs.repository }}:buildcache-${{ matrix.cache_id }}-main
         cache-to: type=registry,ref=ghcr.io/${{ inputs.repository }}:buildcache-${{ matrix.cache_id }}-${{ steps.normalize_version.outputs.normalized_version }},mode=max
         outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+    - name: Generate SBOM for pushed image
+      # Skip on pull_request: PR builds are unreviewed code. Attesting them
+      # would yield signed attestations that pass `gh attestation verify
+      # --repo teslamate-org/teslamate`, which consumers read as "official".
+      if: github.event_name != 'pull_request'
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        image: ${{ env.REGISTRY_IMAGE }}@${{ steps.build.outputs.digest }}
+        format: spdx-json
+        output-file: /tmp/sbom-${{ matrix.cache_id }}.spdx.json
+        upload-artifact: false
+        upload-release-assets: false
+    - name: Resolve attestation subject name
+      # attest-* reads the registry from subject-name's first path segment, so a
+      # bare "teslamate/teslamate" fails. Qualify short names with docker.io;
+      # leave already-qualified names (ghcr.io/...) so REGISTRY_IMAGE stays repointable.
+      id: subject
+      if: github.event_name != 'pull_request'
+      shell: bash
+      env:
+        IMAGE: ${{ env.REGISTRY_IMAGE }}
+      run: |
+        case "${IMAGE%%/*}" in
+          *.* | *:* | localhost) name="$IMAGE" ;;
+          *) name="docker.io/$IMAGE" ;;
+        esac
+        echo "name=$name" >> "$GITHUB_OUTPUT"
+    - name: Attest build provenance
+      if: github.event_name != 'pull_request'
+      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      with:
+        subject-name: ${{ steps.subject.outputs.name }}
+        subject-digest: ${{ steps.build.outputs.digest }}
+        push-to-registry: true
+    - name: Attest SBOM
+      if: github.event_name != 'pull_request'
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+      with:
+        subject-name: ${{ steps.subject.outputs.name }}
+        subject-digest: ${{ steps.build.outputs.digest }}
+        predicate-type: "https://spdx.dev/Document"
+        predicate-path: /tmp/sbom-${{ matrix.cache_id }}.spdx.json
+        push-to-registry: true
     - name: Export digest
       shell: bash
       run: |

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -93,33 +93,26 @@ runs:
         output-file: /tmp/sbom-${{ matrix.cache_id }}.spdx.json
         upload-artifact: false
         upload-release-assets: false
-    - name: Resolve attestation subject name
-      # attest-* reads the registry from subject-name's first path segment, so a
-      # bare "teslamate/teslamate" fails. Qualify short names with docker.io;
-      # leave already-qualified names (ghcr.io/...) so REGISTRY_IMAGE stays repointable.
-      id: subject
-      if: github.event_name != 'pull_request'
-      shell: bash
-      env:
-        IMAGE: ${{ env.REGISTRY_IMAGE }}
-      run: |
-        case "${IMAGE%%/*}" in
-          *.* | *:* | localhost) name="$IMAGE" ;;
-          *) name="docker.io/$IMAGE" ;;
-        esac
-        echo "name=$name" >> "$GITHUB_OUTPUT"
     - name: Attest build provenance
       if: github.event_name != 'pull_request'
       uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
       with:
-        subject-name: ${{ steps.subject.outputs.name }}
+        # attest-* reads the registry from the first path segment of subject-name,
+        # so qualify Docker Hub short names with docker.io; leave ghcr.io as-is.
+        subject-name: >-
+          ${{ startsWith(env.REGISTRY_IMAGE, 'ghcr.io/')
+              && env.REGISTRY_IMAGE
+              || format('docker.io/{0}', env.REGISTRY_IMAGE) }}
         subject-digest: ${{ steps.build.outputs.digest }}
         push-to-registry: true
     - name: Attest SBOM
       if: github.event_name != 'pull_request'
       uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
       with:
-        subject-name: ${{ steps.subject.outputs.name }}
+        subject-name: >-
+          ${{ startsWith(env.REGISTRY_IMAGE, 'ghcr.io/')
+              && env.REGISTRY_IMAGE
+              || format('docker.io/{0}', env.REGISTRY_IMAGE) }}
         subject-digest: ${{ steps.build.outputs.digest }}
         predicate-type: "https://spdx.dev/Document"
         predicate-path: /tmp/sbom-${{ matrix.cache_id }}.spdx.json

--- a/.github/actions/grafana/action.yml
+++ b/.github/actions/grafana/action.yml
@@ -41,20 +41,6 @@ runs:
         sbom: false
         cache-from: type=gha
         cache-to: type=gha,mode=max
-    - name: Resolve attestation subject name
-      # See build action: qualify Docker Hub short names with docker.io so
-      # actions/attest-* can find the registry, without pinning the image input.
-      id: subject
-      if: github.event_name != 'pull_request'
-      shell: bash
-      env:
-        IMAGE: ${{ inputs.image }}
-      run: |
-        case "${IMAGE%%/*}" in
-          *.* | *:* | localhost) name="$IMAGE" ;;
-          *) name="docker.io/$IMAGE" ;;
-        esac
-        echo "name=$name" >> "$GITHUB_OUTPUT"
     - name: Attest grafana provenance
       # grafana is a single multi-arch build, so steps.build.outputs.digest is
       # the manifest-list digest that `gh attestation verify oci://...:tag`
@@ -62,6 +48,10 @@ runs:
       if: github.event_name != 'pull_request'
       uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
       with:
-        subject-name: ${{ steps.subject.outputs.name }}
+        # See build action: qualify Docker Hub short names with docker.io.
+        subject-name: >-
+          ${{ startsWith(inputs.image, 'ghcr.io/')
+              && inputs.image
+              || format('docker.io/{0}', inputs.image) }}
         subject-digest: ${{ steps.build.outputs.digest }}
         push-to-registry: true

--- a/.github/actions/grafana/action.yml
+++ b/.github/actions/grafana/action.yml
@@ -27,11 +27,41 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
     - name: Build and push
+      id: build
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: grafana
         push: true
         platforms: linux/amd64,linux/arm/v7,linux/arm64
         tags: ${{ steps.docker_meta.outputs.tags }}
+        # See build action for why BuildKit-side attestations are disabled:
+        # we want outputs.digest to be the multi-arch manifest list digest so
+        # that signed attestations land where `gh attestation verify` looks.
+        provenance: false
+        sbom: false
         cache-from: type=gha
         cache-to: type=gha,mode=max
+    - name: Resolve attestation subject name
+      # See build action: qualify Docker Hub short names with docker.io so
+      # actions/attest-* can find the registry, without pinning the image input.
+      id: subject
+      if: github.event_name != 'pull_request'
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+      run: |
+        case "${IMAGE%%/*}" in
+          *.* | *:* | localhost) name="$IMAGE" ;;
+          *) name="docker.io/$IMAGE" ;;
+        esac
+        echo "name=$name" >> "$GITHUB_OUTPUT"
+    - name: Attest grafana provenance
+      # grafana is a single multi-arch build, so steps.build.outputs.digest is
+      # the manifest-list digest that `gh attestation verify oci://...:tag`
+      # resolves to. Skip on pull_request: see build action for the rationale.
+      if: github.event_name != 'pull_request'
+      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      with:
+        subject-name: ${{ steps.subject.outputs.name }}
+        subject-digest: ${{ steps.build.outputs.digest }}
+        push-to-registry: true

--- a/.github/actions/merge/action.yml
+++ b/.github/actions/merge/action.yml
@@ -49,26 +49,16 @@ runs:
         DIGEST="$(docker buildx imagetools inspect "$TAG" --format '{{json .Manifest}}' | jq -r .digest)"
         echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
         echo "manifest list digest: ${DIGEST}"
-    - name: Resolve attestation subject name
-      # See build action: qualify Docker Hub short names with docker.io so
-      # actions/attest-* can find the registry, without pinning REGISTRY_IMAGE.
-      id: subject
-      if: github.event_name != 'pull_request'
-      shell: bash
-      env:
-        IMAGE: ${{ env.REGISTRY_IMAGE }}
-      run: |
-        case "${IMAGE%%/*}" in
-          *.* | *:* | localhost) name="$IMAGE" ;;
-          *) name="docker.io/$IMAGE" ;;
-        esac
-        echo "name=$name" >> "$GITHUB_OUTPUT"
     - name: Attest manifest provenance
       # Skip on pull_request: see build action for the rationale.
       if: github.event_name != 'pull_request'
       uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
       with:
-        subject-name: ${{ steps.subject.outputs.name }}
+        # See build action: qualify Docker Hub short names with docker.io.
+        subject-name: >-
+          ${{ startsWith(env.REGISTRY_IMAGE, 'ghcr.io/')
+              && env.REGISTRY_IMAGE
+              || format('docker.io/{0}', env.REGISTRY_IMAGE) }}
         subject-digest: ${{ steps.manifest.outputs.digest }}
         push-to-registry: true
     - name: Inspect image

--- a/.github/actions/merge/action.yml
+++ b/.github/actions/merge/action.yml
@@ -40,6 +40,37 @@ runs:
       run: |
         docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
           $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+    - name: Capture manifest digest
+      id: manifest
+      shell: bash
+      env:
+        TAG: ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+      run: |
+        DIGEST="$(docker buildx imagetools inspect "$TAG" --format '{{json .Manifest}}' | jq -r .digest)"
+        echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+        echo "manifest list digest: ${DIGEST}"
+    - name: Resolve attestation subject name
+      # See build action: qualify Docker Hub short names with docker.io so
+      # actions/attest-* can find the registry, without pinning REGISTRY_IMAGE.
+      id: subject
+      if: github.event_name != 'pull_request'
+      shell: bash
+      env:
+        IMAGE: ${{ env.REGISTRY_IMAGE }}
+      run: |
+        case "${IMAGE%%/*}" in
+          *.* | *:* | localhost) name="$IMAGE" ;;
+          *) name="docker.io/$IMAGE" ;;
+        esac
+        echo "name=$name" >> "$GITHUB_OUTPUT"
+    - name: Attest manifest provenance
+      # Skip on pull_request: see build action for the rationale.
+      if: github.event_name != 'pull_request'
+      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      with:
+        subject-name: ${{ steps.subject.outputs.name }}
+        subject-digest: ${{ steps.manifest.outputs.digest }}
+        push-to-registry: true
     - name: Inspect image
       shell: bash
       run: |

--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -19,6 +19,8 @@ env:
 permissions:
   contents: read
   packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   check_paths:

--- a/.github/workflows/ghcr_build.yml
+++ b/.github/workflows/ghcr_build.yml
@@ -22,6 +22,8 @@ env:
 permissions:
   contents: read
   packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   check_paths:

--- a/website/docs/advanced_guides/verifying_images.md
+++ b/website/docs/advanced_guides/verifying_images.md
@@ -1,0 +1,44 @@
+---
+title: Verifying published container images
+sidebar_label: Verifying images
+---
+
+All TeslaMate images published to Docker Hub (`teslamate/teslamate`,
+`teslamate/grafana`) and GitHub Container Registry
+(`ghcr.io/teslamate-org/teslamate`, `ghcr.io/teslamate-org/teslamate/grafana`)
+carry signed **SLSA build provenance**, generated keylessly via Sigstore using
+the `teslamate-org/teslamate` GitHub Actions OIDC identity. The provenance
+proves an image was built by that workflow, from a specific commit, with no
+shared keys to manage.
+
+`teslamate/teslamate` additionally carries an **SPDX SBOM** (software bill of
+materials) attached to each per-platform image digest. `teslamate/grafana` is
+built as a single multi-arch image and carries provenance only.
+
+## Verify with `gh`
+
+```sh
+gh attestation verify \
+  oci://docker.io/teslamate/teslamate:latest \
+  --repo teslamate-org/teslamate
+```
+
+Use `oci://ghcr.io/teslamate-org/teslamate:latest` for the GHCR image, and the
+`grafana` variants similarly. The `gh` CLI resolves the tag to the multi-arch
+manifest digest and verifies the provenance attached to it.
+
+## Verifying per-platform SBOMs
+
+SBOMs for `teslamate/teslamate` are attached to each per-platform image digest
+(their natural scope — filesystem contents differ per architecture). To inspect,
+resolve the platform digest first:
+
+```sh
+docker buildx imagetools inspect docker.io/teslamate/teslamate:latest \
+  --format '{{ range .Manifest.Manifests }}{{ .Platform.Architecture }} {{ .Digest }}{{ "\n" }}{{ end }}'
+
+gh attestation verify \
+  oci://docker.io/teslamate/teslamate@sha256:<platform-digest> \
+  --repo teslamate-org/teslamate \
+  --predicate-type https://spdx.dev/Document
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -33,6 +33,7 @@ module.exports = {
         "advanced_guides/traefik",
         "advanced_guides/apache",
         "advanced_guides/unix_domain_sockets",
+        "advanced_guides/verifying_images",
       ],
     },
     {


### PR DESCRIPTION
Publishes signed SLSA build provenance for every TeslaMate image (Docker Hub + GHCR), plus SPDX SBOMs for teslamate/teslamate, generated keylessly via Sigstore using the workflow's GitHub OIDC identity.

Consumers can prove an image was built by this repo's CI from a specific commit, with no shared keys to manage:

```sh
gh attestation verify oci://teslamate/teslamate:latest --repo teslamate-org/teslamate
```

## What's attested

- teslamate/teslamate (Docker Hub + GHCR): SLSA provenance on the manifest-list and per-platform digests, plus an SPDX SBOM attached to each per-platform digest.
- teslamate/grafana (Docker Hub + GHCR): SLSA provenance (built as a single multi-arch image).
- Attestations are skipped on pull_request builds, so unmerged code can't produce a signed image that verifies against teslamate-org/teslamate and reads as official.

## How

- Uses actions/attest-build-provenance and actions/attest (SPDX), pushed to the registry as referrers; SBOMs generated by anchore/sbom-action (syft).
- Disables BuildKit-side attestations (provenance and sbom off) so the build digest is the plain image digest that appears in the multi-arch manifest list. BuildKit's own provenance wraps the image in an OCI index whose digest tag-based verification would miss.
- Requires id-token: write and attestations: write.
- REGISTRY_IMAGE stays repointable; the attestation subject-name is qualified with docker.io only when unqualified, so building test images on another registry is unaffected.

## Docs

Verification how-to lives in the docs site (website/docs/advanced_guides/verifying_images.md)

## Tested

Validated end-to-end on a fork: provenance and per-platform SBOMs for teslamate/teslamate verify with gh attestation verify, the per-platform SBOMs are confirmed arch-specific, and a pull_request build was confirmed to produce no attestation.
