### PR TITLE
build: use Elixir 1.19.5 OTP 28 and drop ARMv7 support as announced

### DIFF
--- a/.github/actions/setup-elixir-and-cache-deps/action.yml
+++ b/.github/actions/setup-elixir-and-cache-deps/action.yml
@@ -8,7 +8,7 @@ inputs:
   otp-version:
     description: "OTP version"
     required: false
-    default: "26"
+    default: "28"
   cache-name-deps:
     description: "Cache name for dependencies"
     required: true

--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -34,9 +34,6 @@ jobs:
           - platform: "linux/amd64"
             runs_on: "ubuntu-24.04"
             cache_id: amd64
-          - platform: "linux/arm/v7"
-            runs_on: "ubuntu-24.04-arm"
-            cache_id: arm
           - platform: "linux/arm64"
             runs_on: "ubuntu-24.04-arm"
             cache_id: arm64

--- a/.github/workflows/ghcr_build.yml
+++ b/.github/workflows/ghcr_build.yml
@@ -45,9 +45,6 @@ jobs:
           - platform: "linux/amd64"
             runs_on: "ubuntu-24.04"
             cache_id: amd64
-          - platform: "linux/arm/v7"
-            runs_on: "ubuntu-24.04-arm"
-            cache_id: arm
           - platform: "linux/arm64"
             runs_on: "ubuntu-24.04-arm"
             cache_id: arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 #### Build, CI, internal
 
-- build: use Elixir 1.19.5 OTP 28
+- build: use Elixir 1.19.5 OTP 28 (#5391 - @NirKli and @JakobLichterfeld)
+- build: drop ARMv7 support as announced in Changelog of v3.1.0 (#5391 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 #### Build, CI, internal
 
+- build: use Elixir 1.19.5 OTP 28
+
 #### Dashboards
 
 #### Translations

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.19.5-otp-26 AS builder
+FROM elixir:1.19.5-otp-28 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,4 +1,4 @@
-# Ensure selecting a tag that is available for arm/v7, arm64, and amd64
+# Ensure selecting a tag that is available for arm64 and amd64
 # https://hub.docker.com/r/grafana/grafana/tags
 FROM grafana/grafana:13.0.1-security-01
 

--- a/nix/flake-modules/package.nix
+++ b/nix/flake-modules/package.nix
@@ -7,8 +7,8 @@
     , ...
     }:
     let
-      elixir = pkgs.beam.packages.erlang_27.elixir_1_19;
-      beamPackages = pkgs.beam.packagesWith pkgs.beam.interpreters.erlang_27;
+      beamPackages = pkgs.beam.packagesWith pkgs.beam.interpreters.erlang_28;
+      elixir = beamPackages.elixir_1_19;
 
       src = ../..;
       version = builtins.readFile "${src}/VERSION";

--- a/website/docs/development.mdx
+++ b/website/docs/development.mdx
@@ -9,7 +9,7 @@ sidebar_label: Development and Contributing
 TeslaMate officially supports the versions listed below. However, TeslaMate aims to maintain compatibility with the last three major releases of Erlang and Postgres, as well as the last three minor releases of Elixir.
 When contributing, please use the versions listed below, which match those used in official TeslaMate distributions.
 
-- **Elixir** >= 1.19.5-otp-26
+- **Elixir** >= 1.19.5-otp-28
 - **Postgres** >= 18.0
 - **Grafana** = 12.4.0
 - An **MQTT broker** e.g. mosquitto (_optional_)


### PR DESCRIPTION
successor of #5389

fixes: #5384
closes: #5304