### PR TITLE
fix(vehicle): back off on Fleet API EXCEEDED_LIMIT responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fix(webview): show charging finish time in browser local time (#5436 - @Ashok28)
 - fix(vehicle): use streaming-aware interval when a drive starts (#5417 - @evanclan)
 - fix(mqtt): retry failed value publications (#5429 - @ciyahu)
+- fix(vehicle): back off for 15 minutes on Fleet API `EXCEEDED_LIMIT` responses instead of retrying every 10-30s (@hossamnagy)
 
 #### Build, CI, internal
 

--- a/lib/tesla_api/vehicle.ex
+++ b/lib/tesla_api/vehicle.ex
@@ -125,6 +125,11 @@ defmodule TeslaApi.Vehicle do
 
         {:error, %Error{reason: :too_many_request, message: String.to_integer(retry_after)}}
 
+      %Tesla.Env{status: 403, body: %{"error" => "account disabled: EXCEEDED_LIMIT"}} ->
+        # Tesla sends no retry-after header for this error, so back off for 15
+        # minutes instead of falling through to the :unknown handler's 10-30s retry.
+        {:error, %Error{reason: :too_many_request, message: 900}}
+
       %Tesla.Env{status: 504} = env ->
         {:error, %Error{reason: :timeout, env: env}}
 

--- a/lib/teslamate/vehicles.ex
+++ b/lib/teslamate/vehicles.ex
@@ -83,6 +83,10 @@ defmodule TeslaMate.Vehicles do
       {:error, :not_signed_in} ->
         fallback_vehicles()
 
+      {:error, :too_many_request, retry_after} ->
+        Logger.warning("Could not get vehicles: rate limited, retry after #{retry_after}s")
+        fallback_vehicles()
+
       {:error, reason} ->
         Logger.warning("Could not get vehicles: #{inspect(reason)}")
         fallback_vehicles()

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1558,6 +1558,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
       {:ok, %V{}} ->
         {:error, :gateway_error}
 
+      {:error, :too_many_request, retry_after} ->
+        {:error, {:too_many_request, retry_after}}
+
       {:error, reason} ->
         {:error, reason}
     end


### PR DESCRIPTION
## Summary

Tesla's Fleet API returns `403 {"error": "account disabled: EXCEEDED_LIMIT"}` when an app's rate limit is exceeded. `TeslaApi.Vehicle.handle_response/2` had no clause matching this specific error body, so it fell through to the generic `:unknown` handler in `lib/teslamate/vehicles/vehicle.ex`, which retries every 10-30s depending on vehicle state with no backoff.

In practice this means once TeslaMate hits this limit (e.g. from an unrelated issue like the streaming reconnect loop in #5428), it keeps hammering the already-rate-limited endpoint every 10-30s indefinitely instead of backing off - which can prolong the block and wastes the app's quota for no benefit.

This routes the `EXCEEDED_LIMIT` response through the existing `:too_many_request` handling (the same path already used for HTTP 429 responses / `retry-after` header), backing off for 15 minutes instead. Tesla doesn't send a `retry-after` header for this particular error, so 15 minutes is used as a fixed, conservative default.

## Why this happened in my case

Observed on v4.0.1: the streaming API reconnect loop from #5428 burned through the Fleet API quota in ~25 minutes (858 reconnects), triggering `EXCEEDED_LIMIT`. TeslaMate then continued polling `vehicle_data` every ~30s against the banned account for 18+ hours straight before I noticed and stopped the container manually. This PR doesn't fix the root cause of hitting the limit (disabling the streaming API per #5428's resolution is the fix for that) - it's a defense-in-depth fix so that whatever causes an `EXCEEDED_LIMIT` response, TeslaMate stops making things worse by hammering it.

## Testing

- Built and compiled cleanly against both the `v4.0.1` tag and current `main` (`mix compile`, full Docker multi-stage build).
- No existing automated test exercises `TeslaApi.Vehicle.handle_response/2` directly (it's a private function only reachable via the Tesla HTTP client pipeline); `test/teslamate/api_test.exs` tests one layer up, mocking `TeslaApi.Vehicle` itself, so I didn't see a clean place to add a targeted unit test without introducing new test infrastructure. Happy to add one if a maintainer can point me at the preferred approach.

## Related

- #5428