### PR TITLE
fix(cars): enforce non-null VINs

### DIFF
--- a/lib/teslamate/log/car.ex
+++ b/lib/teslamate/log/car.ex
@@ -17,7 +17,6 @@ defmodule TeslaMate.Log.Car do
 
     field :eid, :integer
     field :vid, :integer
-    # TODO: with v2.0 mark as non nullable
     field :vin, :string
     field :display_priority, :integer
 

--- a/priv/repo/migrations/20260715081000_add_not_null_constraint_to_vin.exs
+++ b/priv/repo/migrations/20260715081000_add_not_null_constraint_to_vin.exs
@@ -1,0 +1,30 @@
+defmodule TeslaMate.Repo.Migrations.AddNotNullConstraintToVin do
+  use Ecto.Migration
+
+  @legacy_vin_prefix "__legacy_null_vin__:"
+
+  def up do
+    # Preserve old cars and their history; vehicle discovery replaces this marker via eid or vid.
+    execute("""
+    UPDATE cars
+    SET vin = '#{@legacy_vin_prefix}' || id::text
+    WHERE vin IS NULL
+    """)
+
+    alter table(:cars) do
+      modify(:vin, :text, null: false)
+    end
+  end
+
+  def down do
+    alter table(:cars) do
+      modify(:vin, :text, null: true)
+    end
+
+    execute("""
+    UPDATE cars
+    SET vin = NULL
+    WHERE vin = '#{@legacy_vin_prefix}' || id::text
+    """)
+  end
+end

--- a/test/teslamate/log/log_car_test.exs
+++ b/test/teslamate/log/log_car_test.exs
@@ -62,6 +62,17 @@ defmodule TeslaMate.LogCarTest do
     assert Log.get_car!(car.id) |> Repo.preload(:settings) == car
   end
 
+  test "vin is non-nullable in the database" do
+    assert %{rows: [["NO"]]} =
+             Repo.query!("""
+             SELECT is_nullable
+             FROM information_schema.columns
+             WHERE table_schema = current_schema()
+               AND table_name = 'cars'
+               AND column_name = 'vin'
+             """)
+  end
+
   test "create_or_update_car/1 with valid data creates a car" do
     alias TeslaMate.Settings.CarSettings
 


### PR DESCRIPTION
## Summary

Backfill legacy `NULL` VIN rows with a unique internal marker, then enforce the existing schema expectation with a database `NOT NULL` constraint.

## Why

The Ecto schema already requires VINs, but the database still permits null values. Applying the constraint directly would fail startup for installations that contain valid historical cars created before VIN was reliably present.

## Migration safety

The migration preserves each car and all related history. Existing vehicle discovery replaces the internal marker through the normal `eid` or `vid` lookup once a real VIN is available. Rollback restores only a marker that exactly matches its car ID, leaving valid VINs untouched.

## Validation

- Isolated PostgreSQL 18 database containing a real legacy `NULL` VIN row
- Verified migration `up -> down -> up`
- Verified marker creation, `NOT NULL`, exact rollback to `NULL`, and reapplication
- Focused car tests and full `mix ci`: 374 tests passed
- `mix format --check-formatted` and staged secret scan

Closes #4801