### PR TITLE
docs(projects): add TeslaMate LLM Bridge to community projects

### DIFF
--- a/website/docs/projects.md
+++ b/website/docs/projects.md
@@ -104,3 +104,9 @@ LINK: [https://github.com/brchri/tesla-geogdo](https://github.com/brchri/tesla-g
 A gamification add-on for TeslaMate that analyzes your historical data to unlock achievements. It features a collection of badges based on driving milestones, charging habits, efficiency, and phantom drain, turning your ownership statistics into a fun progression system.
 
 LINK: [github.com/crstian19/teslamate-achievements](https://github.com/crstian19/teslamate-achievements)
+
+## [TeslaMate LLM Bridge](https://github.com/jakezai250808-sudo/teslamate-llm-bridge)
+
+A bridge that exposes a TeslaMate Postgres database to ChatGPT, Claude Desktop, and Coze through declarative-YAML "plays" — each play is a read-only SQL query plus a compute pipeline plus a creative-prompt template, and the same play definition is rendered as a ChatGPT Action, a Coze plugin, and an MCP tool. Includes 13 plays out of the box (driving personality, monthly wrapped, night-owl, cumulative climb, charging habits, ...) plus a 90-second demo with synthetic data so it can be tried without a Tesla. Java 21 + Python 3.11, multi-arch Docker, AGPL-3.0.
+
+LINK: [github.com/jakezai250808-sudo/teslamate-llm-bridge](https://github.com/jakezai250808-sudo/teslamate-llm-bridge)


### PR DESCRIPTION
Adds **TeslaMate LLM Bridge** to the community projects list.

### What it is

An open-source bridge that exposes a TeslaMate Postgres database to ChatGPT, Claude Desktop, and Coze through declarative-YAML "plays". Each play is one read-only SQL query plus a compute pipeline plus a creative-prompt template, and the **same** play definition is rendered as a ChatGPT Custom GPT Action, a Coze plugin tool, and an MCP tool — write once, every assistant can call it.

13 plays ship out of the box (driving personality, monthly wrapped, night-owl, early-bird, cumulative climb, charging habits, ...) and contributing a new one is YAML-only, no Java or Python required.

### Why submit it here

It is built specifically on top of TeslaMate (reads the standard schema: drives, charging_processes, positions, ...) and the README directs users to install TeslaMate first. Closest existing entries on this page are TeslaMate Achievements (gamified badges) and the various Grafana/HA dashboards — this is a complementary "talk to your car via LLM" angle.

### Safety

Plays are not raw SQL access. Each manifest passes a JSON-Schema gate, an SQL static guard (SELECT-only, no DDL/DML, statement timeout, read-only transaction), and an arithmetic-only expression language before being loaded.

### Try it without a Tesla

```
git clone https://github.com/jakezai250808-sudo/teslamate-llm-bridge
cd teslamate-llm-bridge
docker compose --profile demo up -d --build
curl http://localhost:8770/api/v1/cars/99/play/driving-personality
```

License: AGPL-3.0. Repo: https://github.com/jakezai250808-sudo/teslamate-llm-bridge

Happy to adjust the description if it should be shorter or framed differently. Thanks for maintaining TeslaMate!