### PR TITLE
i18n: improve Traditional Chinese translations

### DIFF
--- a/priv/gettext/zh_Hant/LC_MESSAGES/default.po
+++ b/priv/gettext/zh_Hant/LC_MESSAGES/default.po
@@ -28,7 +28,7 @@ msgstr "目前電量"
 #: lib/teslamate_web/live/car_live/summary.html.heex:347
 #, elixir-autogen, elixir-format
 msgid "Charged"
-msgstr "已充滿"
+msgstr "已充電量"
 
 #: lib/teslamate_web/live/car_live/summary.ex:141
 #, elixir-autogen, elixir-format
@@ -110,7 +110,7 @@ msgstr "進入休眠中"
 #: lib/teslamate_web/live/car_live/summary.ex:142
 #, elixir-autogen, elixir-format
 msgid "unavailable"
-msgstr "不可用"
+msgstr "無法使用"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:279
 #, elixir-autogen, elixir-format
@@ -157,7 +157,7 @@ msgstr "進入休眠前的閒置時間"
 #: lib/teslamate_web/live/geofence_live/index.html.heex:23
 #, elixir-autogen, elixir-format
 msgid "Name"
-msgstr "名字"
+msgstr "名稱"
 
 #: lib/teslamate_web/live/geofence_live/form.html.heex:19
 #: lib/teslamate_web/live/geofence_live/index.html.heex:24
@@ -174,7 +174,7 @@ msgstr "半徑"
 #: lib/teslamate_web/live/geofence_live/form.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Save"
-msgstr "保存"
+msgstr "儲存"
 
 #: lib/teslamate_web/live/charge_live/cost.html.heex:169
 #: lib/teslamate_web/live/geofence_live/form.html.heex:129
@@ -186,7 +186,7 @@ msgstr "儲存中"
 #: lib/teslamate_web/live/settings_live/index.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Time to Try Sleeping"
-msgstr "嘗試進入睡眠"
+msgstr "嘗試休眠前的等待時間"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:64
 #: lib/teslamate_web/live/settings_live/index.html.heex:87
@@ -202,18 +202,18 @@ msgstr "登入成功"
 #: lib/teslamate_web/live/car_live/summary.ex:144
 #, elixir-autogen, elixir-format
 msgid "Car is unlocked"
-msgstr "已鎖車"
+msgstr "車輛未上鎖"
 
 #: lib/teslamate_web/live/geofence_live/index.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Create"
-msgstr "新建"
+msgstr "新增"
 
 #: lib/teslamate_web/live/car_live/summary.ex:148
 #: lib/teslamate_web/live/car_live/summary.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Preconditioning"
-msgstr "預熱/冷"
+msgstr "預先調節車內溫度"
 
 #: lib/teslamate_web/live/car_live/summary.ex:147
 #, elixir-autogen, elixir-format
@@ -224,7 +224,7 @@ msgstr "哨兵模式已啟用"
 #: lib/teslamate_web/live/car_live/summary.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Driver present"
-msgstr "駕駛中"
+msgstr "駕駛座有人"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:508
 #, elixir-autogen, elixir-format
@@ -244,7 +244,7 @@ msgstr "續航里程 (預估)"
 #: lib/teslamate_web/live/car_live/summary.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "for"
-msgstr ""
+msgstr "持續"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:99
 #, elixir-autogen, elixir-format
@@ -294,7 +294,7 @@ msgstr "續航里程 (理想狀態)"
 #: lib/teslamate_web/live/settings_live/index.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "The car's estimate of remaining range is based on a fixed energy consumption in Wh/km. The Wh/km factor is determined by Tesla and is not country specific whereas the rated range is based on regulatory tests in the different markets for that vehicle."
-msgstr "實際續航里程會因車輛配置、電池使用時長和狀況、駕駛習慣及操作、環境和氣候狀況等因素的影響而有所不同。"
+msgstr "車輛顯示的預估剩餘里程，是依每公里固定耗電量（Wh/km）計算；此係數由 Tesla 決定，不因國家而異。表定里程則依該車款在不同市場的法規測試結果計算。"
 
 #: lib/teslamate_web/live/car_live/summary.ex:152
 #, elixir-autogen, elixir-format
@@ -304,12 +304,12 @@ msgstr "更新中"
 #: lib/teslamate_web/live/car_live/summary.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Windows open"
