### PR TITLE
ci: speed up check_linting by running treefmt in a lean app

### DIFF
--- a/.github/workflows/ensure_linting.yml
+++ b/.github/workflows/ensure_linting.yml
@@ -44,5 +44,5 @@ jobs:
         # (and fail to cache) the multi-GB development closure on every run.
         # It runs `mix deps.get` (so mix-format finds its plugin deps) and then
         # treefmt, passing through `--ci`.
-        run: nix run --override-input devenv-root "file+file://"<(printf %s "$PWD") .#lint -- --ci
+        run: nix run .#lint -- --ci
         # or use: https://github.com/cachix/git-hooks.nix?tab=readme-ov-file

--- a/.github/workflows/ensure_linting.yml
+++ b/.github/workflows/ensure_linting.yml
@@ -24,8 +24,10 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           # collect garbage until Nix store size (in bytes) is at most this number
           # before trying to save a new cache
-          # 1G = 1073741824
-          gc-max-store-size-linux: 1073741824
+          # 1G = 1073741824, 2G = 2147483648
+          # The lean lint shell (.#lint) closure is well below this, so the
+          # whole closure gets cached instead of being GC'd away every run.
+          gc-max-store-size-linux: 2147483648
           # do purge caches
           purge: true
           # purge all versions of the cache
@@ -37,5 +39,10 @@ jobs:
           purge-primary-key: never
 
       - name: Run treefmt in CI mode
