### PR TITLE
feat(grafana): make data health summary actionable

### DIFF
--- a/grafana/dashboards/database-info.json
+++ b/grafana/dashboards/database-info.json
@@ -357,7 +357,7 @@
                 "value": 0
               },
               {
-                "color": "red",
+                "color": "orange",
                 "value": 1
               }
             ]
@@ -485,7 +485,7 @@
           }
         }
       ],
-      "title": "Data Health",
+      "title": "Incomplete Data",
       "type": "stat"
     },
     {

--- a/grafana/dashboards/database-info.json
+++ b/grafana/dashboards/database-info.json
@@ -342,7 +342,7 @@
         "type": "grafana-postgresql-datasource",
         "uid": "TeslaMate"
       },
-      "description": "This means you have some **Drives** or **Charges** not closed.\nIf so, you may follow the official guide: \n<a href='https://docs.teslamate.org/docs/maintenance/manually_fixing_data' target='_blank'>Manually fixing data</a>",
+      "description": "Open **Drives** or **Charges** can be active sessions and are not necessarily incomplete. Select a count to review the matching records.\nIf a record is incomplete, follow the official guide: \n<a href='https://docs.teslamate.org/docs/maintenance/manually_fixing_data' target='_blank'>Manually fixing data</a>",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -353,13 +353,54 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "super-light-blue",
+                "color": "green",
                 "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
               }
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Charges not closed"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Review incomplete charges",
+                    "url": "/d/TSmNYvRRk/charges?var-car_id=$car_id&viewPanel=17"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Drives not closed"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Review incomplete drives",
+                    "url": "/d/Y8upc6ZRk/drives?var-car_id=$car_id&viewPanel=9"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 4,
@@ -444,7 +485,7 @@
           }
         }
       ],
-      "title": "Incomplete Data",
+      "title": "Data Health",
       "type": "stat"
     },
     {


### PR DESCRIPTION
## Summary

- rename the existing `Incomplete Data` panel to `Data Health`
- show zero counts in green and nonzero counts in red
- link each count directly to the existing incomplete Drives or Charges detail panel
- preserve the selected car when following either link
- clarify that an open record may still be an active session

## Why

This follows the discussion after #5517. @brianmay suggested having one place to check data-health issues, and @JakobLichterfeld expected the aggregate information in the Database Information dashboard.

The aggregate counts already live there, while the Drives and Charges dashboards already own the full record details. This makes the existing summary actionable without adding another web route, navbar entry, translation surface, or duplicate detail query.

## Validation

- parsed every Grafana dashboard with `jq`
- built and provisioned TeslaMate's Grafana 13.0.1 image
- checked zero and nonzero states against a disposable PostgreSQL 18 database
- verified both links open the intended detail panel with the selected car
- checked the normal compact dashboard layout and expanded panel at desktop and mobile widths
- `mix format --check-formatted`
- `mix deps.unlock --check-unused`
