### PR TITLE
feat(vehicle): publish field provenance and trust metadata

### DIFF
--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -5,6 +5,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
   import Core.Dependency, only: [call: 3]
 
   alias TeslaMate.Mqtt.Publisher
+  alias TeslaMate.Vehicles.Vehicle.DataQuality
   alias TeslaMate.Vehicles.Vehicle.Summary
   alias TeslaMate.Vehicles
 
@@ -66,6 +67,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
       |> add_car_latitude_longitude(summary)
       |> add_geofence(summary)
       |> add_active_route(summary)
+      |> add_data_quality(summary)
 
     last_values = publish_values(values, state)
     {:noreply, %{state | last_values: last_values}}
@@ -197,6 +199,13 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
       active_route_longitude: summary.active_route_longitude,
       active_route: active_route
     })
+  end
+
+  defp add_data_quality(map, %Summary{quality: quality}) do
+    case DataQuality.mqtt_payload(quality) do
+      nil -> map
+      payload -> Map.put(map, :data_quality, payload)
+    end
   end
 
   defp publish({key, value}, %State{car_id: car_id, namespace: namespace, deps: deps}) do

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -3,7 +3,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   require Logger
 
-  alias __MODULE__.Summary
+  alias __MODULE__.{DataQuality, Summary}
   alias TeslaMate.{Vehicles, Api, Log, Locations, Settings, Convert, Repo, Terrain}
   alias TeslaMate.Settings.CarSettings
   alias TeslaMate.Locations.GeoFence
@@ -18,6 +18,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
     defstruct car: nil,
               last_used: nil,
               last_response: nil,
+              quality: %{},
               last_state_change: nil,
               elevation: nil,
               geofence: nil,
@@ -223,7 +224,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         healthy?: healthy?(data.car.id),
         elevation: data.elevation,
         geofence: data.geofence,
-        car: data.car
+        car: data.car,
+        quality: data.quality
       })
 
     {:keep_state_and_data, {:reply, from, summary}}
@@ -298,7 +300,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
         end
 
       {:next_state, {:suspended, :online},
-       %Data{data | last_state_change: DateTime.utc_now(), last_response: vehicle, task: nil},
+       %Data{
+         data
+         | last_state_change: DateTime.utc_now(),
+           last_response: vehicle,
+           quality: DataQuality.from_rest(vehicle),
+           task: nil
+       },
        [
          {:reply, from, :ok},
          broadcast_fetch(false),
@@ -342,8 +350,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
            }, %Data{}} ->
             log_service_mode_transition(data.last_response, vehicle, data.car.id)
 
-            {:keep_state, %Data{data | last_response: vehicle},
-             [broadcast_fetch(false), {:next_event, :internal, {:update, {:online, vehicle}}}]}
+            {:keep_state,
+             %Data{
+               data
+               | last_response: vehicle,
+                 quality: DataQuality.from_rest(vehicle)
+             }, [broadcast_fetch(false), {:next_event, :internal, {:update, {:online, vehicle}}}]}
 
           # Handle fetch of vehicle/id (non-vehicle_data)
           {%Vehicle{}, %Data{}} ->
@@ -404,8 +416,14 @@ defmodule TeslaMate.Vehicles.Vehicle do
                 %Data{} =
                   data =
                   with %Data{last_response: nil} <- data do
-                    {last_response, geofence} = restore_last_known_values(vehicle, data)
-                    %Data{data | last_response: last_response, geofence: geofence}
+                    {last_response, geofence, quality} = restore_last_known_values(vehicle, data)
+
+                    %Data{
+                      data
+                      | last_response: last_response,
+                        geofence: geofence,
+                        quality: quality
+                    }
                   end
 
                 {:ok, pid} = connect_stream(data)
@@ -434,8 +452,14 @@ defmodule TeslaMate.Vehicles.Vehicle do
         %Data{} =
           data =
           with %Data{last_response: nil} <- data do
-            {last_response, geofence} = restore_last_known_values(vehicle, data)
-            %Data{data | last_response: last_response, geofence: geofence}
+            {last_response, geofence, quality} = restore_last_known_values(vehicle, data)
+
+            %Data{
+              data
+              | last_response: last_response,
+                geofence: geofence,
+                quality: quality
+            }
           end
 
         {:keep_state, %Data{data | pre_online_check: :idle, stream_pid: nil},
@@ -624,8 +648,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
         vehicle = merge(data.last_response, stream_data, time: true)
 
         {:next_state, {:driving, :available, drive},
-         %Data{data | last_response: vehicle, elevation: elevation},
-         [broadcast_summary(), schedule_fetch(0, data)]}
+         %Data{
+           data
+           | last_response: vehicle,
+             elevation: elevation,
+             quality: DataQuality.merge_stream(data.quality, stream_data)
+         }, [broadcast_summary(), schedule_fetch(0, data)]}
 
       %Stream.Data{shift_state: nil, power: power} when is_number(power) and power < 0 ->
         vehicle = merge(data.last_response, stream_data, time: true)
@@ -666,8 +694,14 @@ defmodule TeslaMate.Vehicles.Vehicle do
         vehicle = merge(data.last_response, stream_data)
         now = DateTime.utc_now()
 
-        {:keep_state, %{data | last_used: now, last_response: vehicle, elevation: elevation},
-         broadcast_summary()}
+        {:keep_state,
+         %{
+           data
+           | last_used: now,
+             last_response: vehicle,
+             elevation: elevation,
+             quality: DataQuality.merge_stream(data.quality, stream_data)
+         }, broadcast_summary()}
 
       {_status, %Stream.Data{}} ->
         {:keep_state_and_data, schedule_fetch(0, data)}
@@ -701,8 +735,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
         vehicle = merge(data.last_response, stream_data, time: true)
 
         {:next_state, {:driving, :available, drive},
-         %Data{data | last_response: vehicle, elevation: elevation},
-         [broadcast_summary(), schedule_fetch(0, data)]}
+         %Data{
+           data
+           | last_response: vehicle,
+             elevation: elevation,
+             quality: DataQuality.merge_stream(data.quality, stream_data)
+         }, [broadcast_summary(), schedule_fetch(0, data)]}
 
       %Stream.Data{shift_state: s, power: power}
       when s in [nil, "P"] and is_number(power) and power < 0 ->
@@ -719,8 +757,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
         vehicle = merge(data.last_response, stream_data, time: true)
 
         {:next_state, prev_state,
-         %Data{data | last_response: vehicle, last_used: DateTime.utc_now()},
-         schedule_fetch(0, data)}
+         %Data{
+           data
+           | last_response: vehicle,
+             last_used: DateTime.utc_now(),
+             quality: DataQuality.merge_stream(data.quality, stream_data)
+         }, schedule_fetch(0, data)}
 
       %Stream.Data{} ->
         Logger.debug(inspect(stream_data), car_id: data.car.id)
