### PR TITLE
fix: redact Tesla API tokens from logs

### DIFF
--- a/lib/tesla_api.ex
+++ b/lib/tesla_api.ex
@@ -2,6 +2,9 @@ defmodule TeslaApi do
   use Tesla
 
   @version Mix.Project.config()[:version]
+  @redacted "[redacted]"
+  @sensitive_headers ~w(Authorization authorization)
+  @sensitive_query_params ~w(access_token refresh_token token)
 
   adapter Tesla.Adapter.Finch, name: TeslaMate.HTTP, receive_timeout: 35_000
 
@@ -9,9 +12,59 @@ defmodule TeslaApi do
   plug Tesla.Middleware.Headers, [{"user-agent", "TeslaMate/#{@version}"}]
   plug Tesla.Middleware.JSON
   plug TeslaApi.Middleware.TokenAuth
-  plug Tesla.Middleware.Logger, debug: true, log_level: &log_level/1
+
+  plug Tesla.Middleware.Logger,
+    debug: true,
+    filter_headers: @sensitive_headers,
+    format: &__MODULE__.format_log/3,
+    log_level: &log_level/1
+
+  def format_log(%Tesla.Env{} = request, response, time) do
+    [
+      request.method |> to_string() |> String.upcase(),
+      " ",
+      redact_url(request.url),
+      " -> ",
+      response_status(response),
+      " (",
+      :io_lib.format("~.3f", [time / 1000]),
+      " ms)"
+    ]
+  end
 
   defp log_level(%Tesla.Env{} = env) when env.status >= 500, do: :warning
   defp log_level(%Tesla.Env{} = env) when env.status >= 400, do: :info
   defp log_level(%Tesla.Env{}), do: :debug
+
+  defp response_status({:ok, %Tesla.Env{} = env}), do: to_string(env.status)
+  defp response_status({:error, reason}), do: "error: " <> inspect(reason)
+
+  defp redact_url(url) when is_binary(url) do
+    uri = URI.parse(url)
+
+    case uri.query do
+      nil ->
+        url
+
+      query ->
+        query =
+          query
+          |> URI.decode_query()
+          |> Map.new(fn {key, value} ->
+            if sensitive_query_param?(key), do: {key, @redacted}, else: {key, value}
+          end)
+          |> URI.encode_query()
+
+        URI.to_string(%URI{uri | query: query})
+    end
+  rescue
+    _ -> url
+  end
+
+  defp redact_url(url), do: url
+
+  defp sensitive_query_param?(key) when is_binary(key),
+    do: key |> String.downcase() |> then(&(&1 in @sensitive_query_params))
+
+  defp sensitive_query_param?(_key), do: false
 end

--- a/lib/tesla_api/error.ex
+++ b/lib/tesla_api/error.ex
@@ -1,6 +1,10 @@
 defmodule TeslaApi.Error do
   defexception [:reason, :message, :env]
 
+  @redacted "[redacted]"
+  @sensitive_keys ~w(access_token refresh_token token authorization)
+  @sensitive_headers ~w(authorization)
+
   @impl true
   def message(%__MODULE__{message: message}) when is_binary(message), do: message
   def message(%__MODULE__{reason: e}) when is_exception(e), do: Exception.message(e)
@@ -24,7 +28,7 @@ defmodule TeslaApi.Error do
           nil
       end
 
-    {:error, %__MODULE__{reason: reason, message: message, env: env}}
+    {:error, %__MODULE__{reason: reason, message: message, env: redact_env(env)}}
   end
 
   def into({:error, reason}, _reason) when is_atom(reason) do
@@ -33,5 +37,93 @@ defmodule TeslaApi.Error do
 
   def into({:error, error}, reason) do
     {:error, %__MODULE__{reason: reason, message: error}}
