### PR TITLE
fix(import): accept fractional TeslaFi battery levels

### DIFF
--- a/lib/teslamate/import/line_parser.ex
+++ b/lib/teslamate/import/line_parser.ex
@@ -44,6 +44,13 @@ defmodule TeslaMate.Import.LineParser do
   defp map_value("state", "waking"), do: "online"
   defp map_value("state", "shutdown"), do: "online"
 
+  defp map_value(key, val) when key in ["battery_level", "usable_battery_level"] do
+    case map_value(nil, val) do
+      number when is_float(number) -> round(number)
+      value -> value
+    end
+  end
+
   defp map_value("scheduled_charging_start_time", _val), do: nil
 
   @boolean ~w(battery_heater_on is_climate_on is_front_defroster_on is_rear_defroster_on

--- a/test/teslamate/import/line_parser_test.exs
+++ b/test/teslamate/import/line_parser_test.exs
@@ -1,0 +1,24 @@
+defmodule TeslaMate.Import.LineParserTest do
+  use ExUnit.Case, async: true
+
+  alias TeslaApi.Vehicle.State.Charge
+  alias TeslaMate.Import.LineParser
+
+  test "rounds fractional battery levels from TeslaFi exports" do
+    assert %TeslaApi.Vehicle{
+             charge_state: %Charge{battery_level: 28, usable_battery_level: 29}
+           } =
+             LineParser.parse(
+               %{"battery_level" => "28.01", "usable_battery_level" => "28.5"},
+               "Etc/UTC"
+             )
+
+    assert %TeslaApi.Vehicle{
+             charge_state: %Charge{battery_level: 29, usable_battery_level: 30}
+           } =
+             LineParser.parse(
+               %{"battery_level" => "29", "usable_battery_level" => "30"},
+               "Etc/UTC"
+             )
+  end
+end


### PR DESCRIPTION
## Summary

Round fractional TeslaFi `battery_level` and `usable_battery_level` values before Ecto casts them into TeslaMate's integer fields.

## Why

TeslaFi exports can contain fractional battery values. Those rows are otherwise valid but fail import because TeslaMate stores both battery-level fields as integers.

## Compatibility

Both fields reuse the existing generic numeric parser. Parsed floats are rounded; integer inputs, invalid strings, and existing empty-value handling remain unchanged.

## Validation

- Line-parser regression covers fractional and integer values for both battery fields
- Focused importer test passed
- Full combined `mix ci`: 375 tests passed
- `mix format --check-formatted` and staged secret scan

Closes #4477