### PR TITLE
fix(performance): use existing indexes for last-inserted / latest complete position lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - feat(grafana): make data health summary actionable (#5526 - @magrathean-uk)
 - fix(grafana): drop the Releases panel from the home dashboard to end the CORS proxy dependency (#5548 - @JakobLichterfeld)
 - fix(dashboards): filter latest-value position panels on complete rows so they use the partial index (#5438 - @swiffer)
+- fix(grafana): Battery Health latest SOC/kWh panels pick the newest UNION row and use `usable_battery_level` on charges (#5438 - @swiffer)
 - fix(grafana): use local calendar for Statistics period end boundaries (#5562 - @wjsall)
 
 #### Translations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - fix(vehicle): identify base Model 3 from model year 2022 as RWD instead of SR+ (#5551 - @magrathean-uk)
 - fix(mqtt): avoid blocking startup on retained cleanup (#5549 - @magrathean-uk)
 - feat: use Grafana 13.1.1 (#5559 - @swiffer)
+- fix(performance): use existing indexes for last-inserted / latest complete position lookups (#5438 - @swiffer)
 
 #### Build, CI, internal
 
@@ -80,6 +81,7 @@
 
 - feat(grafana): make data health summary actionable (#5526 - @magrathean-uk)
 - fix(grafana): drop the Releases panel from the home dashboard to end the CORS proxy dependency (#5548 - @JakobLichterfeld)
+- fix(dashboards): filter latest-value position panels on complete rows so they use the partial index (#5438 - @swiffer)
 - fix(grafana): use local calendar for Statistics period end boundaries (#5562 - @wjsall)
 
 #### Translations

--- a/grafana/dashboards/battery-health.json
+++ b/grafana/dashboards/battery-health.json
@@ -1093,7 +1093,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT * FROM ((SELECT usable_battery_level, date\r\nFROM positions\r\nWHERE car_id = $car_id AND usable_battery_level IS NOT NULL\r\nORDER BY date DESC\r\nLIMIT 1)\r\nUNION\r\n(SELECT usable_battery_level, date\r\nFROM charges c\r\nJOIN charging_processes p ON p.id = c.charging_process_id\r\nWHERE p.car_id = $car_id AND usable_battery_level IS NOT NULL\r\nORDER BY date DESC\r\nLIMIT 1)) AS last_usable_battery_level LIMIT 1",
+          "rawSql": "SELECT * FROM ((SELECT usable_battery_level, date\r\nFROM positions\r\nWHERE car_id = $car_id AND ideal_battery_range_km IS NOT NULL AND usable_battery_level IS NOT NULL\r\nORDER BY date DESC\r\nLIMIT 1)\r\nUNION ALL\r\n(SELECT c.usable_battery_level, date\r\nFROM charges c\r\nJOIN charging_processes p ON p.id = c.charging_process_id\r\nWHERE p.car_id = $car_id AND c.usable_battery_level IS NOT NULL\r\nORDER BY date DESC\r\nLIMIT 1)) AS last_usable_battery_level ORDER BY date DESC LIMIT 1",
           "refId": "SOC",
           "sql": {
             "columns": [
@@ -1370,7 +1370,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT * FROM ((SELECT usable_battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM positions\nWHERE car_id = $car_id  AND usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)\nUNION\n(SELECT battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM charges c\nJOIN charging_processes p ON p.id = c.charging_process_id\nWHERE p.car_id = $car_id  AND usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)) AS last_usable_battery_level LIMIT 1",
+          "rawSql": "SELECT * FROM ((SELECT usable_battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM positions\nWHERE car_id = $car_id AND ideal_battery_range_km IS NOT NULL AND usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)\nUNION ALL\n(SELECT c.usable_battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM charges c\nJOIN charging_processes p ON p.id = c.charging_process_id\nWHERE p.car_id = $car_id  AND c.usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)) AS last_usable_battery_level ORDER BY date DESC LIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [

--- a/grafana/dashboards/overview.json
+++ b/grafana/dashboards/overview.json
@@ -1601,7 +1601,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n\t$__time(date),\r\n\tconvert_celsius(driver_temp_setting, '$temp_unit') as \"Driver Temperature [°$temp_unit]\",\r\n\tconvert_celsius(inside_temp, '$temp_unit') AS \"Inside Temperature [°$temp_unit]\"\r\nFROM positions\r\nWHERE driver_temp_setting IS NOT NULL AND inside_temp IS NOT NULL AND car_id = $car_id AND date >= (TIMEZONE('UTC', NOW()) - INTERVAL '60m')\r\nORDER BY date DESC\r\nLIMIT 1;",
+          "rawSql": "SELECT\r\n\t$__time(date),\r\n\tconvert_celsius(driver_temp_setting, '$temp_unit') as \"Driver Temperature [°$temp_unit]\",\r\n\tconvert_celsius(inside_temp, '$temp_unit') AS \"Inside Temperature [°$temp_unit]\"\r\nFROM positions\r\nWHERE driver_temp_setting IS NOT NULL AND inside_temp IS NOT NULL AND ideal_battery_range_km IS NOT NULL AND car_id = $car_id AND date >= (TIMEZONE('UTC', NOW()) - INTERVAL '60m')\r\nORDER BY date DESC\r\nLIMIT 1;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -1708,7 +1708,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH last_position AS (\n\tSELECT date, convert_celsius(outside_temp, '$temp_unit') AS \"Outside Temperature [°$temp_unit]\"\n\tFROM positions\n\tWHERE car_id = $car_id AND outside_temp IS NOT NULL AND date >= (TIMEZONE('UTC', NOW()) - INTERVAL '60m')\n\tORDER BY date DESC\n\tLIMIT 1\n),\nlast_charge AS (\n\tSELECT date, convert_celsius(outside_temp, '$temp_unit') AS \"Outside Temperature [°$temp_unit]\"\n\tFROM charges\n\tJOIN charging_processes ON charges.charging_process_id = charging_processes.id\n\tWHERE car_id = $car_id AND outside_temp IS NOT NULL AND date >= (TIMEZONE('UTC', NOW()) - INTERVAL '60m')\n\tORDER BY date DESC\n\tLIMIT 1\n)\nSELECT * FROM last_position\nUNION ALL\nSELECT * FROM last_charge\nORDER BY date DESC\nLIMIT 1;",
+          "rawSql": "WITH last_position AS (\n\tSELECT date, convert_celsius(outside_temp, '$temp_unit') AS \"Outside Temperature [°$temp_unit]\"\n\tFROM positions\n\tWHERE car_id = $car_id AND ideal_battery_range_km IS NOT NULL AND outside_temp IS NOT NULL AND date >= (TIMEZONE('UTC', NOW()) - INTERVAL '60m')\n\tORDER BY date DESC\n\tLIMIT 1\n),\nlast_charge AS (\n\tSELECT date, convert_celsius(outside_temp, '$temp_unit') AS \"Outside Temperature [°$temp_unit]\"\n\tFROM charges\n\tJOIN charging_processes ON charges.charging_process_id = charging_processes.id\n\tWHERE car_id = $car_id AND outside_temp IS NOT NULL AND date >= (TIMEZONE('UTC', NOW()) - INTERVAL '60m')\n\tORDER BY date DESC\n\tLIMIT 1\n)\nSELECT * FROM last_position\nUNION ALL\nSELECT * FROM last_charge\nORDER BY date DESC\nLIMIT 1;",
           "refId": "A",
           "sql": {
             "columns": [

--- a/lib/teslamate/auth.ex
+++ b/lib/teslamate/auth.ex
@@ -4,7 +4,6 @@ defmodule TeslaMate.Auth do
   """
 
   import Ecto.Query, warn: false
-  require Logger
 
   alias TeslaMate.Repo
 

--- a/lib/teslamate/log.ex
+++ b/lib/teslamate/log.ex
@@ -157,14 +157,14 @@ defmodule TeslaMate.Log do
 
   def get_latest_position do
     Position
-    |> order_by(desc: :date)
+    |> order_by(desc: :id)
     |> limit(1)
     |> Repo.one()
   end
 
   def get_latest_position(%Car{id: id}) do
     Position
-    |> where(car_id: ^id)
+    |> where([p], p.car_id == ^id and not is_nil(p.ideal_battery_range_km))
     |> order_by(desc: :date)
     |> limit(1)
     |> Repo.one()

--- a/lib/teslamate/log.ex
+++ b/lib/teslamate/log.ex
@@ -155,13 +155,15 @@ defmodule TeslaMate.Log do
     |> Repo.insert()
   end
 
-  def get_latest_position do
+  # Order by id for PK scan; geofence map center only.
+  def get_last_inserted_position do
     Position
     |> order_by(desc: :id)
     |> limit(1)
     |> Repo.one()
   end
 
+  # Filter ideal_battery_range_km so restore uses partial index, not seq scan.
   def get_latest_position(%Car{id: id}) do
     Position
     |> where([p], p.car_id == ^id and not is_nil(p.ideal_battery_range_km))

--- a/lib/teslamate_web/live/charge_live/cost.ex
+++ b/lib/teslamate_web/live/charge_live/cost.ex
@@ -1,8 +1,6 @@
 defmodule TeslaMateWeb.ChargeLive.Cost do
   use TeslaMateWeb, :live_view
 
-  require Logger
-
   alias TeslaMate.Locations.{GeoFence, Address}
   alias TeslaMate.Log.ChargingProcess
   alias TeslaMate.Log

--- a/lib/teslamate_web/live/geofence_live/form.ex
+++ b/lib/teslamate_web/live/geofence_live/form.ex
@@ -33,7 +33,7 @@ defmodule TeslaMateWeb.GeoFenceLive.Form do
 
   def mount(_params, %{"settings" => settings}, socket) do
     %{latitude: lat, longitude: lng} =
-      case Log.get_latest_position() do
+      case Log.get_last_inserted_position() do
         %Position{latitude: lat, longitude: lng} -> %{latitude: lat, longitude: lng}
         nil -> %{latitude: 0.0, longitude: 0.0}
       end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -395,7 +395,7 @@ msgstr ""
 msgid "≈ %{range} at 100%"
 msgstr ""
 
-#: lib/teslamate_web/live/charge_live/cost.ex:20
+#: lib/teslamate_web/live/charge_live/cost.ex:18
 #: lib/teslamate_web/live/charge_live/cost.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Charge Cost"
@@ -412,7 +412,7 @@ msgstr ""
 msgid "Enter charge cost"
 msgstr ""
 
-#: lib/teslamate_web/live/charge_live/cost.ex:87
+#: lib/teslamate_web/live/charge_live/cost.ex:85
 #, elixir-autogen, elixir-format
 msgid "Saved!"
 msgstr ""

--- a/test/teslamate/log/log_position_test.exs
+++ b/test/teslamate/log/log_position_test.exs
@@ -1,0 +1,93 @@
+defmodule TeslaMate.LogPositionTest do
+  use TeslaMate.DataCase, async: true
+
+  alias TeslaMate.Log
+
+  def car_fixture(attrs \\ %{}) do
+    id = System.unique_integer([:positive, :monotonic])
+
+    {:ok, car} =
+      attrs
+      |> Enum.into(%{
+        efficiency: 0.153,
+        eid: id,
+        model: "M3",
+        vid: id,
+        vin: "test-#{id}"
+      })
+      |> Log.create_car()
+
+    car
+  end
+
+  describe "get_latest_position/1" do
+    test "returns the latest complete position for a car" do
+      car = car_fixture()
+      other_car = car_fixture()
+
+      {:ok, complete_position} =
+        Log.insert_position(car, %{
+          date: ~U[2026-01-01 10:00:00Z],
+          latitude: 1.0,
+          longitude: 1.0,
+          ideal_battery_range_km: 300.0
+        })
+
+      {:ok, _incomplete_streaming_position} =
+        Log.insert_position(car, %{
+          date: ~U[2026-01-01 10:05:00Z],
+          latitude: 2.0,
+          longitude: 2.0
+        })
+
+      {:ok, _other_car_position} =
+        Log.insert_position(other_car, %{
+          date: ~U[2026-01-01 10:10:00Z],
+          latitude: 3.0,
+          longitude: 3.0,
+          ideal_battery_range_km: 200.0
+        })
+
+      assert %{id: id} = Log.get_latest_position(car)
+      assert id == complete_position.id
+    end
+
+    test "returns nil when a car only has incomplete streaming positions" do
+      car = car_fixture()
+
+      {:ok, _incomplete_streaming_position} =
+        Log.insert_position(car, %{
+          date: ~U[2026-01-01 10:05:00Z],
+          latitude: 2.0,
+          longitude: 2.0
+        })
+
+      assert Log.get_latest_position(car) == nil
+    end
+  end
+
+  describe "get_last_inserted_position/0" do
+    test "returns the most recently inserted position across all cars, including incomplete ones" do
+      car = car_fixture()
+      other_car = car_fixture()
+
+      {:ok, _latest_by_date_position} =
+        Log.insert_position(car, %{
+          date: ~U[2026-01-01 10:00:00Z],
+          latitude: 1.0,
+          longitude: 1.0,
+          ideal_battery_range_km: 300.0
+        })
+
+      {:ok, latest_position} =
+        Log.insert_position(other_car, %{
+          date: ~U[2026-01-01 09:55:00Z],
+          latitude: 2.0,
+          longitude: 2.0
+        })
+
+      assert %{id: id} = Log.get_last_inserted_position()
+      assert id == latest_position.id
+    end
+  end
+end

--- a/test/teslamate_web/live/geofence_live_test.exs
+++ b/test/teslamate_web/live/geofence_live_test.exs
@@ -201,7 +201,7 @@ defmodule TeslaMateWeb.GeoFenceLiveTest do
   end
 
   describe "New" do
-    test "pre-fills the coordinates with the most recent position", %{conn: conn} do
+    test "pre-fills the coordinates with the last inserted position", %{conn: conn} do
       car = car_fixture()
 
       assert {:ok, _} =


### PR DESCRIPTION
## Summary

Avoid sequential scans on large `positions` tables after the BRIN migration by using existing indexes — **no new btree**.

### Elixir
- Rename `get_latest_position/0` → `get_last_inserted_position/0`: `ORDER BY id DESC` (PK scan) for geofence map center only
- `get_latest_position(%Car{})`: require `ideal_battery_range_km IS NOT NULL` so restore uses the partial `(car_id, date)` index and skips incomplete streaming rows

### Grafana
- Battery Health / Overview latest-value panels: same complete-row filter (and safer UNION ordering where needed)
- Built on top of Grafana 13.1.1 (#5559)

### i18n
- Refresh POT source refs after unused `Logger` cleanup in charge cost LiveView

Closes #5306

---

🤖 Assisted by Grok 4.5 (xAI) via Grok Build (planning, code edits, PR description).