+  end
+
+  def redacted(%__MODULE__{} = error) do
+    %__MODULE__{error | env: redact_env(error.env)}
+  end
+
+  defp redact_env(%Tesla.Env{} = env) do
+    %Tesla.Env{
+      env
+      | url: redact_url(env.url),
+        query: redact_pairs(env.query),
+        headers: redact_headers(env.headers),
+        opts: redact_pairs(env.opts)
+    }
+  end
+
+  defp redact_env(env), do: env
+
+  defp redact_headers(headers) when is_list(headers) do
+    Enum.map(headers, fn
+      {key, value} when is_binary(key) ->
+        if sensitive_header?(key), do: {key, @redacted}, else: {key, value}
+
+      other ->
+        other
+    end)
+  end
+
+  defp redact_headers(headers), do: headers
+
+  defp redact_url(url) when is_binary(url) do
+    uri = URI.parse(url)
+
+    case uri.query do
+      nil ->
+        url
+
+      query ->
+        query =
+          query
+          |> URI.decode_query()
+          |> Map.new(fn {key, value} ->
+            if sensitive_key?(key), do: {key, @redacted}, else: {key, value}
+          end)
+          |> URI.encode_query()
+
+        URI.to_string(%URI{uri | query: query})
+    end
+  rescue
+    _ -> url
+  end
+
+  defp redact_url(url), do: url
+
+  defp redact_pairs(values) when is_list(values) do
+    Enum.map(values, fn
+      {key, value} when is_atom(key) or is_binary(key) ->
+        if sensitive_key?(key), do: {key, @redacted}, else: {key, value}
+
+      value ->
+        value
+    end)
+  end
+
+  defp redact_pairs(values), do: values
+
+  defp sensitive_key?(key) when is_atom(key), do: key |> Atom.to_string() |> sensitive_key?()
+
+  defp sensitive_key?(key) when is_binary(key),
+    do: key |> String.downcase() |> then(&(&1 in @sensitive_keys))
+
+  defp sensitive_key?(_key), do: false
+
+  defp sensitive_header?(key) do
+    key
+    |> String.downcase()
+    |> then(&(&1 in @sensitive_headers))
+  end
+end
+
+defimpl Inspect, for: TeslaApi.Error do
+  def inspect(error, opts) do
+    error = TeslaApi.Error.redacted(error)
+    fields = [%{field: :reason}, %{field: :message}, %{field: :env}]
+
+    error
+    |> Map.from_struct()
+    |> Inspect.Map.inspect_as_struct("TeslaApi.Error", fields, opts)
   end
 end

--- a/lib/tesla_api/middleware/follow_redirects.ex
+++ b/lib/tesla_api/middleware/follow_redirects.ex
@@ -101,9 +101,14 @@ defmodule TeslaApi.Middleware.FollowRedirects do
   @filter_headers ["authorization", "host"]
   defp filter_headers(env, prev, next) do
     if next.host != prev.host || next.port != prev.port || next.scheme != prev.scheme do
-      %{env | headers: Enum.filter(env.headers, fn {k, _} -> k not in @filter_headers end)}
+      %{env | headers: Enum.reject(env.headers, &filtered_header?/1)}
     else
       env
     end
   end
+
+  defp filtered_header?({key, _value}) when is_binary(key),
+    do: key |> String.downcase() |> then(&(&1 in @filter_headers))
+
+  defp filtered_header?(_header), do: false
 end

--- a/test/tesla_api/error_test.exs
+++ b/test/tesla_api/error_test.exs
@@ -1,0 +1,66 @@
+defmodule TeslaApi.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias TeslaApi.Error
+
+  test "redacts access tokens when inspected" do
+    secret = "secret-access-token"
+
+    {:error, error} =
+      Error.into(
+        {:ok,
+         %Tesla.Env{
+           method: :get,
+           url: "https://owner-api.teslamotors.com/api/1/vehicles/1/vehicle_data?token=#{secret}",
+           query: [token: secret],
+           headers: [{"authorization", "Bearer #{secret}"}],
+           opts: [access_token: secret]
+         }}
+      )
+
+    inspected = inspect(error, pretty: true)
+
+    refute inspected =~ secret
+    assert inspected =~ "[redacted]"
+  end
+
+  test "redacts access tokens when directly constructed errors are inspected" do
+    secret = "secret-access-token"
+
+    error = %Error{
+      reason: :vehicle_unavailable,
+      env: %Tesla.Env{
+        method: :get,
+        url: "https://owner-api.teslamotors.com/api/1/vehicles/1/vehicle_data?token=#{secret}",
+        query: [token: secret],
+        headers: [{"authorization", "Bearer #{secret}"}],
+        opts: [access_token: secret]
+      }
+    }
+
+    inspected = inspect(error, pretty: true)
+
+    refute inspected =~ secret
+    assert inspected =~ "[redacted]"
+  end
+
+  test "keeps non-sensitive Tesla env details when inspected" do
+    {:error, error} =
+      Error.into(
+        {:ok,
+         %Tesla.Env{
+           method: :get,
+           url: "https://owner-api.teslamotors.com/api/1/vehicles/1/vehicle_data",
+           query: [endpoints: "charge_state"],
+           headers: [{"x-request-id", "request-id"}],
+           opts: [receive_timeout: 35_000]
+         }}
+      )
+
+    inspected = inspect(error, pretty: true)
+
+    assert inspected =~ "charge_state"
+    assert inspected =~ "request-id"
+    assert inspected =~ "35000"
+  end
+end