@@ -875,7 +917,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         healthy?: healthy?(data.car.id),
         elevation: data.elevation,
         geofence: data.geofence,
-        car: data.car
+        car: data.car,
+        quality: data.quality
       })
 
     :ok =
@@ -1452,13 +1495,18 @@ defmodule TeslaMate.Vehicles.Vehicle do
         inside_temp: position.inside_temp
       }
 
+      {version, version_observed_at} =
+        case call(data.deps.log, :get_latest_update, [data.car]) do
+          %Log.Update{version: version, start_date: start_date, end_date: end_date} ->
+            {version, end_date || start_date}
+
+          _ ->
+            {nil, nil}
+        end
+
       vehicle_state = %VehicleState{
         odometer: position.odometer |> Convert.km_to_miles(6),
-        car_version:
-          case call(data.deps.log, :get_latest_update, [data.car]) do
-            %Log.Update{version: version} -> version
-            _ -> nil
-          end
+        car_version: version
       }
 
       vehicle = %{
@@ -1471,9 +1519,14 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
       geofence = call(data.deps.locations, :find_geofence, [position])
 
-      {vehicle, geofence}
+      quality =
+        DataQuality.from_restored_position(position, vehicle,
+          version_observed_at: version_observed_at
+        )
+
+      {vehicle, geofence, quality}
     else
-      _ -> {vehicle, nil}
+      _ -> {vehicle, nil, DataQuality.from_rest(vehicle)}
     end
   end
 

--- a/lib/teslamate/vehicles/vehicle/data_quality.ex
+++ b/lib/teslamate/vehicles/vehicle/data_quality.ex
@@ -1,0 +1,468 @@
+defmodule TeslaMate.Vehicles.Vehicle.DataQuality do
+  @moduledoc """
+  Describes where a live summary field came from and how much it can be trusted.
+
+  Quality is kept separately from field values so existing consumers keep receiving
+  exactly the same payloads.
+  """
+
+  alias TeslaApi.Stream
+  alias TeslaApi.Vehicle
+  alias TeslaMate.Log
+
+  @stale_after_seconds 300
+
+  @type confidence :: :exact | :derived | :estimated | :unknown
+  @type freshness :: :fresh | :stale | :unknown
+  @type availability :: :available | :corrupted | :unavailable
+  @type source ::
+          :tesla_rest | :tesla_stream | :teslamate_database | :teslamate_derived | :unknown
+
+  @type t :: %__MODULE__{
+          confidence: confidence(),
+          freshness: freshness(),
+          availability: availability(),
+          source: source(),
+          observed_at: DateTime.t() | nil,
+          reason: atom() | nil
+        }
+
+  defstruct confidence: :unknown,
+            freshness: :unknown,
+            availability: :unavailable,
+            source: :unknown,
+            observed_at: nil,
+            reason: :not_reported
+
+  @drive_fields ~w(
+    active_route_destination active_route_latitude active_route_longitude
+    active_route_energy_at_arrival active_route_miles_to_arrival
+    active_route_minutes_to_arrival active_route_traffic_minutes_delay
+    latitude longitude power speed shift_state heading
+  )a
+
+  @charge_fields ~w(
+    battery_level charging_state usable_battery_level ideal_battery_range_km
+    est_battery_range_km rated_battery_range_km charge_energy_added
+    scheduled_charging_start_time charge_limit_soc charger_power plugged_in
+    charge_port_door_open time_to_full_charge charger_phases charger_actual_current
+    charger_voltage charge_current_request charge_current_request_max
+  )a
+
+  @climate_fields ~w(
+    outside_temp inside_temp is_climate_on is_preconditioning climate_keeper_mode
+  )a
+
+  @vehicle_state_fields ~w(
+    locked sentry_mode windows_open driver_front_window_open driver_rear_window_open
+    passenger_front_window_open passenger_rear_window_open doors_open
+    driver_front_door_open driver_rear_door_open passenger_front_door_open
+    passenger_rear_door_open odometer version update_available update_version
+    update_status is_user_present trunk_open frunk_open tpms_pressure_fl
+    tpms_pressure_fr tpms_pressure_rl tpms_pressure_rr tpms_soft_warning_fl
+    tpms_soft_warning_fr tpms_soft_warning_rl tpms_soft_warning_rr
+    center_display_state service_mode sun_roof_state sun_roof_percent_open
+    download_perc install_perc
+  )a
+
+  @vehicle_config_fields ~w(sun_roof_installed)a
+  @database_fields ~w(model trim_badging exterior_color wheel_type spoiler_type)a
+
+  @derived_fields ~w(
+    plugged_in windows_open driver_front_window_open driver_rear_window_open
+    passenger_front_window_open passenger_rear_window_open doors_open
+    driver_front_door_open driver_rear_door_open passenger_front_door_open
+    passenger_rear_door_open trunk_open frunk_open version update_available
+    update_version sun_roof_installed
+  )a
+
+  @restored_position_fields ~w(
+    latitude longitude battery_level usable_battery_level
+    ideal_battery_range_km est_battery_range_km rated_battery_range_km
+    outside_temp inside_temp odometer
+  )a
+
+  @stream_fields ~w(latitude longitude speed power heading shift_state battery_level odometer)a
+
+  @percentage_fields ~w(
+    battery_level usable_battery_level charge_limit_soc download_perc install_perc
+    sun_roof_percent_open
+  )a
+
+  @non_negative_fields ~w(
+    odometer ideal_battery_range_km est_battery_range_km rated_battery_range_km
+  )a
+
+  @spec from_rest(%Vehicle{}, DateTime.t()) :: %{atom() => t()}
+  def from_rest(%Vehicle{} = vehicle, received_at \\ DateTime.utc_now()) do
+    %{}
+    |> put_fields(@drive_fields, rest_quality(vehicle.drive_state, received_at))
+    |> put_fields(@charge_fields, rest_quality(vehicle.charge_state, received_at))
+    |> put_fields(@climate_fields, rest_quality(vehicle.climate_state, received_at))
+    |> put_fields(@vehicle_state_fields, rest_quality(vehicle.vehicle_state, received_at))
+    |> put_fields(@vehicle_config_fields, rest_quality(vehicle.vehicle_config, received_at))
+    |> Map.put(:display_name, rest_quality(vehicle.vehicle_state, received_at))
+  end
+
+  @spec from_restored_position(%Log.Position{}, %Vehicle{}, keyword()) :: %{atom() => t()}
+  def from_restored_position(
+        %Log.Position{date: observed_at},
+        %Vehicle{} = vehicle,
+        opts \\ []
+      ) do
+    received_at = Keyword.get_lazy(opts, :received_at, &DateTime.utc_now/0)
+    version_observed_at = Keyword.get(opts, :version_observed_at)
+
+    restored = %__MODULE__{
+      confidence: :exact,
+      freshness: :stale,
+      availability: :available,
+      source: :teslamate_database,
+      observed_at: normalize_datetime(observed_at),
+      reason: :restored_last_position
+    }
+
+    %{}
+    |> put_fields(@restored_position_fields, restored)
+    |> put_restored_version(vehicle, version_observed_at)
+    |> Map.put(:display_name, rest_quality(vehicle.vehicle_state, received_at))
+  end
+
+  @spec merge_stream(%{atom() => t()}, %Stream.Data{}, DateTime.t()) :: %{atom() => t()}
+  def merge_stream(quality, %Stream.Data{} = stream_data, received_at \\ DateTime.utc_now()) do
+    observed_at = normalize_datetime(stream_data.time) || received_at
+
+    stream_quality = %__MODULE__{
+      confidence: :exact,
+      freshness: :fresh,
+      availability: :available,
+      source: :tesla_stream,
+      observed_at: observed_at,
+      reason: nil
+    }
+
+    quality
+    |> put_fields(@stream_fields, stream_quality)
+    |> Map.put(:elevation, stream_quality)
+  end
+
+  @spec for_summary(struct(), %{atom() => t()}, map(), DateTime.t()) :: %{atom() => t()}
+  def for_summary(summary, quality, attrs, now \\ DateTime.utc_now()) do
+    quality =
+      quality
+      |> put_internal_fields()
+      |> put_database_fields(attrs[:car])
+      |> put_derived_fields()
+      |> put_geofence(summary)
+      |> put_elevation(summary)
+
+    summary
+    |> Map.from_struct()
+    |> Map.drop([:car, :quality])
+    |> Enum.reduce(%{}, fn {field, value}, acc ->
+      field_quality = quality |> Map.get(field, %__MODULE__{}) |> classify(field, value, now)
+      Map.put(acc, field, field_quality)
+    end)
+  end
+
+  @spec public_payload(%{atom() => t()}, DateTime.t()) :: map()
+  def public_payload(quality, now \\ DateTime.utc_now()) do
+    fields =
+      quality
+      |> Enum.sort_by(fn {field, _quality} -> field end)
+      |> Map.new(fn {field, field_quality} ->
+        {Atom.to_string(field), metadata(field_quality, now, include_age: true)}
+      end)
+
+    %{
+      schema_version: 1,
+      generated_at: DateTime.to_iso8601(now),
+      fields: fields
+    }
+  end
+
+  @spec mqtt_payload(%{atom() => t()}) :: String.t() | nil
+  def mqtt_payload(quality) when map_size(quality) == 0, do: nil
+
+  def mqtt_payload(quality) do
+    groups =
+      quality
+      |> Enum.sort_by(fn {field, _quality} -> field end)
+      |> Enum.map(fn {field, field_quality} ->
+        field_quality = %{
+          field_quality
+          | observed_at: mqtt_observed_at(field_quality.observed_at)
+        }
+
+        {
+          metadata(field_quality, field_quality.observed_at || DateTime.utc_now(),
+            include_age: false
+          ),
+          Atom.to_string(field)
+        }
+      end)
+      |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+      |> Enum.map(fn {metadata, fields} -> Map.put(metadata, :fields, Enum.sort(fields)) end)
+      |> Enum.sort_by(fn %{fields: fields} -> hd(fields) end)
+
+    Jason.encode!(%{schema_version: 1, groups: groups})
+  end
+
+  defp put_internal_fields(quality) do
+    internal = %__MODULE__{
+      confidence: :derived,
+      freshness: :fresh,
+      availability: :available,
+      source: :teslamate_derived,
+      observed_at: nil,
+      reason: :derived_value
+    }
+
+    put_fields(quality, [:state, :since, :healthy], internal)
+  end
+
+  defp put_database_fields(quality, car) do
+    observed_at =
+      case car do
+        %{updated_at: updated_at} -> normalize_datetime(updated_at)
+        _ -> nil
+      end
+
+    database = %__MODULE__{
+      confidence: :exact,
+      freshness: :unknown,
+      availability: :available,
+      source: :teslamate_database,
+      observed_at: observed_at,
+      reason: nil
+    }
+
+    put_fields(quality, @database_fields, database)
+  end
+
+  defp put_derived_fields(quality) do
+    Enum.reduce(@derived_fields, quality, fn field, acc ->
+      base = Map.get(acc, field, %__MODULE__{})
+
+      Map.put(acc, field, %{
+        base
+        | confidence: :derived,
+          source: :teslamate_derived,
+          reason: provenance_reason(base, :derived_value)
+      })
+    end)
+  end
+
+  defp put_geofence(quality, summary) do
+    base = Map.get(quality, :latitude, %__MODULE__{})
+
+    Map.put(quality, :geofence, %{
+      base
+      | confidence: :derived,
+        source: :teslamate_derived,
+        reason: provenance_reason(base, :derived_value),
+        availability: if(summary.geofence, do: :available, else: :unavailable)
+    })
+  end
+
+  defp put_elevation(quality, summary) do
+    if Map.has_key?(quality, :elevation) do
+      quality
+    else
+      base = Map.get(quality, :latitude, %__MODULE__{})
+
+      Map.put(quality, :elevation, %{
+        base
+        | confidence: :estimated,
+          source: :teslamate_derived,
+          reason: :terrain_lookup,
+          availability: if(is_nil(summary.elevation), do: :unavailable, else: :available)
+      })
+    end
+  end
+
+  defp rest_quality(nil, received_at) do
+    %__MODULE__{
+      confidence: :exact,
+      freshness: :fresh,
+      availability: :unavailable,
+      source: :tesla_rest,
+      observed_at: received_at,
+      reason: :not_reported
+    }
+  end
+
+  defp rest_quality(group, received_at) do
+    observed_at = normalize_datetime(Map.get(group, :timestamp)) || received_at
+
+    %__MODULE__{
+      confidence: :exact,
+      freshness: :fresh,
+      availability: :available,
+      source: :tesla_rest,
+      observed_at: observed_at,
+      reason: nil
+    }
+  end
+
+  defp put_fields(quality, fields, field_quality) do
+    Enum.reduce(fields, quality, &Map.put(&2, &1, field_quality))
+  end
+
+  defp classify(field_quality, _field, nil, now) do
+    %{refresh(field_quality, now) | availability: :unavailable, reason: :not_reported}
+  end
+
+  defp classify(field_quality, _field, :unknown, now) do
+    %{refresh(field_quality, now) | availability: :unavailable, reason: :unknown_value}
+  end
+
+  defp classify(field_quality, field, value, now) do
+    field_quality = clear_unavailable_reason(field_quality)
+
+    field_quality =
+      if field == :est_battery_range_km do
+        %{
+          field_quality
+          | confidence: :estimated,
+            reason: field_quality.reason || :tesla_estimate
+        }
+      else
+        field_quality
+      end
+
+    case corrupted_reason(field, value) do
+      nil -> %{refresh(field_quality, now) | availability: :available}
+      reason -> %{refresh(field_quality, now) | availability: :corrupted, reason: reason}
+    end
+  end
+
+  defp corrupted_reason(field, value) when field in @percentage_fields do
+    if number_in_range?(value, 0, 100), do: nil, else: :outside_expected_range
+  end
+
+  defp corrupted_reason(field, value) when field in [:latitude, :active_route_latitude] do
+    if number_in_range?(value, -90, 90), do: nil, else: :outside_expected_range
+  end
+
+  defp corrupted_reason(field, value) when field in [:longitude, :active_route_longitude] do
+    if number_in_range?(value, -180, 180), do: nil, else: :outside_expected_range
+  end
+
+  defp corrupted_reason(field, value) when field in @non_negative_fields do
+    if number_in_range?(value, 0, :infinity), do: nil, else: :outside_expected_range
+  end
+
+  defp corrupted_reason(_field, _value), do: nil
+
+  defp provenance_reason(%__MODULE__{reason: reason}, fallback)
+       when reason in [nil, :not_reported, :unknown_value],
+       do: fallback
+
+  defp provenance_reason(%__MODULE__{reason: reason}, _fallback), do: reason
+
+  defp clear_unavailable_reason(%__MODULE__{reason: reason} = quality)
+       when reason in [:not_reported, :unknown_value],
+       do: %{quality | reason: nil}
+
+  defp clear_unavailable_reason(quality), do: quality
+
+  defp number_in_range?(%Decimal{} = value, min, max) do
+    number_in_range?(Decimal.to_float(value), min, max)
+  end
+
+  defp number_in_range?(value, min, :infinity) when is_number(value), do: value >= min
+  defp number_in_range?(value, min, max) when is_number(value), do: value >= min and value <= max
+  defp number_in_range?(_value, _min, _max), do: false
+
+  defp refresh(
+         %__MODULE__{freshness: :fresh, observed_at: %DateTime{} = observed_at} = quality,
+         now
+       ) do
+    if DateTime.diff(now, observed_at) > @stale_after_seconds do
+      %{quality | freshness: :stale}
+    else
+      quality
+    end
+  end
+
+  defp refresh(quality, _now), do: quality
+
+  defp metadata(%__MODULE__{} = quality, now, opts) do
+    quality = if Keyword.fetch!(opts, :include_age), do: refresh(quality, now), else: quality
+
+    %{
+      label: label(quality),
+      confidence: Atom.to_string(quality.confidence),
+      freshness: Atom.to_string(quality.freshness),
+      availability: Atom.to_string(quality.availability),
+      source: Atom.to_string(quality.source),
+      observed_at: iso8601(quality.observed_at),
+      reason: quality.reason && Atom.to_string(quality.reason)
+    }
+    |> maybe_put_age(quality, now, opts)
+  end
+
+  defp maybe_put_age(metadata, quality, now, include_age: true) do
+    age_seconds =
+      case quality.observed_at do
+        %DateTime{} = observed_at -> max(DateTime.diff(now, observed_at), 0)
+        nil -> nil
+      end
+
+    Map.put(metadata, :age_seconds, age_seconds)
+  end
+
+  defp maybe_put_age(metadata, _quality, _now, include_age: false), do: metadata
+
+  defp label(%__MODULE__{availability: :corrupted}), do: "corrupted"
+  defp label(%__MODULE__{availability: :unavailable}), do: "unavailable"
+  defp label(%__MODULE__{freshness: :stale}), do: "stale"
+  defp label(%__MODULE__{confidence: confidence}), do: Atom.to_string(confidence)
+
+  defp normalize_datetime(%DateTime{} = datetime), do: datetime
+
+  defp normalize_datetime(%NaiveDateTime{} = datetime) do
+    DateTime.from_naive!(datetime, "Etc/UTC")
+  end
+
+  defp normalize_datetime(timestamp) when is_integer(timestamp) and timestamp > 0 do
+    unit = if abs(timestamp) > 10_000_000_000, do: :millisecond, else: :second
+
+    case DateTime.from_unix(timestamp, unit) do
+      {:ok, datetime} -> datetime
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp normalize_datetime(timestamp) when is_integer(timestamp), do: nil
+
+  defp normalize_datetime(_datetime), do: nil
+
+  defp put_restored_version(
+         quality,
+         %Vehicle{vehicle_state: %{car_version: version}},
+         observed_at
+       )
+       when is_binary(version) and version != "" do
+    Map.put(quality, :version, %__MODULE__{
+      confidence: :exact,
+      freshness: :stale,
+      availability: :available,
+      source: :teslamate_database,
+      observed_at: normalize_datetime(observed_at),
+      reason: :restored_last_update
+    })
+  end
+
+  defp put_restored_version(quality, _vehicle, _observed_at), do: quality
+
+  defp iso8601(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
+  defp iso8601(nil), do: nil
+
+  defp mqtt_observed_at(%DateTime{} = datetime) do
+    %{datetime | second: 0, microsecond: {0, 0}}
+  end
+
+  defp mqtt_observed_at(nil), do: nil
+end

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -1,11 +1,12 @@
 defmodule TeslaMate.Vehicles.Vehicle.Summary do
   import TeslaMate.Convert, only: [miles_to_km: 2, mph_to_kmh: 1]
 
+  alias TeslaMate.Vehicles.Vehicle.DataQuality
   alias TeslaApi.Vehicle.State.{Drive, Charge, VehicleConfig, VehicleState}
   alias TeslaApi.Vehicle
   alias TeslaMate.Log.Car
 
-  defstruct ~w(
+  @fields ~w(
     car display_name state since healthy latitude longitude heading battery_level charging_state usable_battery_level
     ideal_battery_range_km est_battery_range_km rated_battery_range_km charge_energy_added
     speed outside_temp inside_temp is_climate_on is_preconditioning locked sentry_mode
@@ -22,17 +23,22 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     center_display_state service_mode sun_roof_state sun_roof_installed sun_roof_percent_open download_perc install_perc
   )a
 
-  def into(nil, %{state: :start, healthy?: healthy?, car: car}) do
-    %__MODULE__{
-      state: :unavailable,
-      healthy: healthy?,
-      trim_badging: get_car_attr(car, :trim_badging),
-      exterior_color: get_car_attr(car, :exterior_color),
-      spoiler_type: get_car_attr(car, :spoiler_type),
-      wheel_type: get_car_attr(car, :wheel_type),
-      model: get_car_attr(car, :model),
-      car: car
-    }
+  defstruct @fields ++ [quality: %{}]
+
+  def into(nil, %{state: :start, healthy?: healthy?, car: car} = attrs) do
+    summary =
+      %__MODULE__{
+        state: :unavailable,
+        healthy: healthy?,
+        trim_badging: get_car_attr(car, :trim_badging),
+        exterior_color: get_car_attr(car, :exterior_color),
+        spoiler_type: get_car_attr(car, :spoiler_type),
+        wheel_type: get_car_attr(car, :wheel_type),
+        model: get_car_attr(car, :model),
+        car: car
+      }
+
+    put_quality(summary, attrs)
   end
 
   def into(vehicle, attrs) do
@@ -45,20 +51,27 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       geofence: gf
     } = attrs
 
-    %__MODULE__{
-      format_vehicle(vehicle)
-      | state: format_state(state),
-        since: since,
-        healthy: healthy?,
-        elevation: elevation,
-        geofence: gf,
-        trim_badging: get_car_attr(car, :trim_badging),
-        exterior_color: get_car_attr(car, :exterior_color),
-        spoiler_type: get_car_attr(car, :spoiler_type),
-        wheel_type: get_car_attr(car, :wheel_type),
-        model: get_car_attr(car, :model),
-        car: car
-    }
+    summary =
+      %__MODULE__{
+        format_vehicle(vehicle)
+        | state: format_state(state),
+          since: since,
+          healthy: healthy?,
+          elevation: elevation,
+          geofence: gf,
+          trim_badging: get_car_attr(car, :trim_badging),
+          exterior_color: get_car_attr(car, :exterior_color),
+          spoiler_type: get_car_attr(car, :spoiler_type),
+          wheel_type: get_car_attr(car, :wheel_type),
+          model: get_car_attr(car, :model),
+          car: car
+      }
+
+    put_quality(summary, attrs)
+  end
+
+  defp put_quality(summary, attrs) do
+    %{summary | quality: DataQuality.for_summary(summary, Map.get(attrs, :quality, %{}), attrs)}
   end
 
   defp format_state({:driving, {:offline, _}, _id}), do: :offline

--- a/lib/teslamate_web/controllers/car_controller.ex
+++ b/lib/teslamate_web/controllers/car_controller.ex
@@ -6,6 +6,7 @@ defmodule TeslaMateWeb.CarController do
 
   alias TeslaMate.Api, warn: false
   alias TeslaMate.{Log, Vehicles}
+  alias TeslaMate.Vehicles.Vehicle.DataQuality
 
   plug :redirect_if_importing when action in [:index]
   plug :fetch_signed_in when action in [:index]
@@ -42,6 +43,28 @@ defmodule TeslaMateWeb.CarController do
     car = Log.get_car!(id)
     :ok = Vehicles.resume_logging(car.id)
     send_resp(conn, :no_content, "")
+  end
+
+  def data_quality(conn, %{"id" => id}) do
+    car = Log.get_car!(id)
+    conn = put_resp_header(conn, "cache-control", "no-store")
+
+    case Process.whereis(:"#{car.id}") do
+      pid when is_pid(pid) ->
+        payload =
+          pid
+          |> Vehicles.summary()
+          |> Map.fetch!(:quality)
+          |> DataQuality.public_payload()
+          |> Map.put(:car_id, car.id)
+
+        json(conn, payload)
+
+      nil ->
+        conn
+        |> put_status(:service_unavailable)
+        |> json(%{error: "vehicle_unavailable"})
+    end
   end
 
   case Mix.env() do

--- a/lib/teslamate_web/router.ex
+++ b/lib/teslamate_web/router.ex
@@ -52,6 +52,7 @@ defmodule TeslaMateWeb.Router do
 
     put "/car/:id/logging/resume", CarController, :resume_logging
     put "/car/:id/logging/suspend", CarController, :suspend_logging
+    get "/car/:id/data-quality", CarController, :data_quality
   end
 
   def fetch_settings(conn, _opts) do

--- a/test/support/mocks/pubsub.ex
+++ b/test/support/mocks/pubsub.ex
@@ -27,6 +27,22 @@ defmodule PubSubMock do
     {:reply, :ok, state}
   end
 
+  def handle_call(
+        {:broadcast, server, topic, %TeslaMate.Vehicles.Vehicle.Summary{} = summary} = event,
+        _from,
+        %State{
+          last_event:
+            {:broadcast, server, topic, %TeslaMate.Vehicles.Vehicle.Summary{} = last_summary}
+        } = state
+      ) do
+    if %{summary | quality: %{}} == %{last_summary | quality: %{}} do
+      {:reply, :ok, state}
+    else
+      send(state.pid, {:pubsub, event})
+      {:reply, :ok, %State{state | last_event: event}}
+    end
+  end
+
   def handle_call({:broadcast, _, _, _} = event, _from, %State{last_event: event} = state) do
     {:reply, :ok, state}
   end

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -79,7 +79,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     send(pid, summary)
 
     for {key, val} <- Map.from_struct(summary),
-        not is_nil(val) and key not in [:since, :geofence] do
+        not is_nil(val) and key not in [:since, :geofence, :quality] do
       topic = "teslamate/cars/0/#{key}"
       data = to_string(val)
       retain = key not in [:healthy]
@@ -173,7 +173,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
                     {:publish, "teslamate/cars/0/healthy", "", [retain: true, qos: 1]}}
 
     for {key, val} <- Map.from_struct(summary),
-        not is_nil(val) and key != :scheduled_charging_start_time do
+        not is_nil(val) and key not in [:quality, :scheduled_charging_start_time] do
       topic = "teslamate/cars/0/#{key}"
       data = to_string(val)
       retain = key not in [:healthy]
@@ -246,6 +246,55 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     send(pid, %Summary{geofence: other_geofence, version: "3"})
     assert_receive {MqttPublisherMock, {:publish, "teslamate/cars/0/geofence", "Work", _}}
     assert_receive {MqttPublisherMock, {:publish, "teslamate/cars/0/version", "3", _}}
+  end
+
+  test "publishes retained, redacted data quality only when it changes", %{test: name} do
+    {:ok, pid} = start_subscriber(name, 0)
+
+    assert_receive {VehiclesMock, {:subscribe_to_summary, 0}}
+
+    observed_at = DateTime.utc_now()
+
+    summary = %Summary{
+      display_name: "Blue Thunder",
+      quality: %{
+        display_name: %TeslaMate.Vehicles.Vehicle.DataQuality{
+          confidence: :exact,
+          freshness: :fresh,
+          availability: :available,
+          source: :tesla_rest,
+          observed_at: observed_at,
+          reason: nil
+        }
+      }
+    }
+
+    send(pid, summary)
+
+    assert_receive {MqttPublisherMock,
+                    {:publish, "teslamate/cars/0/data_quality", payload, [retain: true, qos: 1]}}
+
+    assert %{
+             "schema_version" => 1,
+             "groups" => [
+               %{
+                 "fields" => ["display_name"],
+                 "source" => "tesla_rest",
+                 "confidence" => "exact"
+               } = group
+             ]
+           } = Jason.decode!(payload)
+
+    refute Map.has_key?(group, "age_seconds")
+
+    assert Enum.sort(Map.keys(group)) ==
+             ~w(availability confidence fields freshness label observed_at reason source)
+
+    refute payload =~ "Blue Thunder"
+
+    send(pid, summary)
+
+    refute_receive {MqttPublisherMock, {:publish, "teslamate/cars/0/data_quality", _, _}}
   end
 
   @tag :capture_log

--- a/test/teslamate/vehicles/vehicle/data_quality_test.exs
+++ b/test/teslamate/vehicles/vehicle/data_quality_test.exs
@@ -1,0 +1,275 @@
+defmodule TeslaMate.Vehicles.Vehicle.DataQualityTest do
+  use ExUnit.Case, async: true
+
+  alias TeslaApi.Stream
+  alias TeslaApi.Vehicle
+  alias TeslaApi.Vehicle.State.{Charge, Climate, Drive, VehicleConfig, VehicleState}
+  alias TeslaMate.Log
+  alias TeslaMate.Vehicles.Vehicle.{DataQuality, Summary}
+
+  test "keeps confidence, freshness, availability and source independent" do
+    now = DateTime.utc_now()
+    timestamp = DateTime.to_unix(now, :millisecond)
+
+    vehicle = %Vehicle{
+      display_name: "Blue Thunder",
+      drive_state: %Drive{timestamp: timestamp, latitude: 51.5},
+      charge_state: %Charge{
+        timestamp: timestamp,
+        battery_level: 80,
+        est_battery_range: 200,
+        charging_state: "Disconnected"
+      },
+      climate_state: %Climate{timestamp: timestamp},
+      vehicle_state: %VehicleState{timestamp: timestamp, locked: true},
+      vehicle_config: %VehicleConfig{timestamp: timestamp}
+    }
+
+    summary = %Summary{
+      latitude: 51.5,
+      battery_level: 80,
+      est_battery_range_km: 321.87,
+      plugged_in: false,
+      locked: true
+    }
+
+    quality =
+      summary
+      |> DataQuality.for_summary(DataQuality.from_rest(vehicle, now), %{car: nil}, now)
+
+    assert %DataQuality{
+             confidence: :exact,
+             freshness: :fresh,
+             availability: :available,
+             source: :tesla_rest,
+             reason: nil
+           } = quality.latitude
+
+    assert DateTime.to_unix(quality.latitude.observed_at, :millisecond) == timestamp
+
+    assert %DataQuality{confidence: :estimated, reason: :tesla_estimate} =
+             quality.est_battery_range_km
+
+    assert %DataQuality{confidence: :derived, source: :teslamate_derived} = quality.plugged_in
+
+    assert %DataQuality{availability: :unavailable, reason: :not_reported} =
+             quality.inside_temp
+
+    assert map_size(quality) == map_size(Map.from_struct(summary)) - 2
+  end
+
+  test "stream observations replace only fields merged from the stream" do
+    now = DateTime.utc_now()
+    timestamp = DateTime.to_unix(now, :millisecond)
+
+    vehicle = %Vehicle{
+      drive_state: %Drive{timestamp: timestamp},
+      charge_state: %Charge{timestamp: timestamp},
+      climate_state: %Climate{timestamp: timestamp},
+      vehicle_state: %VehicleState{timestamp: timestamp},
+      vehicle_config: %VehicleConfig{timestamp: timestamp}
+    }
+
+    stream_time = DateTime.add(now, 10, :second)
+
+    stream_data = %Stream.Data{
+      time: stream_time,
+      est_lat: 91,
+      est_lng: 10,
+      speed: 20,
+      power: 5,
+      est_heading: 180,
+      shift_state: "D",
+      soc: 101,
+      odometer: 100,
+      elevation: 12
+    }
+
+    quality =
+      DataQuality.from_rest(vehicle, now)
+      |> DataQuality.merge_stream(stream_data, stream_time)
+
+    summary = %Summary{
+      latitude: 91,
+      active_route_latitude: 91,
+      active_route_longitude: -181,
+      battery_level: 101,
+      locked: true,
+      elevation: 12
+    }
+
+    quality = DataQuality.for_summary(summary, quality, %{car: nil}, stream_time)
+
+    assert %DataQuality{
+             source: :tesla_stream,
+             observed_at: ^stream_time,
+             availability: :corrupted,
+             reason: :outside_expected_range
+           } = quality.latitude
+
+    assert %DataQuality{source: :tesla_stream, availability: :corrupted} =
+             quality.battery_level
+
+    assert %DataQuality{source: :tesla_stream, availability: :available} = quality.elevation
+    assert %DataQuality{source: :tesla_rest, availability: :available} = quality.locked
+
+    assert %DataQuality{availability: :corrupted, reason: :outside_expected_range} =
+             quality.active_route_latitude
+
+    assert %DataQuality{availability: :corrupted, reason: :outside_expected_range} =
+             quality.active_route_longitude
+  end
+
+  test "restored values remain explicitly stale and unknown values remain unavailable" do
+    observed_at = DateTime.add(DateTime.utc_now(), -3600, :second)
+    version_observed_at = DateTime.add(observed_at, -3600, :second)
+    position = %Log.Position{date: observed_at}
+
+    vehicle = %Vehicle{
+      display_name: "Blue Thunder",
+      vehicle_state: %VehicleState{car_version: "2026.20 abc123"}
+    }
+
+    summary = %Summary{
+      latitude: 51.5,
+      est_battery_range_km: 300,
+      shift_state: :unknown,
+      charge_energy_added: :unknown,
+      version: "2026.20"
+    }
+
+    quality =
+      position
+      |> DataQuality.from_restored_position(vehicle,
+        version_observed_at: version_observed_at
+      )
+      |> then(&DataQuality.for_summary(summary, &1, %{car: nil}, DateTime.utc_now()))
+
+    assert %DataQuality{
+             confidence: :exact,
+             freshness: :stale,
+             availability: :available,
+             source: :teslamate_database,
+             observed_at: ^observed_at,
+             reason: :restored_last_position
+           } = quality.latitude
+
+    assert %DataQuality{confidence: :estimated, freshness: :stale} =
+             quality.est_battery_range_km
+
+    assert %DataQuality{
+             availability: :unavailable,
+             confidence: :unknown,
+             source: :unknown,
+             reason: :unknown_value
+           } =
+             quality.shift_state
+
+    assert %DataQuality{availability: :unavailable, source: :unknown} =
+             quality.charge_energy_added
+
+    assert %DataQuality{
+             confidence: :derived,
+             freshness: :stale,
+             source: :teslamate_derived,
+             observed_at: ^version_observed_at,
+             reason: :restored_last_update
+           } = quality.version
+  end
+
+  test "public payload contains metadata but never field values" do
+    now = DateTime.utc_now()
+
+    quality = %{
+      display_name: %DataQuality{
+        confidence: :exact,
+        freshness: :fresh,
+        availability: :available,
+        source: :tesla_rest,
+        observed_at: now,
+        reason: nil
+      }
+    }
+
+    payload = DataQuality.public_payload(quality, now)
+    encoded = Jason.encode!(payload)
+
+    assert payload.fields["display_name"].age_seconds == 0
+    assert payload.fields["display_name"].label == "exact"
+    refute encoded =~ "Blue Thunder"
+    refute encoded =~ "\"value\""
+  end
+
+  test "MQTT groups identical metadata and uses minute precision for stable deduplication" do
+    first = ~U[2026-07-16 10:00:05Z]
+    second = ~U[2026-07-16 10:00:55Z]
+
+    quality = fn observed_at ->
+      %{
+        heading: %DataQuality{
+          confidence: :exact,
+          freshness: :fresh,
+          availability: :available,
+          source: :tesla_stream,
+          observed_at: observed_at,
+          reason: nil
+        },
+        speed: %DataQuality{
+          confidence: :exact,
+          freshness: :fresh,
+          availability: :available,
+          source: :tesla_stream,
+          observed_at: observed_at,
+          reason: nil
+        }
+      }
+    end
+
+    assert DataQuality.mqtt_payload(quality.(first)) == DataQuality.mqtt_payload(quality.(second))
+
+    assert %{
+             "groups" => [
+               %{
+                 "fields" => ["heading", "speed"],
+                 "observed_at" => "2026-07-16T10:00:00Z"
+               }
+             ]
+           } = Jason.decode!(DataQuality.mqtt_payload(quality.(first)))
+
+    refute DataQuality.mqtt_payload(quality.(second)) ==
+             DataQuality.mqtt_payload(quality.(~U[2026-07-16 10:01:00Z]))
+  end
+
+  test "MQTT grouped metadata stays below the 4 KiB payload ceiling" do
+    observed_at = ~U[2026-07-16 10:00:05Z]
+
+    reasons =
+      [nil, :derived_value, :terrain_lookup, :tesla_estimate, :unknown_value, :not_reported]
+
+    quality =
+      %Summary{}
+      |> Map.from_struct()
+      |> Map.drop([:car, :quality])
+      |> Map.keys()
+      |> Enum.sort()
+      |> Enum.with_index()
+      |> Map.new(fn {field, index} ->
+        {field,
+         %DataQuality{
+           confidence: :exact,
+           freshness: :fresh,
+           availability: :available,
+           source: :tesla_rest,
+           observed_at: observed_at,
+           reason: Enum.at(reasons, rem(index, length(reasons)))
+         }}
+      end)
+
+    payload = DataQuality.mqtt_payload(quality)
+    %{"groups" => groups} = Jason.decode!(payload)
+
+    assert length(groups) == length(reasons)
+    assert Enum.sum(Enum.map(groups, &length(&1["fields"]))) == map_size(quality)
+    assert byte_size(payload) < 4_096
+  end
+end

--- a/test/teslamate/vehicles/vehicle/streaming_test.exs
+++ b/test/teslamate/vehicles/vehicle/streaming_test.exs
@@ -86,7 +86,12 @@ defmodule TeslaMate.Vehicles.Vehicle.StreamingTest do
 
       assert_receive {:pubsub,
                       {:broadcast, _, _,
-                       %Summary{state: :driving, speed: 16, power: 5, elevation: 1}}}
+                       %Summary{state: :driving, speed: 16, power: 5, elevation: 1} = summary}}
+
+      assert summary.quality.speed.source == :tesla_stream
+      assert summary.quality.speed.observed_at == now
+      assert summary.quality.elevation.source == :tesla_stream
+      assert summary.quality.locked.source == :tesla_rest
 
       assert position == %{
                latitude: 42.1,

--- a/test/teslamate/vehicles/vehicle_sync_test.exs
+++ b/test/teslamate/vehicles/vehicle_sync_test.exs
@@ -74,6 +74,12 @@ defmodule TeslaMate.Vehicles.VehicleSyncTest do
 
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :asleep} = summary}}
 
