### PR TITLE
test: reuse API snapshots across paired fetches

### DIFF
--- a/test/support/mocks/api.ex
+++ b/test/support/mocks/api.ex
@@ -34,8 +34,7 @@ defmodule ApiMock do
         {:get_vehicle_with_state, id},
         _from,
         %State{pending_vehicle_data: {id, result}} = state
-      )
-      when not is_nil(result) do
+      ) do
     {:reply, result, advance_event(state)}
   end
 

--- a/test/support/mocks/api.ex
+++ b/test/support/mocks/api.ex
@@ -2,13 +2,13 @@ defmodule ApiMock do
   use GenServer
 
   defmodule State do
-    defstruct [:pid, :events]
+    defstruct [:pid, :events, :pending_vehicle_data]
   end
 
   # API
 
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: Keyword.fetch!(opts, :name))
+    GenServer.start_link(__MODULE__, opts, Keyword.take(opts, [:name]))
   end
 
   def get_vehicle(name, id), do: GenServer.call(name, {:get_vehicle, id})
@@ -30,14 +30,26 @@ defmodule ApiMock do
   end
 
   @impl true
-  def handle_call({action, _id}, _from, %State{events: [event | []]} = state)
-      when action in [:get_vehicle, :get_vehicle_with_state] do
-    {:reply, exec(event, action), state}
+  def handle_call(
+        {:get_vehicle_with_state, _id},
+        _from,
+        %State{pending_vehicle_data: result} = state
+      )
+      when not is_nil(result) do
+    {:reply, result, state |> advance_event() |> Map.put(:pending_vehicle_data, nil)}
   end
 
-  def handle_call({action, _id}, _from, %State{events: [event | events]} = state)
+  def handle_call({action, _id}, _from, %State{events: [event | _events]} = state)
       when action in [:get_vehicle, :get_vehicle_with_state] do
-    {:reply, exec(event, action), %State{state | events: events}}
+    result = exec(event, action)
+
+    case {action, snapshot?(event), result} do
+      {:get_vehicle, true, {:ok, %TeslaApi.Vehicle{state: "online"}}} ->
+        {:reply, result, %State{state | pending_vehicle_data: result}}
+
+      _ ->
+        {:reply, result, advance_event(state)}
+    end
   end
 
   def handle_call({:sign_in, _tokens} = event, _from, %State{pid: pid} = state) do
@@ -52,6 +64,8 @@ defmodule ApiMock do
 
   # Events tagged with :get_vehicle or :get_vehicle_with_state may only be
   # consumed by that API call, allowing tests to pin which endpoint was used.
+  defp exec({:snapshot, event}, action), do: exec(event, action)
+
   defp exec({expected_action, event}, action)
        when expected_action in [:get_vehicle, :get_vehicle_with_state] do
     if expected_action != action do
@@ -63,4 +77,12 @@ defmodule ApiMock do
 
   defp exec(event, _action) when is_function(event), do: event.()
   defp exec(event, _action), do: event
+
+  defp snapshot?({:snapshot, _event}), do: true
+  defp snapshot?(_event), do: false
+
+  defp advance_event(%State{events: [_event]} = state), do: state
+
+  defp advance_event(%State{events: [_event | events]} = state),
+    do: %State{state | events: events}
 end

--- a/test/support/mocks/api.ex
+++ b/test/support/mocks/api.ex
@@ -79,6 +79,10 @@ defmodule ApiMock do
   defp exec(event, _action), do: event
 
   defp snapshot?({:snapshot, _event}), do: true
+
+  defp snapshot?({action, event}) when action in [:get_vehicle, :get_vehicle_with_state],
+    do: snapshot?(event)
+
   defp snapshot?(_event), do: false
 
   defp advance_event(%State{events: [_event]} = state),

--- a/test/support/mocks/api.ex
+++ b/test/support/mocks/api.ex
@@ -31,21 +31,21 @@ defmodule ApiMock do
 
   @impl true
   def handle_call(
-        {:get_vehicle_with_state, _id},
+        {:get_vehicle_with_state, id},
         _from,
-        %State{pending_vehicle_data: result} = state
+        %State{pending_vehicle_data: {id, result}} = state
       )
       when not is_nil(result) do
-    {:reply, result, state |> advance_event() |> Map.put(:pending_vehicle_data, nil)}
+    {:reply, result, advance_event(state)}
   end
 
-  def handle_call({action, _id}, _from, %State{events: [event | _events]} = state)
+  def handle_call({action, id}, _from, %State{events: [event | _events]} = state)
       when action in [:get_vehicle, :get_vehicle_with_state] do
     result = exec(event, action)
 
     case {action, snapshot?(event), result} do
       {:get_vehicle, true, {:ok, %TeslaApi.Vehicle{state: "online"}}} ->
-        {:reply, result, %State{state | pending_vehicle_data: result}}
+        {:reply, result, %State{state | pending_vehicle_data: {id, result}}}
 
       _ ->
         {:reply, result, advance_event(state)}
@@ -81,8 +81,9 @@ defmodule ApiMock do
   defp snapshot?({:snapshot, _event}), do: true
   defp snapshot?(_event), do: false
 
-  defp advance_event(%State{events: [_event]} = state), do: state
+  defp advance_event(%State{events: [_event]} = state),
+    do: %State{state | pending_vehicle_data: nil}
 
   defp advance_event(%State{events: [_event | events]} = state),
-    do: %State{state | events: events}
+    do: %State{state | events: events, pending_vehicle_data: nil}
 end

