### PR TITLE
fix: force HTTP/2 for Tesla auth token refresh requests

### DIFF
--- a/lib/teslamate/http.ex
+++ b/lib/teslamate/http.ex
@@ -13,6 +13,9 @@ defmodule TeslaMate.HTTP do
       System.get_env("TESLA_API_HOST", "https://owner-api.teslamotors.com") => [
         size: System.get_env("TESLA_API_POOL_SIZE", "10") |> String.to_integer()
       ],
+      System.get_env("TESLA_AUTH_HOST", "https://auth.tesla.com") => [
+        conn_opts: [protocols: [:http2]]
+      ],
       "https://nominatim.openstreetmap.org" => [size: 3] ++ nominatim_proxy,
       "https://api.github.com" => [size: 1],
       :default => [size: System.get_env("HTTP_POOL_SIZE", "5") |> String.to_integer()]


### PR DESCRIPTION
Refreshing tokens via auth.tesla.com over HTTP/1.1 causes Tesla to issue access tokens scoped to the Fleet API only, which then get a 403 "forbidden, see fleet-api" on legacy Owner API endpoints. Forcing HTTP/2 for the auth host avoids this downgrade.