-msgstr "車窗 開"
+msgstr "車窗開啟"
 
 #: lib/teslamate_web/live/geofence_live/index.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "Delete '%{geo_fence}'?"
-msgstr "確定刪除 ‘%{geo_fence}’ ?"
+msgstr "確定要刪除「%{geo_fence}」嗎？"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:448
 #, elixir-autogen, elixir-format
@@ -325,7 +325,7 @@ msgstr "車外溫度"
 #: lib/teslamate_web/live/settings_live/index.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "Version"
-msgstr "車輛軟體版本"
+msgstr "版本"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:251
 #, elixir-autogen, elixir-format
@@ -346,18 +346,18 @@ msgstr "剩餘時間"
 #: lib/teslamate_web/templates/layout/root.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Dashboards"
-msgstr "控制台"
+msgstr "儀表板"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:327
 #, elixir-autogen, elixir-format
 msgid "URLs"
-msgstr "URLs"
+msgstr "網址"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:216
 #: lib/teslamate_web/live/settings_live/index.html.heex:330
 #, elixir-autogen, elixir-format
 msgid "Web App"
-msgstr "Web應用程式"
+msgstr "網頁應用程式"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:32
 #: lib/teslamate_web/live/settings_live/index.html.heex:144
@@ -378,12 +378,12 @@ msgstr "收藏點 \"%{name}\" 已更新"
 #: lib/teslamate_web/live/car_live/summary.ex:154
 #, elixir-autogen, elixir-format
 msgid "An error occurred"
-msgstr "發生了一個錯誤"
+msgstr "發生錯誤"
 
 #: lib/teslamate_web/live/car_live/summary.ex:153
 #, elixir-autogen, elixir-format
 msgid "Timeout"
-msgstr "已超時"
+msgstr "已逾時"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:84
 #, elixir-autogen, elixir-format
@@ -393,7 +393,7 @@ msgstr "已降低續航里程"
 #: lib/teslamate_web/live/car_live/summary.html.heex:407
 #, elixir-autogen, elixir-format
 msgid "≈ %{range} at 100%"
-msgstr "≈ 100%時續航為 %{range}"
+msgstr "電量 100% 時約可行駛 %{range}"
 
 #: lib/teslamate_web/live/charge_live/cost.ex:20
 #: lib/teslamate_web/live/charge_live/cost.html.heex:4
@@ -415,12 +415,12 @@ msgstr "請輸入充電費用"
 #: lib/teslamate_web/live/charge_live/cost.ex:87
 #, elixir-autogen, elixir-format
 msgid "Saved!"
-msgstr "已儲存!"
+msgstr "已儲存！"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Fetching vehicle data ..."
-msgstr "正在讀取車輛數據"
+msgstr "正在讀取車輛資料……"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:231
 #, elixir-autogen, elixir-format
@@ -435,12 +435,12 @@ msgstr "語言"
 #: lib/teslamate_web/live/settings_live/index.ex:64
 #, elixir-autogen, elixir-format
 msgid "There was a problem retrieving data from OpenStreetMap. Please try again later."
-msgstr "讀取地圖資訊時發成錯誤，請稍後再試。"
+msgstr "讀取 OpenStreetMap 資料時發生錯誤，請稍後再試。"
 
 #: lib/teslamate_web/live/import_live/index.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "TeslaFi Import"
-msgstr "從TeslaFi匯入"
+msgstr "從 TeslaFi 匯入"
 
 #: lib/teslamate_web/live/import_live/index.html.heex:10
 #, elixir-format, elixir-autogen
@@ -483,34 +483,34 @@ msgstr "一般設定"
 #: lib/teslamate_web/live/geofence_live/form.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Session fee"
-msgstr "手續費"
+msgstr "單次充電費"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Doors open"
-msgstr "未鎖車"
+msgstr "車門開啟"
 
 #: lib/teslamate_web/live/charge_live/cost.html.heex:140
 #: lib/teslamate_web/live/geofence_live/form.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "Per kWh"
-msgstr "/度"
+msgstr "每度"
 
 #: lib/teslamate_web/live/charge_live/cost.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Total"
-msgstr "總共"
+msgstr "總計"
 
 #: lib/teslamate_web/live/geofence_live/form.html.heex:163
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
-msgstr[0] "此地點有 <strong>%{n} 次</strong> 充電記錄，尚未增加費用。"
+msgstr[0] "此地點有 <strong>%{n} 次</strong> 充電紀錄尚未登錄費用。"
 
 #: lib/teslamate_web/live/geofence_live/form.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
