### PR TITLE
test: harden async waits

### DIFF
--- a/test/teslamate/terrain_test.exs
+++ b/test/teslamate/terrain_test.exs
@@ -100,14 +100,9 @@ defmodule TeslaMate.TerrainTest do
       assert Terrain.get_elevation(name, {0, 0}) == nil
 
       # circuit broke after 3 attempts
-      TestHelper.eventually(
-        fn ->
-          assert_received {SRTM, {:get_elevation, 0, 0, _opts}}
-          assert_received {SRTM, {:get_elevation, 0, 0, _opts}}
-          assert_received {SRTM, {:get_elevation, 0, 0, _opts}}
-        end,
-        attempts: 25
-      )
+      assert_receive {SRTM, {:get_elevation, 0, 0, _opts}}, 1_000
+      assert_receive {SRTM, {:get_elevation, 0, 0, _opts}}, 1_000
+      assert_receive {SRTM, {:get_elevation, 0, 0, _opts}}, 1_000
 
       refute_receive _
     end

--- a/test/teslamate/updater_test.exs
+++ b/test/teslamate/updater_test.exs
@@ -39,19 +39,25 @@ defmodule TeslaMate.UpdaterTest do
     with_mocks HTTPMocck.vsn("v5.1.2") do
       ## current_version > new_version
       {:ok, pid} = start_updater(name, "5.1.3-dev", id: 0)
-      Process.sleep(100)
+      assert_update_check_count(1)
       assert nil == Updater.get_update(pid)
 
       ## current_version == new_version
       {:ok, pid} = start_updater(name, "5.1.2", id: 1)
-      Process.sleep(100)
+      assert_update_check_count(2)
       assert nil == Updater.get_update(pid)
 
       ## current_version < new_version
       {:ok, pid} = start_updater(name, "4.99.0", id: 2)
-      Process.sleep(100)
+      assert_update_check_count(3)
       assert "5.1.2" == Updater.get_update(pid)
     end
+  end
+
+  defp assert_update_check_count(count) do
+    TestHelper.eventually(fn ->
+      assert_called_at_least(Tesla.Adapter.Finch.call(:_, :_), count)
+    end)
   end
 
   test "returns early even though update check is still in progress", %{test: name} do

--- a/test/teslamate/vehicles/vehicle_test.exs
+++ b/test/teslamate/vehicles/vehicle_test.exs
@@ -77,7 +77,7 @@ defmodule TeslaMate.Vehicles.VehicleTest do
 
       :ok = start_vehicle(name, events)
 
-      assert_receive {:start_state, car, :online, date: _}, 100
+      assert_receive {:start_state, car, :online, date: _}
       assert_receive {ApiMock, {:stream, 1000, _}}
       assert_receive {:insert_position, ^car, %{}}
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
@@ -108,7 +108,7 @@ defmodule TeslaMate.Vehicles.VehicleTest do
 
       assert :ok = Vehicle.resume_logging(name)
 
-      assert_receive {:start_state, ^car, :online, date: _}, 100
+      assert_receive {:start_state, ^car, :online, date: _}
       assert_receive {ApiMock, {:stream, 1000, _}}
       assert_receive {:insert_position, ^car, %{}}
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
@@ -137,7 +137,7 @@ defmodule TeslaMate.Vehicles.VehicleTest do
 
       assert :ok = Vehicle.resume_logging(name)
 
-      assert_receive {:start_state, ^car, :online, date: _}, 100
+      assert_receive {:start_state, ^car, :online, date: _}
       assert_receive {ApiMock, {:stream, 1000, _}}
       assert_receive {:insert_position, ^car, %{}}
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
@@ -551,7 +551,7 @@ defmodule TeslaMate.Vehicles.VehicleTest do
       assert_receive {:insert_position, ^car, %{}}
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
 
-      refute_receive _
+      refute_receive _, 100
     end
   end
 end

--- a/test/teslamate_web/live/car_summary_live_test.exs
+++ b/test/teslamate_web/live/car_summary_live_test.exs
@@ -240,8 +240,12 @@ defmodule TeslaMateWeb.CarLive.SummaryTest do
       |> element(".button", "cancel sleep attempt")
       |> render_click()
 
-      assert html = render(view)
-      assert table_row(html, "Status", "online")
+      TestHelper.eventually(
+        fn ->
+          view |> render() |> table_row("Status", "online")
+        end,
+        delay: 5
+      )
     end
   end
 


### PR DESCRIPTION
## Summary

- replace a fixed sleep with the existing `TestHelper.eventually/1` helper
- avoid timing-sensitive receive assertions in a few async tests
- keep mailbox silence checks bounded where needed

## Context

Extracted from #5452 after maintainer feedback that the test hardening stands well on its own.

## Checks

- `mix format --check-formatted`
- `mix test test/teslamate/terrain_test.exs test/teslamate/updater_test.exs test/teslamate/vehicles/vehicle_test.exs test/teslamate_web/live/car_summary_live_test.exs` -> 50 passed
- `mix test --warnings-as-errors` -> 339 passed
- `mix ci` -> 339 passed
