### PR TITLE
fix: bump builder image to Elixir 1.19.4 / OTP 28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.19.5-otp-26 AS builder
+FROM elixir:1.19.4-otp-28 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
OTP 26's TLS stack causes auth.tesla.com to issue Fleet-API-scoped access tokens on refresh, which owner-api.teslamotors.com rejects with 403 "forbidden, see https://developer.tesla.com/docs/fleet-api". Bumping to OTP 28 results in Owner-API-scoped tokens as before.