### PR TITLE
fix(mqtt): return publish errors without crashing

### DIFF
--- a/lib/teslamate/mqtt/publisher.ex
+++ b/lib/teslamate/mqtt/publisher.ex
@@ -1,8 +1,6 @@
 defmodule TeslaMate.Mqtt.Publisher do
   use GenServer
 
-  require Logger
-
   @name __MODULE__
   @timeout :timer.seconds(10)
 
@@ -29,24 +27,45 @@ defmodule TeslaMate.Mqtt.Publisher do
   end
 
   @impl true
-  def handle_call({:publish, topic, msg, opts}, from, %State{client_id: id, refs: refs} = state) do
+  def handle_call({:publish, topic, msg, opts}, from, %State{client_id: id} = state) do
     opts = Keyword.put_new(opts, :timeout, round(@timeout * 0.95))
 
     case Keyword.get(opts, :qos, 0) do
-      0 ->
-        :ok = Tortoise311.publish(id, topic, msg, opts)
-        {:reply, :ok, state}
+      qos when qos in [0, 1, 2] ->
+        do_publish(id, topic, msg, opts, qos, from, state)
 
-      _ ->
-        {:ok, ref} = Tortoise311.publish(id, topic, msg, opts)
-        {:noreply, %State{state | refs: Map.put(refs, ref, from)}}
+      qos ->
+        {:reply, {:error, {:invalid_qos, qos}}, state}
     end
   end
 
   @impl true
   def handle_info({{Tortoise311, id}, ref, result}, %State{client_id: id, refs: refs} = state) do
-    {from, refs} = Map.pop(refs, ref)
-    GenServer.reply(from, result)
-    {:noreply, %State{state | refs: refs}}
+    case Map.pop(refs, ref) do
+      {nil, _refs} ->
+        {:noreply, state}
+
+      {from, refs} ->
+        GenServer.reply(from, result)
+        {:noreply, %State{state | refs: refs}}
+    end
+  end
+
+  def handle_info({{Tortoise311, _id}, _ref, _result}, state), do: {:noreply, state}
+
+  defp do_publish(id, topic, msg, opts, qos, from, %State{refs: refs} = state) do
+    case Tortoise311.publish(id, topic, msg, opts) do
+      :ok when qos == 0 ->
+        {:reply, :ok, state}
+
+      {:ok, ref} when qos in [1, 2] ->
+        {:noreply, %State{state | refs: Map.put(refs, ref, from)}}
+
+      {:error, _reason} = error ->
+        {:reply, error, state}
+
+      result ->
+        {:reply, {:error, {:unexpected_publish_result, result}}, state}
+    end
   end
 end

--- a/lib/teslamate/mqtt/publisher.ex
+++ b/lib/teslamate/mqtt/publisher.ex
@@ -3,6 +3,7 @@ defmodule TeslaMate.Mqtt.Publisher do
 
   @name __MODULE__
   @timeout :timer.seconds(10)
+  @publish_timeout round(@timeout * 0.95)
 
   defstruct client_id: nil,
             refs: %{}
@@ -18,8 +19,14 @@ defmodule TeslaMate.Mqtt.Publisher do
   def publish(topic, msg \\ nil, opts \\ []) do
     GenServer.call(@name, {:publish, topic, msg, opts}, @timeout)
   catch
-    :exit, {:timeout, _call} -> {:error, :timeout}
-    :exit, _reason -> {:error, :publisher_unavailable}
+    :exit, {:timeout, _call} ->
+      {:error, :timeout}
+
+    :exit, {reason, _call} when reason in [:noproc, :normal, :shutdown] ->
+      {:error, :publisher_unavailable}
+
+    :exit, {{:shutdown, _reason}, _call} ->
+      {:error, :publisher_unavailable}
   end
 
   # Callbacks
@@ -31,11 +38,26 @@ defmodule TeslaMate.Mqtt.Publisher do
 
   @impl true
   def handle_call({:publish, topic, msg, opts}, from, %State{client_id: id} = state) do
-    opts = Keyword.put_new(opts, :timeout, round(@timeout * 0.95))
-
     case Keyword.get(opts, :qos, 0) do
       qos when qos in [0, 1, 2] ->