-msgstr "追溯添加費用"
+msgstr "補登費用"
 
 #: lib/teslamate_web/live/geofence_live/form.html.heex:155
 #, elixir-autogen, elixir-format
@@ -525,12 +525,12 @@ msgstr "下一步"
 #: lib/teslamate_web/live/car_live/summary.html.heex:461
 #, elixir-autogen, elixir-format
 msgid "Mileage"
-msgstr "里程表"
+msgstr "累計里程"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Streaming API"
-msgstr "Tesla串接(預設)"
+msgstr "串流 API"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:395
 #, elixir-autogen, elixir-format
@@ -551,12 +551,12 @@ msgstr "有可用更新"
 #: lib/teslamate_web/live/car_live/summary.ex:145
 #, elixir-autogen, elixir-format
 msgid "Doors are open"
-msgstr "未上鎖"
+msgstr "車門開啟"
 
 #: lib/teslamate_web/live/car_live/summary.ex:146
 #, elixir-autogen, elixir-format
 msgid "Trunk is open"
-msgstr "後行李箱已打開"
+msgstr "行李廂開啟"
 
 #: lib/teslamate_web/live/charge_live/cost.html.heex:141
 #: lib/teslamate_web/live/geofence_live/form.html.heex:73
@@ -567,7 +567,7 @@ msgstr "每分鐘"
 #: lib/teslamate_web/live/car_live/summary.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "Software Update available (%{version})"
-msgstr "有可用更新 (%{version})"
+msgstr "有可用的軟體更新（%{version}）"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:413
 #, elixir-autogen, elixir-format
@@ -577,22 +577,22 @@ msgstr "登出"
 #: lib/teslamate_web/live/signin_live/index.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Access Token"
-msgstr ""
+msgstr "存取權杖（Access Token）"
 
 #: lib/teslamate_web/live/signin_live/index.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Refresh Token"
-msgstr "更新Token"
+msgstr "更新權杖（Refresh Token）"
 
 #: lib/teslamate_web/live/signin_live/index.ex:58
 #, elixir-autogen, elixir-format
 msgid "Tokens are invalid"
-msgstr "Tokens無效"
+msgstr "權杖無效"
 
 #: lib/teslamate_web/live/signin_live/index.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Obtaining tokens through the Tesla API requires programming experience or a 3rd-party service. Information can be found %{here}."
-msgstr "透過 Tesla API 獲得Token需要有程式編寫經驗或者藉由第三方服務。更多資訊詳見 %{here}。"
+msgstr "透過 Tesla API 取得權杖，需要具備程式設計經驗或使用第三方服務。更多資訊請見 %{here}。"
 
 #: lib/teslamate_web/live/signin_live/index.html.heex:92
 #, elixir-autogen, elixir-format
@@ -602,32 +602,32 @@ msgstr "這裡"
 #: lib/teslamate_web/live/signin_live/index.ex:61
 #, elixir-autogen, elixir-format
 msgid "Your Tesla account is locked due to too many failed sign in attempts. To unlock your account, reset your password"
-msgstr "您的 Tesla 帳號因登入失敗次數過多而被鎖定。要解鎖您的帳戶，請重設您的密碼"
+msgstr "您的 Tesla 帳號因登入失敗次數過多而被鎖定。若要解除鎖定，請重設密碼。"
 
 #: lib/teslamate_web/live/car_live/summary.ex:151
 #, elixir-autogen, elixir-format
 msgid "Downloading update"
-msgstr "下載更新"
+msgstr "正在下載更新"
 
 #: lib/teslamate_web/templates/layout/root.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "No encryption key provided"
-msgstr "未提供密鑰"
+msgstr "未提供加密金鑰"
 
 #: lib/teslamate_web/templates/layout/root.html.heex:165
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "For more information, see the updated installation guides on %{link}"
-msgstr "獲取更多資訊，請查看更新安裝指引"
+msgstr "如需更多資訊，請參閱 %{link} 的最新安裝指南。"
 
 #: lib/teslamate_web/templates/layout/root.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "The automatically generated encryption key used for the current session can be found <strong>in the application logs</strong>."
