### PR TITLE
docs: point Tesla Auth users to fixed releases

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -10,6 +10,14 @@ There are multiple apps available to securely generate access tokens yourself, f
 - [Tesla Auth 0.13.0 or newer (macOS, Linux, Windows)](https://github.com/adriankumpf/tesla_auth/releases/latest)
 - [Auth app for Tesla (iOS, macOS)](https://apps.apple.com/us/app/auth-app-for-tesla/id1552058613)
 
+## TeslaMate stopped recording data. How can I fix it?
+
+Check the TeslaMate logs first. They usually show whether TeslaMate cannot reach Tesla, cannot connect to the database, or needs new credentials.
+
+If the logs show an authentication error, use one of the tools above to generate a new access token and refresh token, then enter both on the TeslaMate sign-in page. Signing in again does not remove data that TeslaMate has already recorded.
+
+Tesla's API does not provide historical drives or charges, so TeslaMate cannot recover data that was missed while logging was stopped. If another supported logger recorded the missing period, you may be able to add it with the [TeslaFi import](import/teslafi.md).
+
 ## Why are no consumption values displayed in Grafana?
 
 Unfortunately the Tesla API does not return consumption values for a trip. In order to still be able to display values TeslaMate estimates the consumption on the basis of the recorded (charging) data.

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -7,7 +7,7 @@ sidebar_label: FAQ
 
 There are multiple apps available to securely generate access tokens yourself, for example:
 
-- [Tesla Auth (macOS, Linux, Windows)](https://github.com/adriankumpf/tesla_auth)
+- [Tesla Auth 0.13.0 or newer (macOS, Linux, Windows)](https://github.com/adriankumpf/tesla_auth/releases/latest)
 - [Auth app for Tesla (iOS, macOS)](https://apps.apple.com/us/app/auth-app-for-tesla/id1552058613)
 
 ## Why are no consumption values displayed in Grafana?


### PR DESCRIPTION
## Summary

Update the FAQ to require Tesla Auth 0.13.0 or newer and link to the current latest release.

## Why

Version 0.13.0 fixed the callback redirect used during token generation. Linking to `releases/latest` also prevents the documentation from sending users to an outdated binary again.

## Validation

- Docusaurus production build completed successfully
- Documentation link and rendered content checked
- Staged secret and whitespace scans

Closes #5296