-        do_publish(id, topic, msg, opts, qos, from, state)
+        case Keyword.get(opts, :timeout, @publish_timeout) do
+          timeout when is_integer(timeout) and timeout >= 0 ->
+            timeout = min(timeout, @publish_timeout)
+
+            do_publish(
+              id,
+              topic,
+              msg,
+              Keyword.put(opts, :timeout, timeout),
+              qos,
+              from,
+              timeout,
+              state
+            )
+
+          timeout ->
+            {:reply, {:error, {:invalid_timeout, timeout}}, state}
+        end
 
       qos ->
         {:reply, {:error, {:invalid_qos, qos}}, state}
@@ -68,15 +90,13 @@ defmodule TeslaMate.Mqtt.Publisher do
     end
   end
 
-  defp do_publish(id, topic, msg, opts, qos, from, %State{refs: refs} = state) do
+  defp do_publish(id, topic, msg, opts, qos, from, timeout, %State{refs: refs} = state) do
     case Tortoise311.publish(id, topic, msg, opts) do
       :ok when qos == 0 ->
         {:reply, :ok, state}
 
       {:ok, ref} when qos in [1, 2] ->
-        timer =
-          Process.send_after(self(), {:publish_timeout, ref}, Keyword.fetch!(opts, :timeout))
-
+        timer = Process.send_after(self(), {:publish_timeout, ref}, timeout)
         {:noreply, %State{state | refs: Map.put(refs, ref, {from, timer})}}
 
       {:error, _reason} = error ->

--- a/lib/teslamate/mqtt/publisher.ex
+++ b/lib/teslamate/mqtt/publisher.ex
@@ -48,7 +48,8 @@ defmodule TeslaMate.Mqtt.Publisher do
       {nil, _refs} ->
         {:noreply, state}
 
-      {from, refs} ->
+      {{from, timer}, refs} ->
+        Process.cancel_timer(timer)
         GenServer.reply(from, result)
         {:noreply, %State{state | refs: refs}}
     end
@@ -56,13 +57,27 @@ defmodule TeslaMate.Mqtt.Publisher do
 
   def handle_info({{Tortoise311, _id}, _ref, _result}, state), do: {:noreply, state}
 
+  def handle_info({:publish_timeout, ref}, %State{refs: refs} = state) do
+    case Map.pop(refs, ref) do
+      {nil, _refs} ->
+        {:noreply, state}
+
+      {{from, _timer}, refs} ->
+        GenServer.reply(from, {:error, :timeout})
+        {:noreply, %State{state | refs: refs}}
+    end
+  end
+
   defp do_publish(id, topic, msg, opts, qos, from, %State{refs: refs} = state) do
     case Tortoise311.publish(id, topic, msg, opts) do
       :ok when qos == 0 ->
         {:reply, :ok, state}
 
       {:ok, ref} when qos in [1, 2] ->
-        {:noreply, %State{state | refs: Map.put(refs, ref, from)}}
+        timer =
+          Process.send_after(self(), {:publish_timeout, ref}, Keyword.fetch!(opts, :timeout))
+
+        {:noreply, %State{state | refs: Map.put(refs, ref, {from, timer})}}
 
       {:error, _reason} = error ->
         {:reply, error, state}

--- a/lib/teslamate/mqtt/publisher.ex
+++ b/lib/teslamate/mqtt/publisher.ex
@@ -17,6 +17,9 @@ defmodule TeslaMate.Mqtt.Publisher do
 
   def publish(topic, msg \\ nil, opts \\ []) do
     GenServer.call(@name, {:publish, topic, msg, opts}, @timeout)
+  catch
+    :exit, {:timeout, _call} -> {:error, :timeout}
+    :exit, _reason -> {:error, :publisher_unavailable}
   end
 
   # Callbacks

