### PR TITLE
fix(ci): add artifact-metadata permission for workflows as it is essential for generating attestations

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -21,6 +21,7 @@ permissions:
   packages: write
   id-token: write
   attestations: write
+  artifact-metadata: write
 
 jobs:
   check_paths:

--- a/.github/workflows/ghcr_build.yml
+++ b/.github/workflows/ghcr_build.yml
@@ -24,6 +24,7 @@ permissions:
   packages: write
   id-token: write
   attestations: write
+  artifact-metadata: write
 
 jobs:
   check_paths:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - test: harden async waits (#5456 - @magrathean-uk)
 - build(deps): update flake.lock (#5477)
 - ci: sign published images with SLSA provenance + SBOM attestations (#5380 - @oivindoh)
+- fix(ci): add artifact-metadata permission for workflows (#5484 - @JakobLichterfeld)
 
 #### Dashboards
 


### PR DESCRIPTION
follow up on #5380