### PR TITLE
ci(osv-scanner): don't fail on main pushes and merge queue

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -34,6 +34,10 @@ jobs:
     if: ( github.event_name == 'push' && needs.check_paths.outputs.githubfolder == 'false' ) || github.event_name == 'schedule'
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@fa4ff678dd5d0a4fa3d628e57af8162873e93cd6" # v2.3.8
     with:
+      # Don't fail on push to main / scheduled runs: vulnerabilities are still
+      # reported via the SARIF upload, but the CI run stays green so it doesn't
+      # look like a build failure on main.
+      fail-on-vuln: false
       scan-args: |-
         -r
         ./
@@ -43,6 +47,9 @@ jobs:
     if: ( github.event_name == 'pull_request' && needs.check_paths.outputs.githubfolder == 'false' ) || ( github.event_name == 'merge_group' && needs.check_paths.outputs.githubfolder == 'false' )
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@fa4ff678dd5d0a4fa3d628e57af8162873e93cd6" # v2.3.8
     with:
+      # Fail on real pull_request runs (catch vulns before merge), but don't fail
+      # merge_group runs so a merge to main isn't blocked / shown as failed.
+      fail-on-vuln: ${{ github.event_name != 'merge_group' }}
       scan-args: |-
         -r
         ./

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - ci: remove now obsolete ARMv7 buildcache (#5397 - @swiffer)
 - build: remove now unused zstd compression tool to reduce docker image size (#5397 - @swiffer)
 - build(deps): bump floki from 0.38.1 to 0.38.3 (#5359)
+- ci(osv-scanner): don't fail on main pushes and merge queue (#5410 - @JakobLichterfeld)
 
 #### Dashboards
 


### PR DESCRIPTION
The OSV-Scanner failed the workflow run whenever a vulnerability was found, making the CI on main look like a build failure even though findings are reported via the SARIF upload anyway.

Set fail-on-vuln=false for push/schedule runs and for merge_group runs, while keeping it enabled for regular pull_request runs so vulnerabilities are still caught before merge.