### PR TITLE
fix: remove the unreliable Releases panel from the Grafana home dashboard

### DIFF
--- a/grafana/dashboards/internal/home.json
+++ b/grafana/dashboards/internal/home.json
@@ -47,7 +47,7 @@
     {
       "gridPos": {
         "h": 20,
-        "w": 16,
+        "w": 18,
         "x": 6,
         "y": 0
       },
@@ -63,22 +63,6 @@
       },
       "pluginVersion": "13.0.1+security-01",
       "type": "text"
-    },
-    {
-      "gridPos": {
-        "h": 20,
-        "w": 2,
-        "x": 22,
-        "y": 0
-      },
-      "id": 3,
-      "options": {
-        "feedUrl": "https://api.cors.lol/?url=https://github.com/teslamate-org/teslamate/tags.atom",
-        "showImage": false
-      },
-      "pluginVersion": "13.0.1+security-01",
-      "title": "Releases",
-      "type": "news"
     }
   ],
   "preload": false,

--- a/test/grafana/home_dashboard_test.exs
+++ b/test/grafana/home_dashboard_test.exs
@@ -1,0 +1,46 @@
+defmodule TeslaMate.Grafana.HomeDashboardTest do
+  use ExUnit.Case, async: true
+
+  @dashboard_path "grafana/dashboards/internal/home.json"
+
+  setup_all do
+    json = File.read!(@dashboard_path)
+
+    {:ok, dashboard: Jason.decode!(json), json: json}
+  end
+
+  test "contains only the dashboard list and image panels", %{dashboard: dashboard, json: json} do
+    assert dashboard["title"] == "Home"
+    assert Enum.map(dashboard["panels"], & &1["type"]) == ["dashlist", "text"]
+    assert get_in(dashboard, ["panels", Access.at(1), "options", "content"]) =~ "background-image"
+
+    refute Enum.any?(dashboard["panels"], &(&1["type"] == "news"))
+    refute json =~ "api.cors.lol"
+  end
+
+  test "panels fill the 24-column grid without gaps, overlaps, or overflow", %{
+    dashboard: dashboard
+  } do
+    final_x =
+      dashboard["panels"]
+      |> Enum.sort_by(& &1["gridPos"]["x"])
+      |> Enum.reduce(0, fn %{"gridPos" => %{"w" => width, "x" => x}}, expected_x ->
+        assert width > 0
+        assert x == expected_x
+        assert x + width <= 24
+
+        x + width
+      end)
+
+    assert final_x == 24
+  end
+
+  test "Dockerfile provisions the shipped dashboard as Grafana's home dashboard" do
+    dockerfile = File.read!("grafana/Dockerfile")
+
+    assert dockerfile =~
+             "GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/dashboards_internal/home.json"
+
+    assert dockerfile =~ "COPY dashboards/internal/*.json /dashboards_internal/"
+  end
+end


### PR DESCRIPTION
## Summary

Remove the News panel (`id: 3`) from `grafana/dashboards/internal/home.json` instead of replacing one externally operated CORS proxy with another unreliable dependency. Expand the adjacent image panel from 16 to 18 grid columns so it fills the two columns released by the removed panel while the dashboard list remains at six columns, preserving a complete 24-column row. Keep the existing `grafana/Dockerfile` provisioning path intact so the corrected dashboard remains the image's configured default home dashboard.

## Validation

- Happy path: decode `grafana/dashboards/internal/home.json` and verify the Home dashboard contains the dashboard-list and image panels, no News panel, and top-level widths totaling 24 columns without overlap.
- Edge cases: verify every panel has a positive width and an `x + w` boundary no greater than 24 so reclaiming the removed panel's columns cannot create a gap or overflow.
- Error paths: fail the regression test if the dashboard JSON is malformed, if a News panel or `api.cors.lol` URL is reintroduced, or if the provisioned home dashboard path/copy source in `grafana/Dockerfile` no longer resolves to this file.

## Why

The default Grafana Home dashboard ships a Releases News panel whose Atom feed is routed through the shared public `api.cors.lol` proxy. That endpoint is rate-limited, so browser-side requests fail with HTTP 429 and Grafana displays an RSS loading error. The current `main` branch still contains the failing URL in `grafana/dashboards/internal/home.json`, and `grafana/Dockerfile` copies that file into the image and selects it as the default home dashboard. The issue is reproducible, has no competing or prior closed-unmerged PRs, and a maintainer confirmed that dropping the panel is acceptable.

Closes #5542
