### PR TITLE
fix(vehicle): update geofence while driving with streaming API

### DIFF
--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -660,14 +660,26 @@ defmodule TeslaMate.Vehicles.Vehicle do
       ) do
     case {status, stream_data} do
       {:available, %Stream.Data{shift_state: shift_state}} when shift_state in ~w(D N R) ->
-        {:ok, %{elevation: elevation}} =
-          call(data.deps.log, :insert_position, [drv, create_position(stream_data, data)])
+        {elevation, geofence} =
+          Repo.checkout(fn ->
+            {:ok, %{elevation: elevation} = position} =
+              call(data.deps.log, :insert_position, [drv, create_position(stream_data, data)])
+
+            geofence = call(data.deps.locations, :find_geofence, [position])
+            {elevation, geofence}
+          end)
 
         vehicle = merge(data.last_response, stream_data)
         now = DateTime.utc_now()
 
-        {:keep_state, %{data | last_used: now, last_response: vehicle, elevation: elevation},
-         broadcast_summary()}
+        {:keep_state,
+         %{
+           data
+           | last_used: now,
+             last_response: vehicle,
+             elevation: elevation,
+             geofence: geofence
+         }, broadcast_summary()}
 
       {_status, %Stream.Data{}} ->
         {:keep_state_and_data, schedule_fetch(0, data)}

--- a/test/support/mocks/locations.ex
+++ b/test/support/mocks/locations.ex
@@ -24,6 +24,11 @@ defmodule LocationsMock do
   end
 
   @impl true
+  def handle_call({:find_geofence, %{latitude: 90, longitude: 45.01}}, _from, state) do
+    geofence = %GeoFence{id: 1, name: "Garage", latitude: 90, longitude: 45.01, radius: 20}
+    {:reply, geofence, state}
+  end
+
   def handle_call({:find_geofence, %{latitude: 90, longitude: 45}}, _from, state) do
     geofence = %GeoFence{id: 0, name: "South Pole", latitude: 90, longitude: 45, radius: 100}
     {:reply, geofence, state}

--- a/test/teslamate/vehicles/vehicle/streaming_test.exs
+++ b/test/teslamate/vehicles/vehicle/streaming_test.exs
@@ -3,6 +3,7 @@ defmodule TeslaMate.Vehicles.Vehicle.StreamingTest do
 
   import ExUnit.CaptureLog
 
+  alias TeslaMate.Locations.GeoFence
   alias TeslaMate.Vehicles.Vehicle.Summary
   alias TeslaMate.Vehicles.Vehicle
   alias TeslaApi.Stream
@@ -154,6 +155,55 @@ defmodule TeslaMate.Vehicles.Vehicle.StreamingTest do
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online, elevation: 4}}}
 
       refute_receive _
+    end
+
+    test "updates the geofence from streaming positions", %{test: name} do
+      now = DateTime.utc_now()
+      now_ts = DateTime.to_unix(now, :millisecond)
+
+      events = [
+        {:ok,
+         online_event(now_ts,
+           drive_state: %{timestamp: now_ts, latitude: 90, longitude: 45}
+         )},
+        fn -> Process.sleep(10_000) end
+      ]
+
+      :ok = start_vehicle(name, events)
+
+      assert_receive {:start_state, car, :online, date: _}
+      assert_receive {:insert_position, ^car, %{latitude: 90, longitude: 45}}
+      assert_receive {ApiMock, {:stream, _eid, func}} when is_function(func)
+
+      assert_receive {:pubsub,
+                      {:broadcast, _, _,
+                       %Summary{state: :online, geofence: %GeoFence{name: "South Pole"}}}}
+
+      stream(name, %{shift_state: "D", est_lat: 90, est_lng: 45, time: now})
+      assert_receive {:start_drive, ^car}
+      assert_receive {:insert_position, drive, %{latitude: 90, longitude: 45}}
+
+      assert_receive {:pubsub,
+                      {:broadcast, _, _,
+                       %Summary{state: :driving, geofence: %GeoFence{name: "South Pole"}}}}
+
+      stream(name, %{shift_state: "D", est_lat: 90, est_lng: 45.01, time: now})
+      assert_receive {:insert_position, ^drive, %{latitude: 90, longitude: 45.01}}
+
+      assert_receive {:pubsub,
+                      {:broadcast, _, _,
+                       %Summary{state: :driving, geofence: %GeoFence{name: "Garage"}}}}
+
+      stream(name, %{shift_state: "D", est_lat: 90, est_lng: 45.1, time: now})
+      assert_receive {:insert_position, ^drive, %{latitude: 90, longitude: 45.1}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving, geofence: nil}}}
+
+      stream(name, %{shift_state: "D", est_lat: 90, est_lng: 45, time: now})
+      assert_receive {:insert_position, ^drive, %{latitude: 90, longitude: 45}}
+
+      assert_receive {:pubsub,
+                      {:broadcast, _, _,
+                       %Summary{state: :driving, geofence: %GeoFence{name: "South Pole"}}}}
     end
 
     test "discards fetch result", %{test: name} do


### PR DESCRIPTION
## Summary

Resolve and store the current geofence for every streamed driving position before broadcasting the vehicle summary.

## Why

The streaming path inserts positions but did not refresh the geofence. When a car crossed into a smaller nested geofence between normal API polls, the UI and MQTT summary could continue publishing the previous larger geofence.

## Compatibility

The change mirrors the existing normal API-position path and uses the same repository checkout for position insertion and geofence lookup. Non-driving stream behavior is unchanged.

## Validation

- Streaming tests covering geofence lookup and summary refresh
- Focused vehicle tests
- Full `mix ci` with all candidate changes: 374 tests passed
- `mix format --check-formatted` and staged secret scan

Closes #1135