+      assert summary.quality.latitude.source == :teslamate_database
+      assert summary.quality.latitude.freshness == :stale
+      assert summary.quality.shift_state.availability == :unavailable
+      assert summary.quality.shift_state.source == :unknown
+      assert summary.quality.charge_energy_added.source == :unknown
+
       assert summary == %Summary{
                battery_level: 64,
                car: car,
@@ -105,6 +111,7 @@ defmodule TeslaMate.Vehicles.VehicleSyncTest do
                odometer: 91887.73,
                outside_temp: Decimal.from_float(16.5),
                plugged_in: :unknown,
+               quality: summary.quality,
                rated_battery_range_km: 315.06,
                scheduled_charging_start_time: :unknown,
                sentry_mode: nil,
@@ -180,6 +187,16 @@ defmodule TeslaMate.Vehicles.VehicleSyncTest do
         assert_receive {MqttPublisherMock, {:publish, ^topic, data, [retain: true, qos: 1]}}
         assert Jason.decode!(data) == %{"error" => "No active route available"}
       end
+
+      topic = "teslamate/cars/#{car.id}/data_quality"
+      assert_receive {MqttPublisherMock, {:publish, ^topic, payload, [retain: true, qos: 1]}}
+
+      assert %{"schema_version" => 1, "groups" => groups} = Jason.decode!(payload)
+
+      assert Enum.any?(groups, fn
+               %{"fields" => fields, "freshness" => "stale"} -> "latitude" in fields
+               _group -> false
+             end)
 
       refute_receive _
     end

--- a/test/teslamate_web/controllers/car_controller_test.exs
+++ b/test/teslamate_web/controllers/car_controller_test.exs
@@ -573,6 +573,59 @@ defmodule TeslaMateWeb.CarControllerTest do
     end
   end
 
+  describe "data quality" do
+    test "returns redacted field metadata", %{conn: conn} do
+      car =
+        car_fixture(%{suspend_min: 60, suspend_after_idle_min: 60, use_streaming_api: false})
+
+      now_ts = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+
+      events = [
+        {:ok,
+         online_event(
+           now_ts,
+           display_name: "Blue Thunder",
+           drive_state: %{timestamp: now_ts, latitude: 51.5, longitude: -0.1}
+         )}
+      ]
+
+      :ok = start_vehicles(events)
+      Process.sleep(100)
+
+      conn = get(conn, Routes.car_path(conn, :data_quality, car.id))
+      payload = json_response(conn, 200)
+
+      assert payload["schema_version"] == 1
+      assert payload["car_id"] == car.id
+      assert payload["fields"]["latitude"]["source"] == "tesla_rest"
+      assert payload["fields"]["latitude"]["availability"] == "available"
+      assert is_integer(payload["fields"]["latitude"]["age_seconds"])
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+
+      assert Enum.all?(payload["fields"], fn {_field, metadata} ->
+               Enum.sort(Map.keys(metadata)) ==
+                 ~w(age_seconds availability confidence freshness label observed_at reason source)
+             end)
+
+      refute Enum.any?(payload["fields"], fn {_field, metadata} ->
+               51.5 in Map.values(metadata) or -0.1 in Map.values(metadata)
+             end)
+
+      refute conn.resp_body =~ "Blue Thunder"
+      refute conn.resp_body =~ "xxxxx"
+      refute conn.resp_body =~ "\"value\""
+    end
+
+    test "returns service unavailable when the car logger is unavailable", %{conn: conn} do
+      car = car_fixture(%{})
+
+      conn = get(conn, Routes.car_path(conn, :data_quality, car.id))
+
+      assert json_response(conn, 503) == %{"error" => "vehicle_unavailable"}
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+    end
+  end
+
   describe "suspend" do
     setup %{conn: conn} do
       {:ok, conn: put_req_header(conn, "accept", "application/json")}

--- a/website/docs/integrations/mqtt.md
+++ b/website/docs/integrations/mqtt.md
@@ -15,6 +15,7 @@ Vehicle data will be published to the following topics:
 | `teslamate/cars/$car_id/state`                         | asleep                                                                                      | Status of the vehicle (e.g. `online`, `asleep`, `charging`)                           |
 | `teslamate/cars/$car_id/since`                         | 2019-02-29T23:00:07Z                                                                        | Date of the last status change                                                        |
 | `teslamate/cars/$car_id/healthy`                       | true                                                                                        | Health status of the logger for that vehicle                                          |
+| `teslamate/cars/$car_id/data_quality`                  | _See below_                                                                                 | Retained, metadata-only provenance and trust status for vehicle fields                |
 | `teslamate/cars/$car_id/version`                       | 2019.32.12.2                                                                                | Software Version                                                                      |
 | `teslamate/cars/$car_id/update_available`              | false                                                                                       | Indicates if a software update is available                                           |
 | `teslamate/cars/$car_id/update_version`                | 2019.32.12.3                                                                                | Software version of the available update                                              |
@@ -100,6 +101,42 @@ Vehicle data will be published to the following topics:
 :::note
 `$car_id` usually starts at 1
 :::
+
+### `data_quality` payload
+
+The retained `data_quality` topic describes each field without repeating its value. Existing
+value topics and payloads are unchanged. Fields with identical metadata are grouped together,
+field names are sorted, and observation times use minute precision so streaming updates do not
+republish otherwise unchanged metadata every second.
+
+```json
+{
+  "schema_version": 1,
+  "groups": [
+    {
+      "fields": ["battery_level", "usable_battery_level"],
+      "label": "exact",
+      "confidence": "exact",
+      "freshness": "fresh",
+      "availability": "available",
+      "source": "tesla_rest",
+      "observed_at": "2026-07-16T10:00:00Z",
+      "reason": null
+    }
+  ]
+}
+```
+
+### REST data-quality endpoint
+
+`GET /api/car/$car_id/data-quality` returns the same metadata as an ungrouped JSON
+object and adds `age_seconds` for each field. It does not include the field values and
+responses use `Cache-Control: no-store`.
+
+This endpoint does not authenticate requests. Observation timestamps and field availability can
+still reveal when TeslaMate last received particular kinds of data. Protect access to TeslaMate
+with a reverse proxy or another access-control layer if the service is reachable outside a trusted
+network.
 
 ### `active_route` payload examples
 


### PR DESCRIPTION

### Context

This adapts an operational pattern used in Teslatlas. The TeslaMate implementation here was written for this repository and is contributed under TeslaMate's CLA and AGPLv3 terms; no proprietary Teslatlas code is included.

TeslaMate exposes useful values, but a consumer cannot always tell whether a field came from a fresh REST response, the streaming API, a restored database position, or a derived calculation. It also cannot distinguish unavailable data from a value that is stale or outside an expected range.

### What the suggestion does

- Keeps all existing summary and MQTT value payloads unchanged
- Tracks confidence as `exact`, `derived`, `estimated`, or `unknown`
- Tracks freshness as `fresh`, `stale`, or `unknown`
- Tracks availability as `available`, `corrupted`, or `unavailable`
- Identifies REST, stream, database, and TeslaMate-derived sources
- Includes observation time, age where requested, and a bounded reason
- Detects out-of-range percentages and route or vehicle coordinates
- Marks restored database values as stale rather than pretending they are current
- Adds `GET /api/car/:id/data-quality` for ungrouped field metadata
- Adds retained `teslamate/cars/$car_id/data_quality` MQTT metadata grouped by identical trust state

No field values are copied into either metadata payload. The HTTP response uses `Cache-Control: no-store`. The MQTT form rounds observation time to the minute and relies on existing publisher deduplication.

### Disclosure boundary

The HTTP endpoint follows the existing unauthenticated `/api/car` pattern. Although it contains no vehicle values, observation timestamps and field availability can reveal when TeslaMate last received particular kinds of data. The documentation calls this out and recommends access control when TeslaMate is reachable outside a trusted network.

The MQTT payload is rebuilt for each summary before deduplication. Network volume stays bounded, but busy streams do a small amount of extra CPU work.

### Verification

- `mix ci`: 370 passed
- Independent focused review: 43 passed
- Documentation production build: passed
- Clone trial: 82 fields classified, retained payload 3,499 bytes
- Clone trial proved stale database, derived, and unavailable labels with ages and reasons
- Existing car, position, drive, charging, state, and update counts were unchanged
- Redaction tests prove vehicle values are absent from HTTP and MQTT metadata


### Suggested labels

enhancement, elixir, area:teslamate, note:discussion