-msgstr "目前對話自動生成的密鑰可在<strong>應用程式日誌</strong>中找到"
+msgstr "目前工作階段使用的加密金鑰是自動產生的，可在<strong>應用程式記錄</strong>中找到。"
 
 #: lib/teslamate_web/templates/layout/root.html.heex:151
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "To ensure that your <strong>Tesla API tokens are stored securely</strong>, an encryption key must be provided to TeslaMate via the <code>ENCRYPTION_KEY</code> environment variable. Otherwise, a <strong>login will be required after every restart</strong>."
-msgstr "為了確保你的<strong>Tesla API tokens安全儲存</strong>,密鑰必須透過<code>ENCRYPTION_KEY</code>環境變數提供给Teslamate.否則每次重啟都會被要求登入"
+msgstr "為確保您的 <strong>Tesla API 權杖安全儲存</strong>，必須透過 <code>ENCRYPTION_KEY</code> 環境變數向 TeslaMate 提供加密金鑰，否則<strong>每次重新啟動後都必須再次登入</strong>。"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:309
 #, elixir-autogen, elixir-format
@@ -642,7 +642,7 @@ msgstr "寵物模式"
 #: lib/teslamate_web/live/car_live/summary.ex:149
 #, elixir-autogen, elixir-format
 msgid "Dog mode is enabled"
-msgstr "寵物模式開啓"
+msgstr "寵物模式已啟用"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:299
 #, elixir-autogen, elixir-format
@@ -650,82 +650,82 @@ msgid "Expected Finish Time"
 msgstr "預計充電完成時間"
 
 #: lib/teslamate_web/live/signin_live/index.html.heex:59
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You are using the API key (%{token}) provided by %{url}. It will allow your TeslaMate to access the official Tesla Fleet API and Tesla Telemetry streaming."
-msgstr "正在使用由 %{url} 提供的API key (%{token})。它將允許TeslaMate透過特斯拉官方車隊API和Telemetry數據流讀取你的車輛。"
+msgstr "您目前使用的是由 %{url} 提供的 API 金鑰（%{token}），TeslaMate 可透過此金鑰存取 Tesla 官方 Fleet API 及 Telemetry 串流資料。"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "Data Collection"
-msgstr "數據收集"
+msgstr "資料收集"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "Battery"
-msgstr "電池類型"
+msgstr "電池"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "LFP Battery"
-msgstr "鋰鐵磷酸電池（LFP）"
+msgstr "LFP 電池"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:149
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sentry Mode recording"
-msgstr "哨兵模式錄影中"
+msgstr "哨兵模式正在錄影"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:118
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "View car location on Google Maps"
-msgstr "在Google Maps查看車輛位置"
+msgstr "在 Google 地圖中查看車輛位置"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "Appearance"
-msgstr ""
+msgstr "外觀"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:263
 #, elixir-autogen, elixir-format
 msgid "Dark"
-msgstr ""
+msgstr "深色"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "Follow System"
-msgstr ""
+msgstr "跟隨系統設定"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Light"
-msgstr ""
+msgstr "淺色"
 
 #: lib/teslamate_web/live/settings_live/index.html.heex:251
 #, elixir-autogen, elixir-format
 msgid "Theme"
-msgstr ""
+msgstr "主題"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:108
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Service Mode"
-msgstr ""
+msgstr "維修模式"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:174
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Downloading %{percent}%"
-msgstr "下載更新"
+msgstr "下載中 %{percent}%"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Installing %{percent}%"
-msgstr ""
+msgstr "安裝中 %{percent}%"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:14
 #: lib/teslamate_web/live/car_live/summary.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Maximize map"
-msgstr ""
+msgstr "放大地圖"
 
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
-msgstr ""
+msgstr "縮小地圖"

--- a/priv/gettext/zh_Hant/LC_MESSAGES/errors.po
+++ b/priv/gettext/zh_Hant/LC_MESSAGES/errors.po
@@ -7,14 +7,17 @@
 ## Run `mix gettext.extract` to bring this file up to
 ## date. Leave `msgstr`s empty as changing them here has no
 ## effect: edit them in PO (`.po`) files instead.
-## From Ecto.Changeset.cast/4
-msgid "can't be blank"
+msgid ""
 msgstr ""
 "Language: zh_Hant\n"
 
+## From Ecto.Changeset.cast/4
+msgid "can't be blank"
+msgstr "不可空白"
+
 ## From Ecto.Changeset.unique_constraint/3
 msgid "has already been taken"
-msgstr "已被使用"
+msgstr "已有人使用"
 
 ## From Ecto.Changeset.put_change/3
 msgid "is invalid"
