### PR TITLE
fix(mqtt): retry failed value publications

### DIFF
--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -67,37 +67,36 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
       |> add_geofence(summary)
       |> add_active_route(summary)
 
-    publish_values(values, state)
-    {:noreply, %{state | last_values: values}}
-  end
-
-  defp publish_values(values, %State{last_values: values} = state) do
-    values
-    |> Map.take(@do_not_retain)
-    |> Enum.each(fn {key, value} ->
-      publish({key, value}, state)
-    end)
+    last_values = publish_values(values, state)
+    {:noreply, %{state | last_values: last_values}}
   end
 
   defp publish_values(values, state) do
+    last_values = state.last_values || %{}
+
     values
     |> Stream.reject(&match?({_key, :unknown}, &1))
     |> Stream.filter(fn {key, value} ->
       ((key in @publish_if_nil or value != nil) and
-         (state.last_values == nil or Map.get(state.last_values, key) != value)) or
+         (not Map.has_key?(last_values, key) or Map.get(last_values, key) != value)) or
         key in @do_not_retain
     end)
-    |> Task.async_stream(&publish(&1, state),
+    |> Task.async_stream(fn entry -> {entry, publish(entry, state)} end,
       max_concurrency: 10,
       on_timeout: :kill_task,
       ordered: false
     )
-    |> Enum.each(fn
-      {_, reason} when reason != :ok ->
-        Logger.warning("MQTT publishing failed: #{inspect(reason)}")
+    |> Enum.reduce(last_values, fn
+      {:ok, {{key, value}, :ok}}, acc ->
+        Map.put(acc, key, value)
 
-      _ok ->
-        nil
+      {:ok, {_entry, reason}}, acc ->
+        Logger.warning("MQTT publishing failed: #{inspect(reason)}")
+        acc
+
+      {:exit, reason}, acc ->
+        Logger.warning("MQTT publishing failed: #{inspect(reason)}")
+        acc
     end)
   end
 

--- a/test/support/mocks/mqtt_publisher.ex
+++ b/test/support/mocks/mqtt_publisher.ex
@@ -1,7 +1,7 @@
 defmodule MqttPublisherMock do
   use GenServer
 
-  defstruct [:pid]
+  defstruct [:pid, responses: %{}]
   alias __MODULE__, as: State
 
   # API
@@ -16,12 +16,27 @@ defmodule MqttPublisherMock do
 
   @impl true
   def init(opts) do
-    {:ok, %State{pid: Keyword.fetch!(opts, :pid)}}
+    {:ok,
+     %State{
+       pid: Keyword.fetch!(opts, :pid),
+       responses: Keyword.get(opts, :responses, %{})
+     }}
   end
 
   @impl true
-  def handle_call({:publish, _topic, _msg, _opts} = action, _from, %State{pid: pid} = state) do
+  def handle_call(
+        {:publish, topic, _msg, _opts} = action,
+        _from,
+        %State{pid: pid, responses: responses} = state
+      ) do
     send(pid, {MqttPublisherMock, action})
-    {:reply, :ok, state}
+
+    {response, responses} =
+      case Map.get(responses, topic, []) do
+        [response | rest] -> {response, Map.put(responses, topic, rest)}
+        [] -> {:ok, responses}
+      end
+
+    {:reply, response, %{state | responses: responses}}
   end
 end

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -5,11 +5,16 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
   alias TeslaMate.Vehicles.Vehicle.Summary
   alias TeslaMate.Locations.GeoFence
 
-  defp start_subscriber(name, car_id, namespace \\ nil) do
+  defp start_subscriber(name, car_id, namespace \\ nil, publisher_responses \\ %{}) do
     publisher_name = :"mqtt_publisher_#{name}"
     vehicles_name = :"vehicles_#{name}"
 
-    {:ok, _pid} = start_supervised({MqttPublisherMock, name: publisher_name, pid: self()})
+    {:ok, _pid} =
+      start_supervised(
+        {MqttPublisherMock,
+         name: publisher_name, pid: self(), responses: publisher_responses}
+      )
+
     {:ok, _pid} = start_supervised({VehiclesMock, name: vehicles_name, pid: self()})
 
     start_supervised(
@@ -235,6 +240,39 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     send(pid, %Summary{geofence: other_geofence, version: "3"})
     assert_receive {MqttPublisherMock, {:publish, "teslamate/cars/0/geofence", "Work", _}}
     assert_receive {MqttPublisherMock, {:publish, "teslamate/cars/0/version", "3", _}}
+  end
+
+  @tag :capture_log
+  test "retries failed values until they are published successfully", %{test: name} do
+    display_name_topic = "teslamate/cars/0/display_name"
+    shift_state_topic = "teslamate/cars/0/shift_state"
+
+    responses = %{
+      display_name_topic => [{:error, :disconnected}, :ok],
+      shift_state_topic => [{:error, :disconnected}, :ok]
+    }
+
+    {:ok, pid} = start_subscriber(name, 0, nil, responses)
+
+    assert_receive {VehiclesMock, {:subscribe_to_summary, 0}}
+
+    summary = %Summary{display_name: "Foo", version: "1"}
+    send(pid, summary)
+
+    assert_receive {MqttPublisherMock, {:publish, ^display_name_topic, "Foo", _}}
+    assert_receive {MqttPublisherMock, {:publish, ^shift_state_topic, "", _}}
+    assert_receive {MqttPublisherMock, {:publish, "teslamate/cars/0/version", "1", _}}
+
+    send(pid, summary)
+
+    assert_receive {MqttPublisherMock, {:publish, ^display_name_topic, "Foo", _}}
+    assert_receive {MqttPublisherMock, {:publish, ^shift_state_topic, "", _}}
+    refute_receive {MqttPublisherMock, {:publish, "teslamate/cars/0/version", "1", _}}
+
+    send(pid, summary)
+
+    refute_receive {MqttPublisherMock, {:publish, ^display_name_topic, "Foo", _}}
+    refute_receive {MqttPublisherMock, {:publish, ^shift_state_topic, "", _}}
   end
 
   test "allows namespaces", %{test: name} do

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -11,8 +11,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
 
     {:ok, _pid} =
       start_supervised(
-        {MqttPublisherMock,
-         name: publisher_name, pid: self(), responses: publisher_responses}
+        {MqttPublisherMock, name: publisher_name, pid: self(), responses: publisher_responses}
       )
 
     {:ok, _pid} = start_supervised({VehiclesMock, name: vehicles_name, pid: self()})


### PR DESCRIPTION
## Summary

- Cache MQTT values only after they have been published successfully.
- Retry failed values when the next vehicle summary arrives.
- Distinguish missing cache entries from successfully published `nil` values.

## Problem

`VehicleSubscriber` previously replaced `last_values` with the complete
current value map regardless of individual MQTT publish results.

When a publication failed, the value was still treated as published.
Subsequent summaries containing the same value were filtered out, so a
transient MQTT failure could leave a retained topic missing or stale until
the value changed or the subscriber restarted.

## Solution

Associate each asynchronous publish result with its topic and value, then
add only successful publications to `last_values`.

Failed publications remain uncached and are retried with the next summary.
`Map.has_key?/2` is used to distinguish a value that has never been
published from a successfully published `nil` value.

## Test plan

- Verify that a failed `display_name` publication is retried.
- Verify that a failed `nil` `shift_state` publication is retried.
- Verify that successfully published unchanged values are not published again.
- Full DevOps workflow passed, including formatting, tests, and static analysis.