### PR TITLE
docs: split the backup and restore guides into two separate guides and highlight that you should transfer your backup of the host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - docs: update star history chart links to new format in README (#5482 - @JakobLichterfeld)
 - docs: update star history links in README with to include the now needed sealed token (#5489 - @JakobLichterfeld)
 - docs: link directly to restore section in upgrading PostgreSQL guide (#5501 - @JakobLichterfeld)
+- docs: split the backup and restore guides into two separate guides and highlight that you should transfer your backup of the host (#5502 - @JakobLichterfeld)
 
 ## [4.0.1] - 2026-06-14
 
@@ -545,10 +546,10 @@ Enjoy it.
 
 **This is a breaking change release:** TeslaMate uses PostgreSQL as database, this is an external dependency and needs to be updated by yourself. We now require PostgreSQL 16.7 or 17.3 or higher as we are upgrading the bundled earthdistance extension to v1.2. TeslaMate will now fail to start if you are using an older version. Ensure to upgrade your database before upgrading TeslaMate. To upgrade PostgreSQL, you need to follow these instructions:
 
-- [Backup your data](https://docs.teslamate.org/docs/maintenance/backup_restore#backup)
+- [Backup your data](https://docs.teslamate.org/docs/maintenance/backup)
 - [Upgrade PostgreSQL to postgres:17](https://docs.teslamate.org/docs/maintenance/upgrading_postgres) (Yes, you will have to erase your data, which is why you need your backup in the first place.)
 - [Upgrade TeslaMate to this version](https://docs.teslamate.org/docs/upgrading)
-- [Backup your data after the upgrade](https://docs.teslamate.org/docs/maintenance/backup_restore#backup)
+- [Backup your data after the upgrade](https://docs.teslamate.org/docs/maintenance/backup)
 
 **Note for user which revoked permissions:** If the SUPERUSER privilege has been revoked after the initial (manual) installation, it must be temporarily granted for pending earthdistance migrations to succeed. The privilege can then be safely revoked.
 
@@ -800,9 +801,9 @@ As always, lots of improvements. The focus has been on performance improvements,
 
 **Regarding PostgreSQL 17:** TeslaMate uses PostgreSQL as database, this is an external dependency and needs to be updated by yourself. Although TeslaMate currently runs fine with PostgreSQL 14+ we strongly recommend upgrading to the latest supported version. We recommend that you do this as follows:
 
-- [Backup your data](https://docs.teslamate.org/docs/maintenance/backup_restore#backup)
+- [Backup your data](https://docs.teslamate.org/docs/maintenance/backup)
 - [Upgrade TeslaMate to this version](https://docs.teslamate.org/docs/upgrading)
-- [Backup your data after the upgrade](https://docs.teslamate.org/docs/maintenance/backup_restore#backup)
+- [Backup your data after the upgrade](https://docs.teslamate.org/docs/maintenance/backup)
 - [Upgrade PostgreSQL to postgres:17](https://docs.teslamate.org/docs/maintenance/upgrading_postgres) (Yes, you will have to erase your data, which is why you need your backup in the first place.)
 
 **Additional info:** In some very rare cases with very old installations of TeslaMate (from 2019) we have observed performance issues due to missing indexes. These should normally be added with our automatic migrations. If you think your installation may be missing some indexes, see #4201 for the corrective SQL command.

--- a/website/docs/import/tesla_apiscraper.md
+++ b/website/docs/import/tesla_apiscraper.md
@@ -11,7 +11,7 @@ This is a multi-step process to export your data from a [tesla-apiscraper](https
 
 - A system running Docker with sufficient RAM for InfluxDB to perform the CSV export. This does **not** need to be the same machine where API Scraper and/or TeslaMate was/is running - you can do the export and conversion on your PC/Mac. The important thing is to give the Docker machine more than 2GB of RAM, otherwise the InfluxDB export may fail.
 
-- **CREATE A [BACKUP](../maintenance/backup_restore.mdx) OF YOUR DATA** before attempting to import anything into TeslaMate. This is all highly experimental and has only been successfully done once :)
+- **CREATE A [BACKUP](../maintenance/backup.mdx) OF YOUR DATA** before attempting to import anything into TeslaMate. This is all highly experimental and has only been successfully done once :)
 
 ## Instructions
 

--- a/website/docs/import/teslafi.md
+++ b/website/docs/import/teslafi.md
@@ -5,7 +5,7 @@ sidebar_label: TeslaFi
 
 ## Requirements
 
-- **CREATE A [BACKUP](../maintenance/backup_restore.mdx) OF YOUR DATA‼️**
+- **CREATE A [BACKUP](../maintenance/backup.mdx) OF YOUR DATA‼️**
 
 - If you have been using TeslaMate since before the 1.16 release, the [docker-compose.yml](../installation/docker.md) needs to be updated. Add the following volume mapping to the `teslamate` service:
 

--- a/website/docs/installation/unsupported/debian.md
+++ b/website/docs/installation/unsupported/debian.md
@@ -154,8 +154,8 @@ sudo localectl set-locale LANG=en_US.UTF-8
 
 ## Starting TeslaMate at boot time
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 <Tabs
 defaultValue="systemd"

--- a/website/docs/maintenance/backup.mdx
+++ b/website/docs/maintenance/backup.mdx
@@ -1,6 +1,11 @@
 ---
-title: Backup and Restore
+title: Backup
+sidebar_label: Backup
 ---
+
+:::warning
+**For better protection, the created backup should be transferred off the host to an independent storage location, ensuring it cannot be overwritten or lost in the event of a host failure.**
+:::
 
 :::note
 If you are using `docker-compose`, you are using Docker Compose v1, which has been deprecated. Docker Compose commands refer to Docker Compose v2. Consider upgrading your docker setup, see [Migrate to Compose V2](https://docs.docker.com/compose/migrate/)
@@ -49,53 +54,6 @@ You can use the idiomatic backup script:
 
 ```bash
 teslamate-backup teslamate_$(date +%Y%m%d-%H%M).bck
-```
-
-</TabItem>
-</Tabs>
-
-## Restore
-
-<Tabs
-defaultValue="dockerCompose"
-groupId="type"
-values={[
-    { label: 'Docker Compose', value: 'dockerCompose', },
-    { label: 'NixOS', value: 'nixos', },
-]}>
-<TabItem value="dockerCompose">
-
-:::note
-Replace the default `teslamate` value below with the value defined in the .env file if you have one (TM_DB_USER and TM_DB_NAME)
-:::
-
-```bash
-# Stop the teslamate container to avoid write conflicts
-docker compose stop teslamate
-
-# Drop existing data and reinitialize (Don't forget to replace first teslamate if using different TM_DB_USER)
-docker compose exec -T database psql -U teslamate teslamate << .
-DROP SCHEMA IF EXISTS public CASCADE;
-DROP SCHEMA IF EXISTS private CASCADE;
-CREATE SCHEMA public;
-CREATE EXTENSION cube WITH SCHEMA public;
-CREATE EXTENSION earthdistance WITH SCHEMA public;
-.
-
-# Restore
-docker compose exec -T database psql -U teslamate -d teslamate < teslamate.bck
-
-# Restart the teslamate container
-docker compose start teslamate
-```
-
-</TabItem>
-<TabItem value="nixos">
-
-You can use the idiomatic restore script, for example:
-
-```bash
-teslamate-restore teslamate_20250805-1622.bck
 ```
 
 </TabItem>

--- a/website/docs/maintenance/manually_fixing_data.mdx
+++ b/website/docs/maintenance/manually_fixing_data.mdx
@@ -155,7 +155,7 @@ You can use the idiomatic maintenance script:
 
 ## Remove a vehicle from the database
 
-**NOTE:** Always [backup](https://docs.teslamate.org/docs/maintenance/backup_restore "backup") your data before performing any database changes.
+**NOTE:** Always [backup](backup.mdx) your data before performing any database changes.
 
 1. Connect to your running TeslaMate database
 

--- a/website/docs/maintenance/restore.mdx
+++ b/website/docs/maintenance/restore.mdx
@@ -1,0 +1,55 @@
+---
+title: Restore
+sidebar_label: Restore data from Backup
+---
+
+:::note
+If you are using `docker-compose`, you are using Docker Compose v1, which has been deprecated. Docker Compose commands refer to Docker Compose v2. Consider upgrading your docker setup, see [Migrate to Compose V2](https://docs.docker.com/compose/migrate/)
+:::
+
+## Restore
+
+<Tabs
+defaultValue="dockerCompose"
+groupId="type"
+values={[
+    { label: 'Docker Compose', value: 'dockerCompose', },
+    { label: 'NixOS', value: 'nixos', },
+]}>
+<TabItem value="dockerCompose">
+
+:::note
+Replace the default `teslamate` value below with the value defined in the .env file if you have one (TM_DB_USER and TM_DB_NAME)
+:::
+
+```bash
+# Stop the teslamate container to avoid write conflicts
+docker compose stop teslamate
+
+# Drop existing data and reinitialize (Don't forget to replace first teslamate if using different TM_DB_USER)
+docker compose exec -T database psql -U teslamate teslamate << .
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP SCHEMA IF EXISTS private CASCADE;
+CREATE SCHEMA public;
+CREATE EXTENSION cube WITH SCHEMA public;
+CREATE EXTENSION earthdistance WITH SCHEMA public;
+.
+
+# Restore
+docker compose exec -T database psql -U teslamate -d teslamate < teslamate.bck
+
+# Restart the teslamate container
+docker compose start teslamate
+```
+
+</TabItem>
+<TabItem value="nixos">
+
+You can use the idiomatic restore script, for example:
+
+```bash
+teslamate-restore teslamate_20250805-1622.bck
+```
+
+</TabItem>
+</Tabs>

--- a/website/docs/maintenance/restore.mdx
+++ b/website/docs/maintenance/restore.mdx
@@ -9,6 +9,9 @@ If you are using `docker-compose`, you are using Docker Compose v1, which has be
 
 ## Restore
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 <Tabs
 defaultValue="dockerCompose"
 groupId="type"

--- a/website/docs/maintenance/upgrading_postgres.md
+++ b/website/docs/maintenance/upgrading_postgres.md
@@ -3,7 +3,7 @@ title: Upgrading PostgreSQL to a new major version
 sidebar_label: Upgrading PostgreSQL
 ---
 
-1. Create a [backup](backup_restore.mdx)
+1. Create a [backup](backup.mdx)
 2. Stop all TeslaMate containers
 
    ```bash
@@ -30,4 +30,4 @@ sidebar_label: Upgrading PostgreSQL
    docker compose up -d database
    ```
 
-5. [Restore](backup_restore.mdx#restore) the backup
+5. [Restore](restore.mdx) the backup

--- a/website/docs/upgrading.mdx
+++ b/website/docs/upgrading.mdx
@@ -5,7 +5,7 @@ sidebar_label: Upgrading to a new version
 ---
 
 :::warning
-**Create a [backup](maintenance/backup_restore.mdx) before updating!**
+**Create a [backup](maintenance/backup.mdx) before updating!**
 :::
 
 :::info

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -71,4 +71,17 @@ module.exports = {
       },
     ],
   ],
+  plugins: [
+    [
+      "@docusaurus/plugin-client-redirects",
+      {
+        redirects: [
+          {
+            from: "/docs/maintenance/backup_restore",
+            to: "/docs/maintenance/backup",
+          },
+        ],
+      },
+    ],
+  ],
 };

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -27,7 +27,6 @@ module.exports = {
           label: "Docs",
           position: "left",
         },
-        // { to: "blog", label: "Blog", position: "left" },
         {
           href: "https://github.com/teslamate-org/teslamate",
           label: "GitHub",
@@ -35,21 +34,6 @@ module.exports = {
         },
       ],
     },
-    // footer: {
-    //   style: "dark",
-    //   items: [
-    //     {
-    //       title: "Community",
-    //       items: [
-    //         {
-    //           label: "Discord",
-    //           href: "https://discordapp.com/invite/docusaurus",
-    //         },
-    //       ],
-    //     },
-    //   ],
-    //   copyright: `Copyright © ${new Date().getFullYear()} Adrian Kumpf`,
-    // },
     prism: {
       additionalLanguages: ["apacheconf", "sql"],
     },
@@ -59,7 +43,6 @@ module.exports = {
       "@docusaurus/preset-classic",
       {
         docs: {
-          // routeBasePath: "", // Docs-only
           sidebarCollapsible: false,
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl:

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/faster": "^3.10.1",
+        "@docusaurus/plugin-client-redirects": "^3.10.1",
         "@docusaurus/preset-classic": "^3.10.1",
         "classnames": "^2.5.1",
         "react": "^19.2.7",
@@ -3636,6 +3637,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.1.tgz",
+      "integrity": "sha512-LHgd+YDvkhfOHMAE6XtUng3DQNzVM765RqVRrMJgHtzAvfopQhY6ieprqjxDVBdv21cLma6I0jHr+YCZH8fL9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/website/package.json
+++ b/website/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.10.1",
     "@docusaurus/faster": "^3.10.1",
+    "@docusaurus/plugin-client-redirects": "^3.10.1",
     "@docusaurus/preset-classic": "^3.10.1",
     "classnames": "^2.5.1",
     "react": "^19.2.7",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -60,7 +60,8 @@ module.exports = {
       label: "Maintenance",
       items: [
         "upgrading",
-        "maintenance/backup_restore",
+        "maintenance/backup",
+        "maintenance/restore",
         "maintenance/manually_fixing_data",
         "maintenance/upgrading_postgres",
       ],


### PR DESCRIPTION
- [x] split the backup and restore guides into two separate guides
- [x] highlight that you should transfer your backup of the host
- [x] Correct backup links in various documentation files to point to the new backup.mdx.
- [x] redirect old `backup_restore` path to `backup`