### PR TITLE
fix(geofences): increase cost precision

### DIFF
--- a/priv/repo/migrations/20260718160000_increase_geofence_cost_precision.exs
+++ b/priv/repo/migrations/20260718160000_increase_geofence_cost_precision.exs
@@ -1,0 +1,59 @@
+defmodule TeslaMate.Repo.Migrations.IncreaseGeofenceCostPrecision do
+  use Ecto.Migration
+
+  @legacy_max_cost_per_unit "99.9999"
+  @legacy_max_fixed_cost "9999.99"
+
+  def up do
+    alter table(:charging_processes) do
+      modify(:cost, :decimal, precision: 14, scale: 2)
+    end
+
+    alter table(:geofences) do
+      modify(:cost_per_unit, :decimal, precision: 9, scale: 4)
+      modify(:session_fee, :decimal, precision: 14, scale: 2)
+    end
+  end
+
+  def down do
+    # Do not silently truncate or discard costs that cannot fit the old schema.
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM geofences
+        WHERE ABS(cost_per_unit) > #{@legacy_max_cost_per_unit}
+      ) THEN
+        RAISE EXCEPTION
+          'cannot restore geofences.cost_per_unit to numeric(6,4): values exceed #{@legacy_max_cost_per_unit}';
+      END IF;
+
+      IF EXISTS (
+        SELECT 1 FROM geofences
+        WHERE ABS(session_fee) > #{@legacy_max_fixed_cost}
+      ) THEN
+        RAISE EXCEPTION
+          'cannot restore geofences.session_fee to numeric(6,2): values exceed #{@legacy_max_fixed_cost}';
+      END IF;
+
+      IF EXISTS (
+        SELECT 1 FROM charging_processes
+        WHERE ABS(cost) > #{@legacy_max_fixed_cost}
+      ) THEN
+        RAISE EXCEPTION
+          'cannot restore charging_processes.cost to numeric(6,2): values exceed #{@legacy_max_fixed_cost}';
+      END IF;
+    END
+    $$;
+    """)
+
+    alter table(:geofences) do
+      modify(:cost_per_unit, :decimal, precision: 6, scale: 4)
+      modify(:session_fee, :decimal, precision: 6, scale: 2)
+    end
+
+    alter table(:charging_processes) do
+      modify(:cost, :decimal, precision: 6, scale: 2)
+    end
+  end
+end

--- a/test/teslamate/locations/geofences_test.exs
+++ b/test/teslamate/locations/geofences_test.exs
@@ -57,6 +57,42 @@ defmodule TeslaMate.LocationsGeofencesTest do
       assert geofence.session_fee == nil
     end
 
+    test "create_geofence/1 accepts high-value local currency costs" do
+      attrs =
+        Map.merge(@valid_attrs, %{
+          cost_per_unit: Decimal.new("99999.9999"),
+          session_fee: Decimal.new("999999.99")
+        })
+
+      assert {:ok, %GeoFence{} = geofence} = Locations.create_geofence(attrs)
+      assert geofence.cost_per_unit == Decimal.new("99999.9999")
+      assert geofence.session_fee == Decimal.new("999999.99")
+    end
+
+    test "calculate_charge_costs/1 stores high-value local currency totals" do
+      car = car_fixture()
+
+      assert %ChargingProcess{id: id, geofence_id: nil, cost: nil} =
+               create_charging_process(car, %{latitude: 52.514521, longitude: 13.350144})
+
+      geofence =
+        geofence_fixture(%{
+          latitude: 52.514521,
+          longitude: 13.350144,
+          radius: 250,
+          cost_per_unit: Decimal.new("99999.9999")
+        })
+
+      geofence_id = geofence.id
+
+      assert %ChargingProcess{geofence_id: ^geofence_id, cost: nil} =
+               Repo.get!(ChargingProcess, id)
+
+      assert :ok = Locations.calculate_charge_costs(geofence)
+      assert %ChargingProcess{cost: cost} = Repo.get!(ChargingProcess, id)
+      assert cost == Decimal.new("31000.00")
+    end
+
     test "create_geofence/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{} = changeset} = Locations.create_geofence(@invalid_attrs)
 


### PR DESCRIPTION
## Summary

Expand `geofences.cost_per_unit` from `numeric(6,4)` to `numeric(9,4)` and `charging_processes.cost` from `numeric(6,2)` to `numeric(14,2)`.

## Why

Charging rates in high-denomination currencies can exceed the current maximum and fail with a PostgreSQL numeric overflow. Widening only the rate column would still let the calculated charging total overflow, so both storage points are covered.

## Migration safety

Normal rollback restores both legacy widths. If any stored rate or total no longer fits, rollback raises before changing either column instead of truncating or discarding data.

## Validation

- 18 focused geofence tests, including the upper-bound rate and a recalculated high-value total
- Full combined `mix ci`: 374 tests passed
- PostgreSQL 18 migration `up -> down -> up`
- Verified rollback refusal for an oversized rate and an oversized total, with the widened schema left intact
- `mix format --check-formatted` and staged secret scan

Closes #4410