### PR TITLE
fix(webview): show charging finish time in browser local time

### DIFF
--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -43,6 +43,27 @@ export const LocalTime = {
   },
 };
 
+export const LocalDateTime = {
+  render() {
+    const dateStr = this.el.dataset.date;
+    const date = toLocalDate(dateStr, {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    const time = toLocalTime(dateStr);
+    this.el.innerText = `${date}, ${time}`;
+  },
+
+  mounted() {
+    this.render();
+  },
+
+  updated() {
+    this.render();
+  },
+};
+
 export const LocalTimeRange = {
   exec() {
     const date = toLocalDate(this.el.dataset.startDate, {

--- a/lib/teslamate_web/live/car_live/summary.html.heex
+++ b/lib/teslamate_web/live/car_live/summary.html.heex
@@ -237,12 +237,7 @@
             <% current_time = Timex.now()
 
             finish_time =
-              Timex.add(current_time, Timex.Duration.from_hours(@summary.time_to_full_charge))
-
-            local_finish_time = Timex.local(finish_time)
-
-            formatted_finish_time =
-              Timex.format!(local_finish_time, "%Y-%m-%d %H:%M:%S", :strftime) %>
+              Timex.add(current_time, Timex.Duration.from_hours(@summary.time_to_full_charge)) %>
             <tr>
               <td class="has-text-weight-medium"><%= gettext("Remaining Time") %></td>
               <td>
@@ -254,7 +249,13 @@
             </tr>
             <tr>
               <td class="has-text-weight-medium"><%= gettext("Expected Finish Time") %></td>
-              <td><%= formatted_finish_time %></td>
+              <td>
+                <%= tag(:span,
+                  data: [date: finish_time |> DateTime.to_iso8601()],
+                  phx_hook: "LocalDateTime",
+                  id: "expected_finish_time_#{@car.id}"
+                ) %>
+              </td>
             </tr>
           <% end %>
           <%= unless is_nil(@summary.ideal_battery_range_km) do %>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -15,17 +15,17 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:374
+#: lib/teslamate_web/live/car_live/summary.html.heex:375
 #, elixir-autogen, elixir-format
 msgid "Speed"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:364
+#: lib/teslamate_web/live/car_live/summary.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "State of Charge"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:298
+#: lib/teslamate_web/live/car_live/summary.html.heex:299
 #, elixir-autogen, elixir-format
 msgid "Charged"
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:313
+#: lib/teslamate_web/live/car_live/summary.html.heex:314
 #, elixir-autogen, elixir-format
 msgid "Scheduled Charging"
 msgstr ""
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Plugged In"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:325
+#: lib/teslamate_web/live/car_live/summary.html.heex:326
 #, elixir-autogen, elixir-format
 msgid "Charge Limit"
 msgstr ""
@@ -226,17 +226,17 @@ msgstr ""
 msgid "Driver present"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:459
+#: lib/teslamate_web/live/car_live/summary.html.heex:460
 #, elixir-autogen, elixir-format
 msgid "cancel sleep attempt"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:450
+#: lib/teslamate_web/live/car_live/summary.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "try to sleep"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:285
+#: lib/teslamate_web/live/car_live/summary.html.heex:286
 #, elixir-autogen, elixir-format
 msgid "Range (est.)"
 msgstr ""
@@ -256,12 +256,12 @@ msgstr ""
 msgid "Vehicle must be locked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:265
+#: lib/teslamate_web/live/car_live/summary.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "Range (rated)"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:304
+#: lib/teslamate_web/live/car_live/summary.html.heex:305
 #, elixir-autogen, elixir-format
 msgid "Charger Power"
 msgstr ""
@@ -286,7 +286,7 @@ msgstr ""
 msgid "rated"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:264
+#: lib/teslamate_web/live/car_live/summary.html.heex:265
 #, elixir-autogen, elixir-format
 msgid "Range (ideal)"
 msgstr ""
@@ -311,17 +311,17 @@ msgstr ""
 msgid "Delete '%{geo_fence}'?"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:399
+#: lib/teslamate_web/live/car_live/summary.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "Inside Temperature"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:387
+#: lib/teslamate_web/live/car_live/summary.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "Outside Temperature"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:424
+#: lib/teslamate_web/live/car_live/summary.html.heex:425
 #: lib/teslamate_web/live/settings_live/index.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "Version"
@@ -337,7 +337,7 @@ msgstr ""
 msgid "Unlocked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:247
+#: lib/teslamate_web/live/car_live/summary.html.heex:242
 #, elixir-autogen, elixir-format
 msgid "Remaining Time"
 msgstr ""
@@ -390,7 +390,7 @@ msgstr ""
 msgid "Reduced Battery Range"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:358
+#: lib/teslamate_web/live/car_live/summary.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "≈ %{range} at 100%"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:412
+#: lib/teslamate_web/live/car_live/summary.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "Mileage"
 msgstr ""
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Dog mode is enabled"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:256
+#: lib/teslamate_web/live/car_live/summary.html.heex:251
 #, elixir-autogen, elixir-format
 msgid "Expected Finish Time"
 msgstr ""


### PR DESCRIPTION
The "Expected Finish Time" was formatted server-side with Timex.local/1, which uses the server's timezone (UTC in typical Docker deployments) rather than the user's. 

Render the UTC instant as ISO-8601 and convert it client-side with a new LocalDateTime hook, matching the existing pattern used by the Scheduled Charging row.