### PR TITLE
perf: use existing indexes for latest-position lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - fix(import): accept fractional TeslaFi battery levels (#5513 - @magrathean-uk)
 - fix(cars): enforce non-null VINs (#5512 - @magrathean-uk)
 - fix(mqtt): return publish errors without crashing (#5514 - @magrathean-uk)
-- fix(performance): use existing indexes for latest-position lookups to avoid sequential scans on large databases (#5306 - @magrathean-uk)
+- fix(performance): use existing indexes for latest-position lookups to avoid sequential scans on large databases (#5483 - @magrathean-uk)
 
 #### Build, CI, internal
 
@@ -54,7 +54,7 @@
 
 #### Dashboards
 
-- fix(dashboards): filter latest-value position panels on complete rows so they use the partial index (#5306 - @magrathean-uk)
+- fix(dashboards): filter latest-value position panels on complete rows so they use the partial index (#5483 - @magrathean-uk)
 
 #### Translations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fix(import): accept fractional TeslaFi battery levels (#5513 - @magrathean-uk)
 - fix(cars): enforce non-null VINs (#5512 - @magrathean-uk)
 - fix(mqtt): return publish errors without crashing (#5514 - @magrathean-uk)
+- fix(performance): use existing indexes for latest-position lookups to avoid sequential scans on large databases (#5306 - @magrathean-uk)
 
 #### Build, CI, internal
 
@@ -52,6 +53,8 @@
 - test: reuse API snapshots across paired fetches (#5510 - @magrathean-uk)
 
 #### Dashboards
+
+- fix(dashboards): filter latest-value position panels on complete rows so they use the partial index (#5306 - @magrathean-uk)
 
 #### Translations
 

--- a/grafana/dashboards/battery-health.json
+++ b/grafana/dashboards/battery-health.json
@@ -1089,7 +1089,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT * FROM ((SELECT usable_battery_level, date\r\nFROM positions\r\nWHERE car_id = $car_id AND ideal_battery_range_km IS NOT NULL AND usable_battery_level IS NOT NULL\r\nORDER BY date DESC\r\nLIMIT 1)\r\nUNION\r\n(SELECT usable_battery_level, date\r\nFROM charges c\r\nJOIN charging_processes p ON p.id = c.charging_process_id\r\nWHERE p.car_id = $car_id AND usable_battery_level IS NOT NULL\r\nORDER BY date DESC\r\nLIMIT 1)) AS last_usable_battery_level LIMIT 1",
+          "rawSql": "SELECT * FROM ((SELECT usable_battery_level, date\r\nFROM positions\r\nWHERE car_id = $car_id AND ideal_battery_range_km IS NOT NULL AND usable_battery_level IS NOT NULL\r\nORDER BY date DESC\r\nLIMIT 1)\r\nUNION ALL\r\n(SELECT c.usable_battery_level, date\r\nFROM charges c\r\nJOIN charging_processes p ON p.id = c.charging_process_id\r\nWHERE p.car_id = $car_id AND c.usable_battery_level IS NOT NULL\r\nORDER BY date DESC\r\nLIMIT 1)) AS last_usable_battery_level ORDER BY date DESC LIMIT 1",
           "refId": "SOC",
           "sql": {
             "columns": [
@@ -1365,7 +1365,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT * FROM ((SELECT usable_battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM positions\nWHERE car_id = $car_id AND ideal_battery_range_km IS NOT NULL AND usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)\nUNION\n(SELECT c.usable_battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM charges c\nJOIN charging_processes p ON p.id = c.charging_process_id\nWHERE p.car_id = $car_id  AND c.usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)) AS last_usable_battery_level LIMIT 1",
+          "rawSql": "SELECT * FROM ((SELECT usable_battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM positions\nWHERE car_id = $car_id AND ideal_battery_range_km IS NOT NULL AND usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)\nUNION ALL\n(SELECT c.usable_battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM charges c\nJOIN charging_processes p ON p.id = c.charging_process_id\nWHERE p.car_id = $car_id  AND c.usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)) AS last_usable_battery_level ORDER BY date DESC LIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [

--- a/grafana/dashboards/battery-health.json
+++ b/grafana/dashboards/battery-health.json
@@ -1365,7 +1365,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT * FROM ((SELECT usable_battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM positions\nWHERE car_id = $car_id AND ideal_battery_range_km IS NOT NULL AND usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)\nUNION\n(SELECT battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM charges c\nJOIN charging_processes p ON p.id = c.charging_process_id\nWHERE p.car_id = $car_id  AND usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)) AS last_usable_battery_level LIMIT 1",
+          "rawSql": "SELECT * FROM ((SELECT usable_battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM positions\nWHERE car_id = $car_id AND ideal_battery_range_km IS NOT NULL AND usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)\nUNION\n(SELECT c.usable_battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM charges c\nJOIN charging_processes p ON p.id = c.charging_process_id\nWHERE p.car_id = $car_id  AND c.usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)) AS last_usable_battery_level LIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [

--- a/grafana/dashboards/battery-health.json
+++ b/grafana/dashboards/battery-health.json
@@ -1089,7 +1089,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT * FROM ((SELECT usable_battery_level, date\r\nFROM positions\r\nWHERE car_id = $car_id AND usable_battery_level IS NOT NULL\r\nORDER BY date DESC\r\nLIMIT 1)\r\nUNION\r\n(SELECT usable_battery_level, date\r\nFROM charges c\r\nJOIN charging_processes p ON p.id = c.charging_process_id\r\nWHERE p.car_id = $car_id AND usable_battery_level IS NOT NULL\r\nORDER BY date DESC\r\nLIMIT 1)) AS last_usable_battery_level LIMIT 1",
+          "rawSql": "SELECT * FROM ((SELECT usable_battery_level, date\r\nFROM positions\r\nWHERE car_id = $car_id AND ideal_battery_range_km IS NOT NULL AND usable_battery_level IS NOT NULL\r\nORDER BY date DESC\r\nLIMIT 1)\r\nUNION\r\n(SELECT usable_battery_level, date\r\nFROM charges c\r\nJOIN charging_processes p ON p.id = c.charging_process_id\r\nWHERE p.car_id = $car_id AND usable_battery_level IS NOT NULL\r\nORDER BY date DESC\r\nLIMIT 1)) AS last_usable_battery_level LIMIT 1",
           "refId": "SOC",
           "sql": {
             "columns": [
@@ -1365,7 +1365,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT * FROM ((SELECT usable_battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM positions\nWHERE car_id = $car_id  AND usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)\nUNION\n(SELECT battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM charges c\nJOIN charging_processes p ON p.id = c.charging_process_id\nWHERE p.car_id = $car_id  AND usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)) AS last_usable_battery_level LIMIT 1",
+          "rawSql": "SELECT * FROM ((SELECT usable_battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM positions\nWHERE car_id = $car_id AND ideal_battery_range_km IS NOT NULL AND usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)\nUNION\n(SELECT battery_level * ('$aux'::json ->> 'CurrentCapacity')::float / 100 as kWh, date, ('$aux'::json ->> 'CurrentCapacity')::float as Total\nFROM charges c\nJOIN charging_processes p ON p.id = c.charging_process_id\nWHERE p.car_id = $car_id  AND usable_battery_level IS NOT NULL\nORDER BY date DESC\nLIMIT 1)) AS last_usable_battery_level LIMIT 1",
           "refId": "A",
           "sql": {
             "columns": [

--- a/grafana/dashboards/overview.json
+++ b/grafana/dashboards/overview.json
@@ -1597,7 +1597,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n\t$__time(date),\r\n\tconvert_celsius(driver_temp_setting, '$temp_unit') as \"Driver Temperature [°$temp_unit]\",\r\n\tconvert_celsius(inside_temp, '$temp_unit') AS \"Inside Temperature [°$temp_unit]\"\r\nFROM positions\r\nWHERE driver_temp_setting IS NOT NULL AND inside_temp IS NOT NULL AND car_id = $car_id AND date >= (TIMEZONE('UTC', NOW()) - INTERVAL '60m')\r\nORDER BY date DESC\r\nLIMIT 1;",
+          "rawSql": "SELECT\r\n\t$__time(date),\r\n\tconvert_celsius(driver_temp_setting, '$temp_unit') as \"Driver Temperature [°$temp_unit]\",\r\n\tconvert_celsius(inside_temp, '$temp_unit') AS \"Inside Temperature [°$temp_unit]\"\r\nFROM positions\r\nWHERE driver_temp_setting IS NOT NULL AND inside_temp IS NOT NULL AND ideal_battery_range_km IS NOT NULL AND car_id = $car_id AND date >= (TIMEZONE('UTC', NOW()) - INTERVAL '60m')\r\nORDER BY date DESC\r\nLIMIT 1;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -1704,7 +1704,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH last_position AS (\n\tSELECT date, convert_celsius(outside_temp, '$temp_unit') AS \"Outside Temperature [°$temp_unit]\"\n\tFROM positions\n\tWHERE car_id = $car_id AND outside_temp IS NOT NULL AND date >= (TIMEZONE('UTC', NOW()) - INTERVAL '60m')\n\tORDER BY date DESC\n\tLIMIT 1\n),\nlast_charge AS (\n\tSELECT date, convert_celsius(outside_temp, '$temp_unit') AS \"Outside Temperature [°$temp_unit]\"\n\tFROM charges\n\tJOIN charging_processes ON charges.charging_process_id = charging_processes.id\n\tWHERE car_id = $car_id AND outside_temp IS NOT NULL AND date >= (TIMEZONE('UTC', NOW()) - INTERVAL '60m')\n\tORDER BY date DESC\n\tLIMIT 1\n)\nSELECT * FROM last_position\nUNION ALL\nSELECT * FROM last_charge\nORDER BY date DESC\nLIMIT 1;",
+          "rawSql": "WITH last_position AS (\n\tSELECT date, convert_celsius(outside_temp, '$temp_unit') AS \"Outside Temperature [°$temp_unit]\"\n\tFROM positions\n\tWHERE car_id = $car_id AND ideal_battery_range_km IS NOT NULL AND outside_temp IS NOT NULL AND date >= (TIMEZONE('UTC', NOW()) - INTERVAL '60m')\n\tORDER BY date DESC\n\tLIMIT 1\n),\nlast_charge AS (\n\tSELECT date, convert_celsius(outside_temp, '$temp_unit') AS \"Outside Temperature [°$temp_unit]\"\n\tFROM charges\n\tJOIN charging_processes ON charges.charging_process_id = charging_processes.id\n\tWHERE car_id = $car_id AND outside_temp IS NOT NULL AND date >= (TIMEZONE('UTC', NOW()) - INTERVAL '60m')\n\tORDER BY date DESC\n\tLIMIT 1\n)\nSELECT * FROM last_position\nUNION ALL\nSELECT * FROM last_charge\nORDER BY date DESC\nLIMIT 1;",
           "refId": "A",
           "sql": {
             "columns": [

--- a/lib/teslamate/log.ex
+++ b/lib/teslamate/log.ex
@@ -160,7 +160,7 @@ defmodule TeslaMate.Log do
   # the btree on positions(date) was replaced with BRIN. Only used to centre the
   # map when creating a geofence, where "most recently inserted position" is the
   # answer we want.
-  def get_latest_position do
+  def get_last_inserted_position do
     Position
     |> order_by(desc: :id)
     |> limit(1)

--- a/lib/teslamate/log.ex
+++ b/lib/teslamate/log.ex
@@ -155,16 +155,26 @@ defmodule TeslaMate.Log do
     |> Repo.insert()
   end
 
+  # Ordered by `id` (primary key) rather than `date` so this uses the
+  # always-present `positions_pkey` index instead of sequential-scanning after
+  # the btree on positions(date) was replaced with BRIN. Only used to centre the
+  # map when creating a geofence, where "most recently inserted position" is the
+  # answer we want.
   def get_latest_position do
     Position
-    |> order_by(desc: :date)
+    |> order_by(desc: :id)
     |> limit(1)
     |> Repo.one()
   end
 
+  # `ideal_battery_range_km IS NOT NULL` selects the latest *complete* position
+  # (full vehicle sample) and skips lightweight streaming-API rows, which never
+  # carry battery/climate data. It also matches the partial index
+  # `positions(car_id, date) WHERE ideal_battery_range_km IS NOT NULL`, so this
+  # resolves to an index scan instead of a sequential scan on large tables.
   def get_latest_position(%Car{id: id}) do
     Position
-    |> where(car_id: ^id)
+    |> where([p], p.car_id == ^id and not is_nil(p.ideal_battery_range_km))
     |> order_by(desc: :date)
     |> limit(1)
     |> Repo.one()

--- a/lib/teslamate_web/live/geofence_live/form.ex
+++ b/lib/teslamate_web/live/geofence_live/form.ex
@@ -33,7 +33,7 @@ defmodule TeslaMateWeb.GeoFenceLive.Form do
 
   def mount(_params, %{"settings" => settings}, socket) do
     %{latitude: lat, longitude: lng} =
-      case Log.get_latest_position() do
+      case Log.get_last_inserted_position() do
         %Position{latitude: lat, longitude: lng} -> %{latitude: lat, longitude: lng}
         nil -> %{latitude: 0.0, longitude: 0.0}
       end

--- a/test/teslamate/grafana/dashboard_queries_test.exs
+++ b/test/teslamate/grafana/dashboard_queries_test.exs
@@ -13,7 +13,7 @@ defmodule TeslaMate.Grafana.DashboardQueriesTest do
   #
   # `(?:(?!\bfrom\b).)*?` keeps a match from spilling across into a following
   # `FROM charges`/CTE, so the filter must appear inside the *same* positions block.
-  @latest_position_block ~r/from positions\b(?:(?!\bfrom\b).)*?order by date desc(?:(?!\bfrom\b).)*?limit 1/
+  @latest_position_block ~r/from positions\b(?:(?!\bfrom\b).)*?order by date desc(?:(?!\bfrom\b).)*?limit 1\b/
 
   test "latest position queries use complete position rows" do
     offenders =
@@ -46,6 +46,35 @@ defmodule TeslaMate.Grafana.DashboardQueriesTest do
         "ORDER BY date DESC LIMIT 1"
 
     assert unfiltered_latest_position_blocks(query) == []
+  end
+
+  test "detector ignores queries with a larger limit" do
+    query = "SELECT date FROM positions WHERE car_id = 1 ORDER BY date DESC LIMIT 10"
+
+    assert unfiltered_latest_position_blocks(query) == []
+  end
+
+  test "latest usable battery unions select the newest source row" do
+    queries =
+      "grafana/dashboards/battery-health.json"
+      |> dashboard_queries()
+      |> Enum.map(fn {_path, query} ->
+        query
+        |> String.downcase()
+        |> String.replace(~r/\s+/, " ")
+      end)
+      |> Enum.filter(&String.contains?(&1, "last_usable_battery_level"))
+
+    assert length(queries) == 2
+
+    for query <- queries do
+      assert String.contains?(query, "union all")
+
+      assert String.contains?(
+               query,
+               "as last_usable_battery_level order by date desc limit 1"
+             )
+    end
   end
 
   defp dashboard_queries(path) do

--- a/test/teslamate/grafana/dashboard_queries_test.exs
+++ b/test/teslamate/grafana/dashboard_queries_test.exs
@@ -1,0 +1,88 @@
+defmodule TeslaMate.Grafana.DashboardQueriesTest do
+  use ExUnit.Case, async: true
+
+  @query_keys ~w(definition query rawSql)
+
+  # A "latest position" lookup is a `FROM positions ... ORDER BY date DESC LIMIT 1`
+  # block. After the btree index on positions(date) was replaced with BRIN, such a
+  # block only stays fast if it also filters `ideal_battery_range_km IS NOT NULL`,
+  # which lets it use the partial index `positions(car_id, date) WHERE
+  # ideal_battery_range_km IS NOT NULL`. A query can contain several sub-blocks
+  # (e.g. a UNION of positions and charges), so we match each positions block on
+  # its own rather than searching the whole query string. See issue #5306.
+  #
+  # `(?:(?!\bfrom\b).)*?` keeps a match from spilling across into a following
+  # `FROM charges`/CTE, so the filter must appear inside the *same* positions block.
+  @latest_position_block ~r/from positions\b(?:(?!\bfrom\b).)*?order by date desc(?:(?!\bfrom\b).)*?limit 1/
+
+  test "latest position queries use complete position rows" do
+    offenders =
+      "grafana/dashboards/**/*.json"
+      |> Path.wildcard()
+      |> Enum.flat_map(&dashboard_queries/1)
+      |> Enum.flat_map(fn {path, query} ->
+        query
+        |> unfiltered_latest_position_blocks()
+        |> Enum.map(&"#{path}: #{&1}")
+      end)
+
+    assert offenders == []
+  end
+
+  test "detector flags a positions block missing the filter even when the token appears elsewhere" do
+    # Negative control: an unrelated CTE mentions the filter token, but the actual
+    # positions latest-block does not. A whole-string check would wrongly pass this.
+    query = """
+    WITH t AS (SELECT 1 WHERE ideal_battery_range_km IS NOT NULL)
+    SELECT date FROM positions WHERE car_id = 1 ORDER BY date DESC LIMIT 1
+    """
+
+    assert unfiltered_latest_position_blocks(query) != []
+  end
+
+  test "detector accepts a positions block that carries the filter" do
+    query =
+      "SELECT date FROM positions WHERE car_id = 1 AND ideal_battery_range_km IS NOT NULL " <>
+        "ORDER BY date DESC LIMIT 1"
+
+    assert unfiltered_latest_position_blocks(query) == []
+  end
+
+  defp dashboard_queries(path) do
+    path
+    |> File.read!()
+    |> Jason.decode!()
+    |> collect_queries()
+    |> Enum.map(&{path, &1})
+  end
+
+  defp collect_queries(%{} = value) do
+    own_queries =
+      value
+      |> Map.take(@query_keys)
+      |> Map.values()
+      |> Enum.filter(&is_binary/1)
+
+    child_queries =
+      value
+      |> Map.values()
+      |> Enum.flat_map(&collect_queries/1)
+
+    own_queries ++ child_queries
+  end
+
+  defp collect_queries(values) when is_list(values), do: Enum.flat_map(values, &collect_queries/1)
+  defp collect_queries(_value), do: []
+
+  defp unfiltered_latest_position_blocks(query) do
+    normalized =
+      query
+      |> String.downcase()
+      |> String.replace(~r/\s+/, " ")
+
+    @latest_position_block
+    |> Regex.scan(normalized)
+    |> List.flatten()
+    |> Enum.reject(&String.contains?(&1, "ideal_battery_range_km is not null"))
+  end
+end

--- a/test/teslamate/log/log_position_test.exs
+++ b/test/teslamate/log/log_position_test.exs
@@ -1,0 +1,85 @@
+defmodule TeslaMate.LogPositionTest do
+  use TeslaMate.DataCase, async: true
+
+  alias TeslaMate.Log
+
+  def car_fixture(attrs \\ %{}) do
+    {:ok, car} =
+      attrs
+      |> Enum.into(%{efficiency: 0.153, eid: 42, model: "M3", vid: 42, vin: "xxxxx"})
+      |> Log.create_car()
+
+    car
+  end
+
+  describe "get_latest_position/1" do
+    test "returns the latest complete position for a car" do
+      car = car_fixture()
+      other_car = car_fixture(eid: 43, vid: 43, vin: "yyyyy")
+
+      {:ok, complete_position} =
+        Log.insert_position(car, %{
+          date: ~U[2026-01-01 10:00:00Z],
+          latitude: 1.0,
+          longitude: 1.0,
+          ideal_battery_range_km: 300.0
+        })
+
+      {:ok, _incomplete_streaming_position} =
+        Log.insert_position(car, %{
+          date: ~U[2026-01-01 10:05:00Z],
+          latitude: 2.0,
+          longitude: 2.0
+        })
+
+      {:ok, _other_car_position} =
+        Log.insert_position(other_car, %{
+          date: ~U[2026-01-01 10:10:00Z],
+          latitude: 3.0,
+          longitude: 3.0,
+          ideal_battery_range_km: 200.0
+        })
+
+      assert %{id: id} = Log.get_latest_position(car)
+      assert id == complete_position.id
+    end
+
+    test "returns nil when a car only has incomplete streaming positions" do
+      car = car_fixture()
+
+      {:ok, _incomplete_streaming_position} =
+        Log.insert_position(car, %{
+          date: ~U[2026-01-01 10:05:00Z],
+          latitude: 2.0,
+          longitude: 2.0
+        })
+
+      assert Log.get_latest_position(car) == nil
+    end
+  end
+
+  describe "get_latest_position/0" do
+    test "returns the most recently inserted position across all cars, including incomplete ones" do
+      car = car_fixture()
+      other_car = car_fixture(eid: 43, vid: 43, vin: "yyyyy")
+
+      {:ok, _latest_by_date_position} =
+        Log.insert_position(car, %{
+          date: ~U[2026-01-01 10:00:00Z],
+          latitude: 1.0,
+          longitude: 1.0,
+          ideal_battery_range_km: 300.0
+        })
+
+      {:ok, latest_position} =
+        Log.insert_position(other_car, %{
+          date: ~U[2026-01-01 09:55:00Z],
+          latitude: 2.0,
+          longitude: 2.0
+        })
+
+      assert %{id: id} = Log.get_latest_position()
+      assert id == latest_position.id
+    end
+  end
+end

--- a/test/teslamate/log/log_position_test.exs
+++ b/test/teslamate/log/log_position_test.exs
@@ -58,7 +58,7 @@ defmodule TeslaMate.LogPositionTest do
     end
   end
 
-  describe "get_latest_position/0" do
+  describe "get_last_inserted_position/0" do
     test "returns the most recently inserted position across all cars, including incomplete ones" do
       car = car_fixture()
       other_car = car_fixture(eid: 43, vid: 43, vin: "yyyyy")
@@ -78,7 +78,7 @@ defmodule TeslaMate.LogPositionTest do
           longitude: 2.0
         })
 
-      assert %{id: id} = Log.get_latest_position()
+      assert %{id: id} = Log.get_last_inserted_position()
       assert id == latest_position.id
     end
   end

--- a/test/teslamate/log/log_position_test.exs
+++ b/test/teslamate/log/log_position_test.exs
@@ -4,9 +4,17 @@ defmodule TeslaMate.LogPositionTest do
   alias TeslaMate.Log
 
   def car_fixture(attrs \\ %{}) do
+    id = System.unique_integer([:positive, :monotonic])
+
     {:ok, car} =
       attrs
-      |> Enum.into(%{efficiency: 0.153, eid: 42, model: "M3", vid: 42, vin: "xxxxx"})
+      |> Enum.into(%{
+        efficiency: 0.153,
+        eid: id,
+        model: "M3",
+        vid: id,
+        vin: "test-#{id}"
+      })
       |> Log.create_car()
 
     car
@@ -15,7 +23,7 @@ defmodule TeslaMate.LogPositionTest do
   describe "get_latest_position/1" do
     test "returns the latest complete position for a car" do
       car = car_fixture()
-      other_car = car_fixture(eid: 43, vid: 43, vin: "yyyyy")
+      other_car = car_fixture()
 
       {:ok, complete_position} =
         Log.insert_position(car, %{
@@ -61,7 +69,7 @@ defmodule TeslaMate.LogPositionTest do
   describe "get_last_inserted_position/0" do
     test "returns the most recently inserted position across all cars, including incomplete ones" do
       car = car_fixture()
-      other_car = car_fixture(eid: 43, vid: 43, vin: "yyyyy")
+      other_car = car_fixture()
 
       {:ok, _latest_by_date_position} =
         Log.insert_position(car, %{


### PR DESCRIPTION
## Summary

This addresses #5306 with a query-only change: use existing indexes for latest-position lookups instead of adding another positions index.

- filter car-specific latest-position lookups to complete position rows so PostgreSQL can use the existing partial `(car_id, date)` index
- order the geofence map-centering lookup by `id` so it can use the primary key instead of sorting by `date`
- add the same complete-row filter to the dashboard latest-value position panels that were still doing `ORDER BY date DESC LIMIT 1` without the partial-index predicate
- add regression coverage for the log queries and a dashboard-query detector for unfiltered latest-position blocks

No migration, new index, repair action, or behavior outside these latest-value lookup paths.

## Validation

- `MIX_ENV=test DATABASE_PORT=55432 mix test test/teslamate/log/log_position_test.exs test/teslamate/grafana/dashboard_queries_test.exs`
- `mix format --check-formatted`
- `git diff --check`
- `MIX_ENV=test DATABASE_PORT=55432 mix ci`