### PR TITLE
Minor docs & code changes after bumping to OTP 28

### DIFF
--- a/.github/workflows/ghcr_purge.yml
+++ b/.github/workflows/ghcr_purge.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           packages: "teslamate"
           token: ${{ secrets.GITHUB_TOKEN }}
-          delete-tags: "buildcache-arm-${{ steps.normalize_version.outputs.normalized_version }},buildcache-arm64-${{ steps.normalize_version.outputs.normalized_version }},buildcache-amd64-${{ steps.normalize_version.outputs.normalized_version }}"
+          delete-tags: "buildcache-arm64-${{ steps.normalize_version.outputs.normalized_version }},buildcache-amd64-${{ steps.normalize_version.outputs.normalized_version }}"
 
       - uses: dataaxiom/ghcr-cleanup-action@f092b48ba3b604b2a83690dc4b2bbb3392e1045f # v1.2.1
         name: Delete untagged images from ghcr.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,22 @@
 ### Improvements and bug fixes
 
 - fix: enable HTTP/2 and set TLS to 1.3 for TESLA_AUTH_HOST (#5406 - @kenc420 and @longzheng)
+- feat: log Erlang and OTP version (#5397 - @swiffer)
 
 #### Build, CI, internal
+
+- ci: remove now obsolete ARMv7 buildcache (#5397 - @swiffer)
+- build: remove now unused zstd compression tool to reduce docker image size (#5397 - @swiffer)
 
 #### Dashboards
 
 #### Translations
 
 #### Documentation
+
+- docs: clarify Grafana and Erlang requirements (#5397 - @swiffer)
+- docs: clarify which docker images are provided and what to do if the user have a Raspberry Pi with ARMv7 OS (#5397 - @swiffer)
+- docs: clarify Erlang and OTP support in contributing guide (#5397 - @swiffer)
 
 ## [4.0.0] - 2026-06-13
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM elixir:1.19.5-otp-28 AS builder
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
-    && apt-get install -y ca-certificates curl gnupg zstd brotli \
+    && apt-get install -y ca-certificates curl gnupg brotli \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
      | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \

--- a/lib/teslamate/application.ex
+++ b/lib/teslamate/application.ex
@@ -4,7 +4,7 @@ defmodule TeslaMate.Application do
   require Logger
 
   def start(_type, _args) do
-    Logger.info("System Info: #{system_info()}")
+    Logger.info("System Info: Erlang/OTP #{otp_release()} (#{emu_flavor()})")
     Logger.info("Version: #{Application.spec(:teslamate, :vsn) || "???"}")
 
     # Disable log entries
@@ -49,13 +49,6 @@ defmodule TeslaMate.Application do
           {TeslaMate.Repair, limit: 250},
           {TeslaMate.Import, directory: import_directory}
         ]
-    end
-  end
-
-  defp system_info do
-    case otp_release() do
-      vsn when vsn <= 23 -> "Erlang/OTP #{vsn}"
-      vsn -> "Erlang/OTP #{vsn} (#{emu_flavor()})"
     end
   end
 

--- a/website/docs/development.mdx
+++ b/website/docs/development.mdx
@@ -6,12 +6,12 @@ sidebar_label: Development and Contributing
 
 ## Requirements
 
-TeslaMate officially supports the versions listed below. However, TeslaMate aims to maintain compatibility with the last three major releases of Erlang and Postgres, as well as the last three minor releases of Elixir.
+TeslaMate officially supports the versions listed below. However, TeslaMate aims to maintain compatibility with the last three major releases of Postgres as well as the last three minor releases of Elixir (OTP 28 is required).
 When contributing, please use the versions listed below, which match those used in official TeslaMate distributions.
 
 - **Elixir** >= 1.19.5-otp-28
 - **Postgres** >= 18.0
-- **Grafana** = 12.4.0
+- **Grafana** = 13.0.1
 - An **MQTT broker** e.g. mosquitto (_optional_)
 - **NodeJS** >= 22.22.0
 

--- a/website/docs/development.mdx
+++ b/website/docs/development.mdx
@@ -6,7 +6,7 @@ sidebar_label: Development and Contributing
 
 ## Requirements
 
-TeslaMate officially supports the versions listed below. However, TeslaMate aims to maintain compatibility with the last three major releases of Postgres as well as the last three minor releases of Elixir (OTP 28 is required).
+TeslaMate officially supports the versions listed below. In general, TeslaMate aims to stay compatible with the last three major Erlang and Postgres releases and the last three minor Elixir releases. At the moment, OTP 28+ is a hard requirement, so Elixir support is currently limited to versions that support OTP 28 (Elixir 1.18.4+ and 1.19.x).
 When contributing, please use the versions listed below, which match those used in official TeslaMate distributions.
 
 - **Elixir** >= 1.19.5-otp-28

--- a/website/docs/installation/docker.md
+++ b/website/docs/installation/docker.md
@@ -15,6 +15,7 @@ Alternatively, you can use a reverse proxy (such as Traefik, Apache2 or Caddy) w
 - A Machine that's always on, so TeslaMate can continually fetch data
 - At least 1 GB of RAM on the machine for the installation to succeed. It is recommended to have at least 2 GB of RAM for optimal operation.
 - External internet access, to talk to tesla.com
+- Docker images are available for aarch64 (ARM 64-bit) and amd64 (Intel/AMD 64-bit). For Raspberry Pi users: armv7 is no longer supported. You must use a 64-bit Raspberry Pi OS with an ARMv8-compatible board (Raspberry Pi 3 or newer)
 
 ## Instructions
 

--- a/website/docs/installation/unsupported/debian.md
+++ b/website/docs/installation/unsupported/debian.md
@@ -55,7 +55,7 @@ sudo apt install erlang erlang-dev erlang-syntax-tools elixir
 </details>
 
 <details>
-  <summary>Grafana (v12.4.0+)</summary>
+  <summary>Grafana (v13.0.1+)</summary>
 
 ```bash
 sudo apt-get install -y apt-transport-https software-properties-common

--- a/website/docs/installation/unsupported/freebsd.md
+++ b/website/docs/installation/unsupported/freebsd.md
@@ -70,7 +70,7 @@ service postgresql initdb
 </details>
 
 <details>
-  <summary>Grafana (v12.3.0+)</summary>
+  <summary>Grafana (v13.0.1+)</summary>
 
 ```bash
 pkg install grafana


### PR DESCRIPTION
Did some minor refinements since we're requiring OTP 28 now. Noticed that we forgot to the supported Grafana version in the docs as well.

FreeBSD & Debian (Trixie) ship with Erlang 26 / 27 - therefore installs most likely do not work anymore when relying on those Erlang versions as per #5391.

We currently don't list any requirements (architecture wise) in the docker requirements - should we add them?

-> https://docs.teslamate.org/docs/installation/docker#requirements