### PR TITLE
docs: add TeslaMate Dash to the projects page

### DIFF
--- a/website/docs/projects.md
+++ b/website/docs/projects.md
@@ -104,3 +104,9 @@ LINK: [https://github.com/brchri/tesla-geogdo](https://github.com/brchri/tesla-g
 A gamification add-on for TeslaMate that analyzes your historical data to unlock achievements. It features a collection of badges based on driving milestones, charging habits, efficiency, and phantom drain, turning your ownership statistics into a fun progression system.
 
 LINK: [github.com/crstian19/teslamate-achievements](https://github.com/crstian19/teslamate-achievements)
+
+## [TeslaMate Dash](https://github.com/gmaslowski/teslamate-dash)
+
+A read-only, map-first dashboard for browsing your TeslaMate history without navigating Grafana. Every drive is drawn from its GPS trace and colored by speed; drives and charges open detail panels with speed/battery charts and charging curves, and a selection of activities can be turned into a route-planner-style trip summary. Ships as a single Go binary / Docker container (multi-arch images on GHCR) with a built-in demo mode, connects to the TeslaMate Postgres database with forced read-only sessions, and sends no telemetry.
+
+LINK: [github.com/gmaslowski/teslamate-dash](https://github.com/gmaslowski/teslamate-dash)


### PR DESCRIPTION
Adds [TeslaMate Dash](https://github.com/gmaslowski/teslamate-dash) to the *Projects using TeslaMate* page, following the existing entry format (appended at the end of the list).

TeslaMate Dash is a read-only, map-first dashboard for browsing TeslaMate history: speed-colored GPS traces for every drive, detail panels with speed/battery charts and charging curves, and a trip summary that turns a selection of drives and charges into an itinerary. It is a single Go binary / Docker container (multi-arch images on GHCR), connects to the TeslaMate Postgres database with forced read-only sessions, sends no telemetry, and never writes to TeslaMate. A demo mode with synthetic data lets anyone try it without a database.

Happy to adjust wording or placement if you prefer a different spot in the list.