### PR TITLE
fix(vehicle): use streaming-aware interval when a drive starts

### DIFF
--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1035,11 +1035,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
         Logger.info("Start of drive initiated by: #{inspect(vehicle.drive_state)}")
 
         {drive, data} = start_drive(create_position(vehicle, data), data)
+        interval = if streaming?(data), do: default_interval(), else: driving_interval()
 
         {:next_state, {:driving, :available, drive}, data,
          [
            broadcast_summary(),
-           schedule_fetch(driving_interval(), data)
+           schedule_fetch(interval, data)
          ]}
 
       %V{charge_state: %Charge{charging_state: charging_state, battery_level: lvl}}


### PR DESCRIPTION
## Summary
Aligns the polling interval used when a drive is first detected with the interval already used for subsequent driving updates. Issue #5323 noted that drive start always scheduled `driving_interval()`, while the `:driving` update handler switches to `default_interval()` when streaming is active.

## Problem
When a drive begins via the polling path, the first scheduled fetch always uses `driving_interval()`:

```elixir
# lib/teslamate/vehicles/vehicle.ex (before)
schedule_fetch(driving_interval(), data)
```

During an active drive, updates already use a streaming-aware interval:

```elixir
interval = if streaming?(data), do: default_interval(), else: driving_interval()
```

With streaming enabled, that meant the first fetch after drive start polled at the faster driving cadence and then immediately switched to the default interval on the next update.

## Solution
Compute the same `interval` at drive start and pass it to `schedule_fetch/2`, matching the existing driving-update logic.

## Out of scope
- Other drive-start paths that originate from stream events (`schedule_fetch(0, data)`) — those already rely on stream delivery rather than polling cadence.
- Broader polling-interval refactors or new tests for the state machine.

## Test plan
- [ ] Verified the change mirrors the existing `handle_event/4` interval selection at `vehicle.ex` line ~1287.
- [ ] Elixir toolchain not available locally; CI to run the project test suite.

## Related
- #5323 — documents the inconsistent `driving_interval()` usage at drive start

Made with [Cursor](https://cursor.com)