-        run: nix develop --override-input devenv-root "file+file://"<(printf %s "$PWD") . --command treefmt --ci
+        # Use the lean `.#lint` app instead of the full devenv shell: it only
+        # provides the treefmt wrapper + Elixir, so CI does not have to realize
+        # (and fail to cache) the multi-GB development closure on every run.
+        # It runs `mix deps.get` (so mix-format finds its plugin deps) and then
+        # treefmt, passing through `--ci`.
+        run: nix run --override-input devenv-root "file+file://"<(printf %s "$PWD") .#lint -- --ci
         # or use: https://github.com/cachix/git-hooks.nix?tab=readme-ov-file

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ config/*.env
 
 # Used during tests
 /tmp/
+
+# Codegraph
+.codegraph/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 - build(deps): bump launch-editor from 2.13.2 to 2.14.1 in /website (#5426)
 - build(deps): update flake.lock (#5427)
 - build(deps): bump webpack-dev-server from 5.2.4 to 5.2.5 in /website (#5445)
-- chore: add .codegraph to .gitignore (- @JakobLichterfeld)
-- ci: speed up check_linting by running treefmt in a lean app (- @JakobLichterfeld)
+- chore: add .codegraph to .gitignore (#5440- @JakobLichterfeld)
+- ci: speed up check_linting by running treefmt in a lean app (#5440- @JakobLichterfeld)
 
 #### Dashboards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - build(deps): bump launch-editor from 2.13.2 to 2.14.1 in /website (#5426)
 - build(deps): update flake.lock (#5427)
 - build(deps): bump webpack-dev-server from 5.2.4 to 5.2.5 in /website (#5445)
+- chore: add .codegraph to .gitignore
 
 #### Dashboards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 - build(deps): bump launch-editor from 2.13.2 to 2.14.1 in /website (#5426)
 - build(deps): update flake.lock (#5427)
 - build(deps): bump webpack-dev-server from 5.2.4 to 5.2.5 in /website (#5445)
-- chore: add .codegraph to .gitignore
+- chore: add .codegraph to .gitignore (- @JakobLichterfeld)
+- ci: speed up check_linting by running treefmt in a lean app (- @JakobLichterfeld)
 
 #### Dashboards
 

--- a/nix/flake-modules/devenv.nix
+++ b/nix/flake-modules/devenv.nix
@@ -70,7 +70,7 @@
           export MQTT_PORT="${toString mosquitto_port}"
           export RELEASE_COOKIE="1234567890123456789"
           export TZDATA_DIR="$PWD/tzdata"
-          export MIX_REBAR3="${pkgs.beam27Packages.rebar3}/bin/rebar3";
+          export MIX_REBAR3="${config.teslamate.rebar3}/bin/rebar3";
           mix deps.get
         '';
         enterTest = ''

--- a/nix/flake-modules/formatter.nix
+++ b/nix/flake-modules/formatter.nix
@@ -64,5 +64,31 @@
 
         programs.nixpkgs-fmt.enable = true;
       };
+
+      # Lean treefmt entrypoint for CI: `nix run .#lint -- --ci`
+      # (locally just `nix run .#lint`; any extra args are passed to treefmt).
+      #
+      # The default devenv shell pulls in the whole development closure
+      # (elixir-ls, postgres, nodejs, mosquitto, osv-scanner, …), which is
+      # several GB and does not fit the cache GC budget, so CI rebuilds it on
+      # every run. Linting only needs the treefmt wrapper (which already bundles
+      # all formatters via absolute store paths) plus Elixir, which is the same
+      # one as the release (see package.nix), so the formatter runs against the
+      # project's toolchain. mix-format needs its plugin
+      # (Phoenix.LiveView.HTMLFormatter) and that plugin's deps compiled, so
+      # MIX_REBAR3 is pinned (a clean CI MIX_HOME has no rebar3), mirroring the
+      # devenv shell. mix deps.get fetches the formatter plugin deps first.
+      packages.lint = pkgs.writeShellApplication {
+        name = "lint";
+        runtimeInputs = [
+          config.teslamate.elixir
+          config.treefmt.build.wrapper
+        ];
+        runtimeEnv.MIX_REBAR3 = "${config.teslamate.rebar3}/bin/rebar3";
+        text = ''
+          mix deps.get
+          exec treefmt "$@"
+        '';
+      };
     };
 }

--- a/nix/flake-modules/package.nix
+++ b/nix/flake-modules/package.nix
@@ -9,6 +9,7 @@
     let
       beamPackages = pkgs.beam.packagesWith pkgs.beam.interpreters.erlang_28;
       elixir = beamPackages.elixir_1_19;
+      rebar3 = beamPackages.rebar3;
 
       src = ../..;
       version = builtins.readFile "${src}/VERSION";
@@ -96,11 +97,15 @@
           type = lib.types.package;
           readOnly = true;
         };
+        teslamate.rebar3 = lib.mkOption {
+          type = lib.types.package;
+          readOnly = true;
+        };
       };
 
       config = {
         teslamate = {
-          inherit cldr elixir;
+          inherit cldr elixir rebar3;
         };
 
         packages = {

--- a/website/docs/development.mdx
+++ b/website/docs/development.mdx
@@ -233,14 +233,14 @@ When reviewing a pull request that updates dependencies, it's crucial to verify 
 
 - `nix flake check ...`: Verifies the flake's integrity across different systems.
 - `nix build ...`: Ensures the project builds successfully with the new dependencies.
-- `nix develop ... --command treefmt`: Checks if the code formatting still runs.
+- `nix run .#lint`: Checks if the code formatting still runs.
 - `devenv up`: Confirms that the development environment starts up as expected.
 
 ```bash
 # Run these commands to ensure everything works as expected
 nix flake check --override-input devenv-root "file+file://"<(printf %s "$PWD") . --all-systems
 nix build --override-input devenv-root "file+file://"<(printf %s "$PWD")
-nix develop --override-input devenv-root "file+file://"<(printf %s "$PWD") . --command treefmt
+nix run .#lint
 devenv up
 ```
 

--- a/website/docs/development.mdx
+++ b/website/docs/development.mdx
@@ -63,10 +63,10 @@ Install [Treefmt](https://github.com/numtide/treefmt/releases) or use nix develo
 treefmt
 ```
 
-or with nix, when not using direnv:
+or with nix flake app, when not using direnv:
 
 ```bash
-nix develop --override-input devenv-root "file+file://"<(printf %s "$PWD") . --command treefmt
+nix run .#lint
 ```
 
 You can even use a VS Code extension like [treefmt](https://marketplace.visualstudio.com/items?itemName=ibecker.treefmt-vscode) to format the files on save.


### PR DESCRIPTION
The check_linting job took ~17m because `nix develop` realised the full devenv shell (elixir-ls, postgres, nodejs, mosquitto, osv-scanner, …).
That closure is several GB and exceeds the cache GC budget, so it was garbage-collected before saving and rebuilt on every run.

Add a lean `.#lint` flake app (treefmt wrapper + the release Elixir) that runs `mix deps.get` and then `exec treefmt "$@"`, so CI calls `nix run .#lint -- --ci` and `--ci` is just a pass-through arg. Also bump gc-max-store-size to 2G so the small closure is actually cached.

Expose `teslamate.rebar3` from package.nix as the single source of truth and use it in both the devenv and lint setups, replacing the hardcoded `beam27Packages.rebar3` (erlang 27) that did not match the project's erlang_28 toolchain.