### PR TITLE
Bump Tesla Auth API to TLS v1.3 to ensure tokens are valid for owner API

### DIFF
--- a/lib/teslamate/http.ex
+++ b/lib/teslamate/http.ex
@@ -13,6 +13,13 @@ defmodule TeslaMate.HTTP do
       System.get_env("TESLA_API_HOST", "https://owner-api.teslamotors.com") => [
         size: System.get_env("TESLA_API_POOL_SIZE", "10") |> String.to_integer()
       ],
+      System.get_env("TESLA_AUTH_HOST", "https://auth.tesla.com") => [
+        conn_opts: [
+          transport_opts: [
+            versions: [:"tlsv1.3"]
+          ]
+        ]
+      ],
       "https://nominatim.openstreetmap.org" => [size: 3] ++ nominatim_proxy,
       "https://api.github.com" => [size: 1],
       :default => [size: System.get_env("HTTP_POOL_SIZE", "5") |> String.to_integer()]


### PR DESCRIPTION
Fixes https://github.com/teslamate-org/teslamate/issues/5384

Alternative to https://github.com/teslamate-org/teslamate/pull/5389 that doesn't require bumping the base image which has [armv7 implications](https://github.com/teslamate-org/teslamate/pull/5389#issuecomment-4698050986)