--- a/test/teslamate/mqtt/publisher_test.exs
+++ b/test/teslamate/mqtt/publisher_test.exs
@@ -1,0 +1,90 @@
+defmodule TeslaMate.Mqtt.PublisherTest do
+  use ExUnit.Case, async: false
+
+  import Mock
+
+  alias TeslaMate.Mqtt.Publisher
+
+  setup do
+    start_supervised!({Publisher, client_id: "test_client"})
+    :ok
+  end
+
+  test "returns successful QoS 0 publishes immediately" do
+    with_mock Tortoise311, publish: fn _id, _topic, _msg, _opts -> :ok end do
+      assert :ok = Publisher.publish("test/topic", "value")
+    end
+  end
+
+  test "returns successful QoS 1 publishes after acknowledgement" do
+    parent = self()
+
+    with_mock Tortoise311,
+      publish: fn _id, _topic, _msg, _opts ->
+        send(parent, :published)
+        {:ok, :publish_ref}
+      end do
+      task = Task.async(fn -> Publisher.publish("test/topic", "value", qos: 1) end)
+
+      assert_receive :published
+      send(Publisher, {{Tortoise311, "test_client"}, :publish_ref, :ok})
+      assert :ok = Task.await(task, :timer.seconds(11))
+    end
+  end
+
+  test "keeps running when a QoS 0 publish fails" do
+    publisher = Process.whereis(Publisher)
+
+    with_mock Tortoise311,
+      publish: fn _id, _topic, _msg, _opts -> {:error, :unknown_connection} end do
+      assert {:error, :unknown_connection} = Publisher.publish("test/topic", "value")
+      assert Process.whereis(Publisher) == publisher
+    end
+  end
+
+  test "keeps running when a QoS 1 publish fails before acknowledgement" do
+    publisher = Process.whereis(Publisher)
+
+    with_mock Tortoise311,
+      publish: fn _id, _topic, _msg, _opts -> {:error, :timeout} end do
+      assert {:error, :timeout} = Publisher.publish("test/topic", "value", qos: 1)
+
+      assert Process.whereis(Publisher) == publisher
+    end
+  end
+
+  test "rejects invalid QoS values without publishing" do
+    publisher = Process.whereis(Publisher)
+
+    with_mock Tortoise311,
+      publish: fn _id, _topic, _msg, _opts -> flunk("publish should not be called") end do
+      for qos <- ["1", 1.0] do
+        assert {:error, {:invalid_qos, ^qos}} =
+                 Publisher.publish("test/topic", "value", qos: qos)
+      end
+
+      assert Process.whereis(Publisher) == publisher
+    end
+  end
+
+  test "returns unexpected publish results without crashing" do
+    publisher = Process.whereis(Publisher)
+
+    with_mock Tortoise311, publish: fn _id, _topic, _msg, _opts -> :unexpected end do
+      assert {:error, {:unexpected_publish_result, :unexpected}} =
+               Publisher.publish("test/topic", "value")
+
+      assert Process.whereis(Publisher) == publisher
+    end
+  end
+
+  test "ignores acknowledgements for unknown references and clients" do
+    publisher = Process.whereis(Publisher)
+
+    send(Publisher, {{Tortoise311, "test_client"}, :unknown_ref, :ok})
+    send(Publisher, {{Tortoise311, "other_client"}, :unknown_ref, :ok})
+    :sys.get_state(Publisher)
+
+    assert Process.whereis(Publisher) == publisher
+  end
+end

--- a/test/teslamate/mqtt/publisher_test.exs
+++ b/test/teslamate/mqtt/publisher_test.exs
@@ -75,6 +75,50 @@ defmodule TeslaMate.Mqtt.PublisherTest do
     end
   end
 
+  test "clamps publish timeouts to the call budget" do
+    parent = self()
+
+    with_mock Tortoise311,
+      publish: fn _id, _topic, _msg, opts ->
+        send(parent, {:publish_timeout, Keyword.fetch!(opts, :timeout)})
+        :ok
+      end do
+      assert :ok = Publisher.publish("test/topic", "value", timeout: :timer.minutes(1))
+      assert_receive {:publish_timeout, 9_500}
+    end
+  end
+
+  test "rejects invalid timeout values without publishing" do
+    publisher = Process.whereis(Publisher)
+
+    with_mock Tortoise311,
+      publish: fn _id, _topic, _msg, _opts -> flunk("publish should not be called") end do
+      for timeout <- [-1, "20", 1.0] do
+        assert {:error, {:invalid_timeout, ^timeout}} =
+                 Publisher.publish("test/topic", "value", timeout: timeout)
+      end
+
+      assert Process.whereis(Publisher) == publisher
+    end
+  end
+
+  test "does not hide unexpected publisher exits" do
+    parent = self()
+
+    with_mock Tortoise311,
+      publish: fn _id, _topic, _msg, _opts ->
+        send(parent, :publishing)
+        Process.sleep(:infinity)
+      end do
+      task = Task.async(fn -> catch_exit(Publisher.publish("test/topic", "value")) end)
+
+      assert_receive :publishing
+      Process.exit(Process.whereis(Publisher), :unexpected)
+
+      assert {:unexpected, {GenServer, :call, _call}} = Task.await(task, :timer.seconds(1))
+    end
+  end
+
   test "keeps running when a QoS 0 publish fails" do
     publisher = Process.whereis(Publisher)
 