@@ -26,70 +29,70 @@ msgstr "必須接受"
 
 ## From Ecto.Changeset.validate_format/3
 msgid "has invalid format"
-msgstr "為無效格式"
+msgstr "格式無效"
 
 ## From Ecto.Changeset.validate_subset/3
 msgid "has an invalid entry"
-msgstr "為無效輸入"
+msgstr "含有無效項目"
 
 ## From Ecto.Changeset.validate_exclusion/3
 msgid "is reserved"
-msgstr "已被使用"
+msgstr "為保留值"
 
 ## From Ecto.Changeset.validate_confirmation/3
 msgid "does not match confirmation"
-msgstr "與已確認的不相符"
+msgstr "與確認內容不符"
 
 ## From Ecto.Changeset.no_assoc_constraint/3
 msgid "is still associated with this entry"
-msgstr "仍然與該輸入相關聯"
+msgstr "仍與此項目關聯"
 
 msgid "are still associated with this entry"
-msgstr "仍然與該輸入相關聯"
+msgstr "仍與此項目關聯"
 
 ## From Ecto.Changeset.validate_length/3
 msgid "should be %{count} character(s)"
 msgid_plural "should be %{count} character(s)"
-msgstr[0] "應為 %{count}"
-msgstr[1] ""
+msgstr[0] "應為 %{count} 個字元"
+msgstr[1] "應為 %{count} 個字元"
 
 msgid "should have %{count} item(s)"
 msgid_plural "should have %{count} item(s)"
-msgstr[0] "應有 %{count}"
-msgstr[1] ""
+msgstr[0] "應有 %{count} 個項目"
+msgstr[1] "應有 %{count} 個項目"
 
 msgid "should be at least %{count} character(s)"
 msgid_plural "should be at least %{count} character(s)"
-msgstr[0] "應至少有 %{count}"
-msgstr[1] ""
+msgstr[0] "應至少有 %{count} 個字元"
+msgstr[1] "應至少有 %{count} 個字元"
 
 msgid "should have at least %{count} item(s)"
 msgid_plural "should have at least %{count} item(s)"
-msgstr[0] "應至少有 %{count}"
-msgstr[1] ""
+msgstr[0] "應至少有 %{count} 個項目"
+msgstr[1] "應至少有 %{count} 個項目"
 
 msgid "should be at most %{count} character(s)"
 msgid_plural "should be at most %{count} character(s)"
-msgstr[0] "應不超過 %{count}"
-msgstr[1] ""
+msgstr[0] "應不超過 %{count} 個字元"
+msgstr[1] "應不超過 %{count} 個字元"
 
 msgid "should have at most %{count} item(s)"
 msgid_plural "should have at most %{count} item(s)"
-msgstr[0] "應不超過 %{count}"
-msgstr[1] ""
+msgstr[0] "應不超過 %{count} 個項目"
+msgstr[1] "應不超過 %{count} 個項目"
 
 ## From Ecto.Changeset.validate_number/3
 msgid "must be less than %{number}"
-msgstr "應少於 %{number}"
+msgstr "必須小於 %{number}"
 
 msgid "must be greater than %{number}"
-msgstr "應大於 %{number}"
+msgstr "必須大於 %{number}"
 
 msgid "must be less than or equal to %{number}"
-msgstr "應小於或等於 %{number}"
+msgstr "必須小於或等於 %{number}"
 
 msgid "must be greater than or equal to %{number}"
-msgstr "應大於或等於 %{number}"
+msgstr "必須大於或等於 %{number}"
 
 msgid "must be equal to %{number}"
-msgstr "應為 %{number}"
+msgstr "必須等於 %{number}"


### PR DESCRIPTION
## Summary

- Fill missing Traditional Chinese (`zh_Hant`) translations for newer UI strings, including appearance settings, map controls, service mode, software update progress, and API token messages.
- Correct inaccurate or ambiguous translations and improve consistency across the existing Traditional Chinese locale.
- Complete validation and error-message translations, including plural forms.

## Scope

Changes are limited to:

- `priv/gettext/zh_Hant/LC_MESSAGES/default.po`
- `priv/gettext/zh_Hant/LC_MESSAGES/errors.po`

The existing `zh_Hant` locale identifier remains unchanged. This is a follow-up to #4995.

## Validation

- `git diff --check`
- Checked interpolation placeholders such as `%{...}` across both catalogs: 0 mismatches
- Reviewed the changed strings for consistency and natural Traditional Chinese usage