### PR TITLE
fix: reconnect stream when a drive resumes after mid-drive offline phase to avoid missing elevation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - fix(cars): enforce non-null VINs (#5512 - @magrathean-uk)
 - fix(mqtt): return publish errors without crashing (#5514 - @magrathean-uk)
 - fix(geofences): increase cost precision (#5508 - @magrathean-uk)
+- fix: reconnect stream when a drive resumes after mid-drive offline phase to avoid missing elevation (#5535 - @JakobLichterfeld)
 
 #### Build, CI, internal
 
@@ -33,7 +34,7 @@
 - build(deps): update flake.lock (#5427)
 - build(deps): bump webpack-dev-server from 5.2.4 to 5.2.5 in /website (#5445)
 - chore: add .codegraph to .gitignore (#5440- @JakobLichterfeld)
-- ci: speed up check_linting by running treefmt in a lean app (#5440- @JakobLichterfeld)
+- ci: speed up check_linting by running treefmt in a lean app (#5440 - @JakobLichterfeld)
 - sec(deps): add ws override to version 8.21.0 in /website (#5446 - @JakobLichterfeld)
 - build(deps-dev): bump esbuild from 0.28.0 to 0.28.1 in /assets (#5444)
 - sec(deps): add joi override to version 17.13.4 in /website (#5448 - @JakobLichterfeld)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - build(deps): bump launch-editor from 2.13.2 to 2.14.1 in /website (#5426)
 - build(deps): update flake.lock (#5427)
 - build(deps): bump webpack-dev-server from 5.2.4 to 5.2.5 in /website (#5445)
-- chore: add .codegraph to .gitignore (#5440- @JakobLichterfeld)
+- chore: add .codegraph to .gitignore (#5440 - @JakobLichterfeld)
 - ci: speed up check_linting by running treefmt in a lean app (#5440 - @JakobLichterfeld)
 - sec(deps): add ws override to version 8.21.0 in /website (#5446 - @JakobLichterfeld)
 - build(deps-dev): bump esbuild from 0.28.0 to 0.28.1 in /assets (#5444)

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1255,6 +1255,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
          {:next_event, :internal, {:update, {:online, now}}}}
 
       not is_nil(drv) ->
+        data = maybe_reconnect_stream(data)
+
         {:next_state, {:driving, :available, drv}, %{data | last_used: DateTime.utc_now()},
          {:next_event, :internal, {:update, {:online, now}}}}
     end
@@ -1276,6 +1278,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         %Data{} = data
       ) do
     Logger.info("Vehicle is back online", car_id: data.car.id)
+
+    data = maybe_reconnect_stream(data)
 
     {:next_state, {:driving, :available, drv}, %{data | last_used: DateTime.utc_now()},
      {:next_event, :internal, {:update, e}}}
@@ -1969,6 +1973,17 @@ defmodule TeslaMate.Vehicles.Vehicle do
   defp disconnect_stream(%Data{stream_pid: pid} = data) when is_pid(pid) do
     Logger.info("Stream disconnecting ...", car_id: data.car.id)
     Stream.disconnect(pid)
+  end
+
+  defp maybe_reconnect_stream(%Data{car: %Car{settings: settings}} = data) do
+    case {settings, streaming?(data)} do
+      {%CarSettings{use_streaming_api: true}, false} ->
+        {:ok, pid} = connect_stream(data)
+        %Data{data | stream_pid: pid}
+
+      {%CarSettings{}, _} ->
+        data
+    end
   end
 
   defp summary_topic(car_id) when is_number(car_id), do: "#{__MODULE__}/summary/#{car_id}"

--- a/test/teslamate/vehicles/vehicle/driving_test.exs
+++ b/test/teslamate/vehicles/vehicle/driving_test.exs
@@ -535,6 +535,121 @@ defmodule TeslaMate.Vehicles.Vehicle.DrivingTest do
 
       refute_receive _
     end
+
+    @tag :capture_log
+    test "reconnects the stream when a drive resumes after an offline period",
+         %{test: name} do
+      now = DateTime.utc_now()
+      now_ts = DateTime.to_unix(now, :millisecond)
+
+      events =
+        [
+          {:ok, online_event(now_ts)},
+          drive_event(now_ts, 0.1, 30, 20, 200, nil),
+          drive_event(now_ts + 1, 0.1, 30, 20, 200, nil)
+        ] ++
+          List.duplicate({:ok, %TeslaApi.Vehicle{state: "offline"}}, 20) ++
+          [
+            drive_event(now_ts + 1 + :timer.minutes(4), 0.2, 20, 19, 190, nil),
+            {:ok,
+             online_event(now_ts + 1 + :timer.minutes(4) + 1,
+               drive_state: %{
+                 timestamp: now_ts + 1 + :timer.minutes(4) + 1,
+                 latitude: 0.3,
+                 longitude: 0.3
+               }
+             )}
+          ]
+
+      :ok = start_vehicle(name, events)
+
+      d0 = DateTime.from_unix!(now_ts, :millisecond)
+      assert_receive {:start_state, car, :online, date: ^d0}
+      assert_receive {ApiMock, {:stream, 1000, _}}
+      assert_receive {:insert_position, ^car, %{}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving}}}
+
+      assert_receive {:start_drive, ^car}
+      assert_receive {:insert_position, drive, %{longitude: 0.1, speed: 48}}
+      assert_receive {:insert_position, ^drive, %{longitude: 0.1, speed: 48}}
+
+      # Vehicle goes offline: the stream is disconnected
+      assert_receive {:"$websockex_cast", :disconnect}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :offline}}}, 500
+
+      # Vehicle comes back online mid-drive: the stream is reconnected
+      assert_receive {ApiMock, {:stream, 1000, _}}, 500
+
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving}}}
+      assert_receive {:insert_position, drive, %{longitude: 0.2, speed: 32}}
+      assert_receive {:insert_position, ^drive, %{longitude: 0.3}}
+      assert_receive {:close_drive, ^drive, lookup_address: true}
+
+      d1 = DateTime.from_unix!(now_ts + 1 + :timer.minutes(4) + 1, :millisecond)
+      assert_receive {:start_state, ^car, :online, date: ^d1}
+      assert_receive {:insert_position, ^car, %{}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
+
+      refute_receive _
+    end
+
+    @tag :capture_log
+    test "reconnects the stream when a drive resumes after a short unavailability",
+         %{test: name} do
+      now = DateTime.utc_now()
+      now_ts = DateTime.to_unix(now, :millisecond)
+
+      events =
+        [
+          {:ok, online_event(now_ts)},
+          drive_event(now_ts, 0.1, 30, 20, 200, nil),
+          drive_event(now_ts + 1, 0.1, 30, 20, 200, nil)
+        ] ++
+          List.duplicate({:ok, %TeslaApi.Vehicle{state: "offline"}}, 16) ++
+          [
+            drive_event(now_ts + :timer.minutes(4), 0.2, 20, 19, 190, nil),
+            {:ok,
+             online_event(now_ts + :timer.minutes(4) + 1,
+               drive_state: %{
+                 timestamp: now_ts + :timer.minutes(4) + 1,
+                 latitude: 0.3,
+                 longitude: 0.3
+               }
+             )}
+          ]
+
+      :ok = start_vehicle(name, events)
+
+      d0 = DateTime.from_unix!(now_ts, :millisecond)
+      assert_receive {:start_state, car, :online, date: ^d0}
+      assert_receive {ApiMock, {:stream, 1000, _}}
+      assert_receive {:insert_position, ^car, %{}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving}}}
+
+      assert_receive {:start_drive, ^car}
+      assert_receive {:insert_position, drive, %{longitude: 0.1, speed: 48}}
+      assert_receive {:insert_position, ^drive, %{longitude: 0.1, speed: 48}}
+
+      # Vehicle becomes unavailable: the stream is disconnected
+      assert_receive {:"$websockex_cast", :disconnect}
+
+      # Vehicle comes back online mid-drive: the stream is reconnected
+      assert_receive {ApiMock, {:stream, 1000, _}}, 500
+
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving}}}
+      assert_receive {:insert_position, drive, %{longitude: 0.2, speed: 32}}
+      assert_receive {:insert_position, ^drive, %{longitude: 0.3}}
+      assert_receive {:close_drive, ^drive, lookup_address: true}
+
+      d1 = DateTime.from_unix!(now_ts + :timer.minutes(4) + 1, :millisecond)
+      assert_receive {:start_state, ^car, :online, date: ^d1}
+      assert_receive {:insert_position, ^car, %{}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
+
+      refute_receive _
+    end
   end
 
   describe "geofencing" do


### PR DESCRIPTION
When the vehicle went offline mid-drive, the streaming websocket was not re-established on resume. The rest of the drive was recorded via REST polling only, whose positions carry no elevation. Reconnect the stream when a drive resumes after an offline or unavailable phase.

fixes: #5534

🤖 PR drafted with [Claude Code](https://claude.com/claude-code) (Fable 5 extra) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)