--- a/test/teslamate/mqtt/publisher_test.exs
+++ b/test/teslamate/mqtt/publisher_test.exs
@@ -32,6 +32,24 @@ defmodule TeslaMate.Mqtt.PublisherTest do
     end
   end
 
+  test "returns QoS 1 acknowledgement errors" do
+    parent = self()
+    publisher = Process.whereis(Publisher)
+
+    with_mock Tortoise311,
+      publish: fn _id, _topic, _msg, _opts ->
+        send(parent, :published)
+        {:ok, :publish_ref}
+      end do
+      task = Task.async(fn -> Publisher.publish("test/topic", "value", qos: 1) end)
+
+      assert_receive :published
+      send(Publisher, {{Tortoise311, "test_client"}, :publish_ref, {:error, :timeout}})
+      assert {:error, :timeout} = Task.await(task, :timer.seconds(1))
+      assert Process.whereis(Publisher) == publisher
+    end
+  end
+
   test "keeps running when a QoS 0 publish fails" do
     publisher = Process.whereis(Publisher)
 
@@ -76,6 +94,11 @@ defmodule TeslaMate.Mqtt.PublisherTest do
 
       assert Process.whereis(Publisher) == publisher
     end
+  end
+
+  test "returns an error when the publisher is unavailable" do
+    assert :ok = stop_supervised(Publisher)
+    assert {:error, :publisher_unavailable} = Publisher.publish("test/topic", "value")
   end
 
   test "ignores acknowledgements for unknown references and clients" do

--- a/test/teslamate/mqtt/publisher_test.exs
+++ b/test/teslamate/mqtt/publisher_test.exs
@@ -50,6 +50,31 @@ defmodule TeslaMate.Mqtt.PublisherTest do
     end
   end
 
+  test "expires unacknowledged QoS 1 publishes" do
+    parent = self()
+    publisher = Process.whereis(Publisher)
+
+    with_mock Tortoise311,
+      publish: fn _id, _topic, _msg, _opts ->
+        send(parent, :published)
+        {:ok, :publish_ref}
+      end do
+      task =
+        Task.async(fn ->
+          Publisher.publish("test/topic", "value", qos: 1, timeout: 20)
+        end)
+
+      assert_receive :published
+      assert {:error, :timeout} = Task.await(task, :timer.seconds(1))
+      assert %{refs: %{}} = :sys.get_state(Publisher)
+      assert Process.whereis(Publisher) == publisher
+
+      send(Publisher, {{Tortoise311, "test_client"}, :publish_ref, :ok})
+      assert %{refs: %{}} = :sys.get_state(Publisher)
+      assert Process.whereis(Publisher) == publisher
+    end
+  end
+
   test "keeps running when a QoS 0 publish fails" do
     publisher = Process.whereis(Publisher)
 


### PR DESCRIPTION
## Summary

Return MQTT publish failures to the caller without crashing the publisher process.

## Why

Temporary MQTT broker or TLS failures can otherwise destabilize the publishing path and leave incomplete drives instead of allowing the existing subscriber error reporting and retry behavior to respond.

## Compatibility

Successful QoS 0, 1, and 2 publishes are unchanged. Invalid QoS and timeout values are rejected before calling Tortoise. Known transient failures and unexpected client results become explicit errors, while genuine publisher bugs still propagate. Unacknowledged QoS refs expire within the existing publish timeout, and late, duplicate, or stray acknowledgements are ignored without stopping the publisher.

## Validation

- 13 focused publisher tests covering success, known failures, asynchronous acknowledgement errors, bounded ref expiry, invalid QoS/timeouts, unexpected exits, and stray acknowledgements
- 18 focused publisher and vehicle-subscriber tests passed
- Full `mix ci`: 374 tests passed
- Hosted Elixir tests, static analysis, formatting, security scans, CLA, and deploy preview passed

Closes #4944
