### PR TITLE
fix: enable HTTP/2 and set TLS to 1.3 for TESLA_AUTH_HOST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improvements and bug fixes
 
+- fix: enable HTTP/2 and set TLS to 1.3 for TESLA_AUTH_HOST (#5406 - @kenc420 and @longzheng)
+
 #### Build, CI, internal
 
 #### Dashboards

--- a/lib/teslamate/http.ex
+++ b/lib/teslamate/http.ex
@@ -15,6 +15,14 @@ defmodule TeslaMate.HTTP do
       ],
       "https://nominatim.openstreetmap.org" => [size: 3] ++ nominatim_proxy,
       "https://api.github.com" => [size: 1],
+      System.get_env("TESLA_AUTH_HOST", "https://auth.tesla.com") => [
+        protocols: [:http1, :http2],
+        conn_opts: [
+          transport_opts: [
+            versions: [:"tlsv1.3"]
+          ]
+        ]
+      ],
       :default => [size: System.get_env("HTTP_POOL_SIZE", "5") |> String.to_integer()]
     }
   end


### PR DESCRIPTION
replicating #5405 as long as we are not allowing docker builds from external PRs

please follow https://docs.teslamate.org/docs/development#testing-with-our-ci-which-builds-the-docker-images-automatically-per-pr when testing this PR. ensure to revert back to a stable version when released!

credits to @kenc420 and @longzheng 