### PR TITLE
build: require Elixir 1.19.5 or newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 #### Build, CI, internal
 
+- build: require Elixir 1.19.5 or newer (#5507 - @magrathean-uk)
 - build(nix): update mixFodDeps hash in nix builds ([954e8739](https://github.com/teslamate-org/teslamate/commit/954e8739326e092f7cddf7308dd4b704cc008f62) - @JakobLichterfeld)
 - build(deps): bump launch-editor from 2.13.2 to 2.14.1 in /website (#5426)
 - build(deps): update flake.lock (#5427)

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule TeslaMate.MixProject do
     [
       app: :teslamate,
       version: version(),
-      elixir: "~> 1.17",
+      elixir: ">= 1.19.5 and < 2.0.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,

--- a/website/docs/development.mdx
+++ b/website/docs/development.mdx
@@ -6,10 +6,10 @@ sidebar_label: Development and Contributing
 
 ## Requirements
 
-TeslaMate officially supports the versions listed below. In general, TeslaMate aims to stay compatible with the last three major Erlang and Postgres releases and the last three minor Elixir releases. At the moment, OTP 28+ is a hard requirement, so Elixir support is currently limited to versions that support OTP 28 (Elixir 1.18.4+ and 1.19.x).
-When contributing, please use the versions listed below, which match those used in official TeslaMate distributions.
+TeslaMate officially supports the versions listed below. These match the versions used in official TeslaMate distributions and CI; older versions are not tested.
 
-- **Elixir** >= 1.19.5-otp-28
+- **Elixir** >= 1.19.5
+- **Erlang/OTP** >= 28.0
 - **Postgres** >= 18.0
 - **Grafana** = 13.0.1
 - An **MQTT broker** e.g. mosquitto (_optional_)

--- a/website/docs/installation/unsupported/debian.md
+++ b/website/docs/installation/unsupported/debian.md
@@ -9,10 +9,10 @@ This document provides the necessary steps for installation of TeslaMate on a va
 
 Click on the following items to view detailed installation steps.
 
-Note that in very recent distributions, you might have the required versions already packaged. However, the contents or naming of the Debian/Ubuntu packages might slightly differ than the ones from upstream, so you might need to install extra packages or do other tweaks.
+Distribution packages may lag behind TeslaMate's runtime requirements. Verify the installed Elixir and Erlang/OTP versions before compiling TeslaMate.
 
 <details>
-  <summary>Postgres (v16.7+, v17.3+ or v18.0+)</summary>
+  <summary>Postgres (v18.0+)</summary>
 
 Either upstream:
 
@@ -25,32 +25,18 @@ sudo apt-get install -y postgresql-18 postgresql-client-18
 
 Source: [postgresql.org/download](https://www.postgresql.org/download/)
 
-Or if you run a recent enough distribution (e.g. Debian Trixie:):
-
-```bash
-sudo apt install postgresql-17 postgresql-client-17
-```
-
 </details>
 
 <details>
-  <summary>Elixir (v1.17+)</summary>
+  <summary>Erlang/OTP (v28+) and Elixir (v1.19.5+)</summary>
 
-Either from upstream:
-
-```bash
-wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && sudo dpkg -i erlang-solutions_2.0_all.deb
-sudo apt-get update
-sudo apt-get install -y elixir esl-erlang
-```
-
-Source: [erlang.org/downloads](https://www.erlang.org/downloads#prebuilt)
-
-Or if you run a recent enough distribution (e.g. Debian Trixie:):
+Install both runtimes using one of the methods in the [official Elixir installation guide](https://elixir-lang.org/install.html). The Elixir install scripts, version managers and precompiled packages can provide current versions when distribution packages are too old.
 
 ```bash
-sudo apt install erlang erlang-dev erlang-syntax-tools elixir
+elixir --version
 ```
+
+The output must report Elixir 1.19.5 or newer running on Erlang/OTP 28 or newer.
 
 </details>
 

--- a/website/docs/installation/unsupported/freebsd.md
+++ b/website/docs/installation/unsupported/freebsd.md
@@ -3,8 +3,8 @@ title: Manual install - FreeBSD (no support)
 sidebar_label: Manual - FreeBSD (no support)
 ---
 
-This document provides the necessary steps for installation of TeslaMate in a FreeBSD jail. The **recommended and most straightforward installation approach is through the use of [Docker](../docker.md)**, however this walkthrough provides the necessary steps for manual installation in a FreeBSD 13.0 environment.
-It assumes that pre-requisites are met and only basic instructions are provided and should also work in FreeBSD before 13.0.
+This document provides the necessary steps for installation of TeslaMate in a FreeBSD jail. The **recommended and most straightforward installation approach is through the use of [Docker](../docker.md)**, however this walkthrough provides the necessary steps for manual installation in a FreeBSD 14.x environment using the [latest package repository](https://docs.freebsd.org/en/books/handbook/ports/#quarterly-latest-branch).
+Older FreeBSD releases and quarterly package repositories may not provide the required Erlang/OTP and Elixir versions.
 
 ## Requirements
 
@@ -32,7 +32,7 @@ pkg install git
 </details>
 
 <details>
-  <summary>Erlang (v26+)</summary>
+  <summary>Erlang/OTP (v28+)</summary>
 
 ```bash
 pkg install erlang
@@ -41,16 +41,19 @@ pkg install erlang
 </details>
 
 <details>
-  <summary>Elixir (v1.17+)</summary>
+  <summary>Elixir (v1.19.5+)</summary>
 
 ```bash
 pkg install elixir
+elixir --version
 ```
+
+The output must report Elixir 1.19.5 or newer running on Erlang/OTP 28 or newer. If `lang/elixir` is older, use the latest package repository or the `lang/elixir-devel` port described in the [official Elixir installation guide](https://elixir-lang.org/install.html#bsd).
 
 </details>
 
 <details>
-  <summary>Postgres (v16.7+, v17.3+ or v18.0+)</summary>
+  <summary>Postgres (v18.0+)</summary>
 
 ```bash
 pkg install postgresql18-server


### PR DESCRIPTION
## Summary

- Require Elixir 1.19.5 or newer in `mix.exs`, matching the current official image and CI runtime.
- List Elixir and Erlang/OTP separately and remove the untested Elixir 1.18.4 support claim.
- Update the unsupported Debian and FreeBSD guides so manual installations can still use versions that meet the current runtime requirements.
- Keep both manual guides consistent with the PostgreSQL 18 baseline.

## Package check

Checked on 2026-07-15:

- [Debian Trixie ships Elixir 1.18.3 on Erlang/OTP 27](https://packages.debian.org/trixie/elixir), so its stock packages already do not meet TeslaMate's OTP 28 requirement.
- FreeBSD's latest ports provide [Elixir 1.19.5](https://www.freshports.org/lang/elixir/) and [Erlang/OTP 28](https://www.freshports.org/lang/erlang/). The quarterly Elixir port is still 1.17.3, so the guide now points to FreeBSD's latest package repository and requires a version check.
- Debian users are directed to the official Elixir installation methods when distribution packages are too old.

The previous Inspect compatibility workaround has been removed completely. This does not add a version matrix.

## Validation

- `mix ci` on Elixir 1.19.5 / Erlang/OTP 28 with PostgreSQL 18.4: 361 tests, 0 failures
- `npm run build` in `website`
- Prettier and typos checks
- Requirement accepts 1.19.5 and 1.20.x, and rejects 1.19.4 and 2.0.0

Closes #5505