--- a/test/teslamate/vehicles/api_mock_test.exs
+++ b/test/teslamate/vehicles/api_mock_test.exs
@@ -27,6 +27,23 @@ defmodule TeslaMate.Vehicles.ApiMockTest do
     refute_receive :event_evaluated
   end
 
+  test "does not reuse a snapshot for a different vehicle" do
+    test_pid = self()
+
+    event = fn ->
+      send(test_pid, :event_evaluated)
+      {:ok, %TeslaApi.Vehicle{state: "online"}}
+    end
+
+    name = start_api_mock([{:snapshot, event}])
+
+    assert {:ok, %TeslaApi.Vehicle{state: "online"}} = ApiMock.get_vehicle(name, 1)
+    assert_receive :event_evaluated
+
+    assert {:ok, %TeslaApi.Vehicle{state: "online"}} = ApiMock.get_vehicle_with_state(name, 2)
+    assert_receive :event_evaluated
+  end
+
   defp start_api_mock(events) do
     start_supervised!({ApiMock, events: events, pid: self()})
   end

--- a/test/teslamate/vehicles/api_mock_test.exs
+++ b/test/teslamate/vehicles/api_mock_test.exs
@@ -44,6 +44,16 @@ defmodule TeslaMate.Vehicles.ApiMockTest do
     assert_receive :event_evaluated
   end
 
+  test "reuses a snapshot nested inside an endpoint wrapper" do
+    first = {:ok, %TeslaApi.Vehicle{state: "online", display_name: "first"}}
+    second = {:ok, %TeslaApi.Vehicle{state: "online", display_name: "second"}}
+    name = start_api_mock([{:get_vehicle, {:snapshot, first}}, second])
+
+    assert ApiMock.get_vehicle(name, 1) == first
+    assert ApiMock.get_vehicle_with_state(name, 1) == first
+    assert ApiMock.get_vehicle(name, 1) == second
+  end
+
   defp start_api_mock(events) do
     start_supervised!({ApiMock, events: events, pid: self()})
   end

--- a/test/teslamate/vehicles/api_mock_test.exs
+++ b/test/teslamate/vehicles/api_mock_test.exs
@@ -1,0 +1,33 @@
+defmodule TeslaMate.Vehicles.ApiMockTest do
+  use ExUnit.Case, async: true
+
+  test "reuses an online snapshot for a lightweight and full-data fetch" do
+    first = {:ok, %TeslaApi.Vehicle{state: "online", display_name: "first"}}
+    second = {:ok, %TeslaApi.Vehicle{state: "online", display_name: "second"}}
+    name = start_api_mock([{:snapshot, first}, second])
+
+    assert ApiMock.get_vehicle(name, 1) == first
+    assert ApiMock.get_vehicle_with_state(name, 1) == first
+    assert ApiMock.get_vehicle(name, 1) == second
+  end
+
+  test "evaluates a reused snapshot only once" do
+    test_pid = self()
+
+    event = fn ->
+      send(test_pid, :event_evaluated)
+      {:ok, %TeslaApi.Vehicle{state: "online"}}
+    end
+
+    name = start_api_mock([{:snapshot, event}])
+
+    assert {:ok, %TeslaApi.Vehicle{state: "online"}} = ApiMock.get_vehicle(name, 1)
+    assert {:ok, %TeslaApi.Vehicle{state: "online"}} = ApiMock.get_vehicle_with_state(name, 1)
+    assert_receive :event_evaluated
+    refute_receive :event_evaluated
+  end
+
+  defp start_api_mock(events) do
+    start_supervised!({ApiMock, events: events, pid: self()})
+  end
+end

--- a/test/teslamate/vehicles/vehicle/updating_test.exs
+++ b/test/teslamate/vehicles/vehicle/updating_test.exs
@@ -9,8 +9,8 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
     now_ts = DateTime.to_unix(now, :millisecond)
 
     events = [
-      {:ok, online_event(now_ts - 2)},
-      {:ok, update_event(now_ts - 1, "available", nil, update_version: "2019.8.5 3aaa23d")},
+      {:snapshot,
+       {:ok, update_event(now_ts - 1, "available", nil, update_version: "2019.8.5 3aaa23d")}},
       {:ok, update_event(now_ts, "installing", "2019.8.4 530d1d3")},
       {:ok, update_event(now_ts + 1, "installing", "2019.8.4 530d1d3")},
       {:ok, update_event(now_ts + 2, "installing", "2019.8.4 530d1d3")},


### PR DESCRIPTION
## Summary

Add an explicit API mock snapshot wrapper for responses that should represent one logical vehicle state across TeslaMate's lightweight and full fetch sequence.

## Why

The production update cycle can perform two API calls for one logical state. Stateful mock functions were evaluated twice, which could consume two fixtures and make tests observe a transition that production did not intend.

## Compatibility

Snapshot reuse is opt-in. Existing sequential mock behavior remains the default, wrapped functions are evaluated exactly once for paired fetches, and cached snapshots are isolated by vehicle id. Snapshot and endpoint-pinning wrappers compose in either order. Isolated mocks are addressed by PID rather than dynamically generated registered atoms.

## Validation

- Four dedicated API mock tests covering reuse, single evaluation, cross-vehicle isolation, and endpoint-wrapper composition
- Seven focused API mock and vehicle-updating tests passed
- Full `mix ci`: 365 tests passed
- Hosted Elixir tests, static analysis, formatting, security scans, CLA, and deploy preview passed

Closes #5278