--- a/test/tesla_api/middleware/follow_redirects_test.exs
+++ b/test/tesla_api/middleware/follow_redirects_test.exs
@@ -1,0 +1,45 @@
+defmodule TeslaApi.Middleware.FollowRedirectsTest do
+  use ExUnit.Case, async: true
+
+  alias TeslaApi.Middleware.FollowRedirects
+
+  test "strips authorization and host headers case-insensitively on cross-origin redirects" do
+    parent = self()
+    secret = "secret-access-token"
+
+    adapter = fn
+      %Tesla.Env{url: "https://owner-api.teslamotors.com/start"} = env ->
+        {:ok,
+         %{
+           env
+           | status: 302,
+             headers: [{"location", "https://fleet-api.prd.na.vn.cloud.tesla.com/next"}]
+         }}
+
+      %Tesla.Env{url: "https://fleet-api.prd.na.vn.cloud.tesla.com/next"} = env ->
+        send(parent, {:redirected_headers, env.headers})
+        {:ok, %{env | status: 200, headers: [], body: nil}}
+    end
+
+    env = %Tesla.Env{
+      method: :get,
+      url: "https://owner-api.teslamotors.com/start",
+      headers: [
+        {"Authorization", "Bearer #{secret}"},
+        {"authorization", "Bearer lowercase-token"},
+        {"Host", "owner-api.teslamotors.com"},
+        {"host", "owner-api.teslamotors.com"},
+        {"x-request-id", "request-id"}
+      ]
+    }
+
+    assert {:ok, %Tesla.Env{status: 200}} = FollowRedirects.call(env, fn: adapter)
+    assert_receive {:redirected_headers, headers}
+
+    refute {"Authorization", "Bearer #{secret}"} in headers
+    refute {"authorization", "Bearer lowercase-token"} in headers
+    refute {"Host", "owner-api.teslamotors.com"} in headers
+    refute {"host", "owner-api.teslamotors.com"} in headers
+    assert {"x-request-id", "request-id"} in headers
+  end
+end

--- a/test/tesla_api_test.exs
+++ b/test/tesla_api_test.exs
@@ -1,0 +1,60 @@
+defmodule TeslaApiTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  test "redacts token query params from request logs" do
+    secret = "secret-query-token"
+
+    log =
+      %Tesla.Env{
+        method: :get,
+        url: "https://owner-api.teslamotors.com/api/1/vehicles/1/vehicle_data?token=#{secret}"
+      }
+      |> TeslaApi.format_log({:ok, %Tesla.Env{status: 408}}, 18_345)
+      |> IO.iodata_to_binary()
+
+    refute log =~ secret
+    assert log =~ "redacted"
+    assert log =~ "GET https://owner-api.teslamotors.com"
+    assert log =~ "-> 408"
+  end
+
+  test "filters capitalized authorization headers from debug logs" do
+    secret = "secret-access-token"
+
+    level = Logger.level()
+    Logger.configure(level: :debug)
+
+    log =
+      try do
+        capture_log(fn ->
+          assert {:ok, %Tesla.Env{status: 200}} =
+                   Tesla.Middleware.Logger.call(
+                     %Tesla.Env{
+                       method: :get,
+                       url: "https://owner-api.teslamotors.com/api/1/vehicles",
+                       headers: [{"Authorization", "Bearer #{secret}"}]
+                     },
+                     [fn: fn env -> {:ok, %{env | status: 200, headers: [], body: nil}} end],
+                     tesla_api_logger_opts()
+                   )
+        end)
+      after
+        Logger.configure(level: level)
+      end
+
+    refute log =~ secret
+    assert log =~ "Authorization: [FILTERED]"
+  end
+
+  defp tesla_api_logger_opts do
+    TeslaApi.__middleware__()
+    |> Enum.find(fn
+      {Tesla.Middleware.Logger, :call, [_opts]} -> true
+      _middleware -> false
+    end)
+    |> elem(2)
+    |> List.first()
+  end
+end


### PR DESCRIPTION
## Summary
- redact token-like query params from Tesla API request log lines
- filter authorization headers in Tesla middleware debug logs
- redact token-bearing Tesla.Env fields when TeslaApi.Error values are inspected, including directly constructed errors

Closes #4902

## Checks
- `mix format --check-formatted`
- `mix test test/tesla_api_test.exs test/tesla_api/error_test.exs test/teslamate/api_test.exs` -> 23 passed
- `MIX_ENV=test ELIXIR_ASSERT_TIMEOUT=1000 mix ci` -> 343 passed