### PR TITLE
fix(grafana): drop the Releases panel from the home dashboard to end the CORS proxy dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 #### Dashboards
 
 - feat(grafana): make data health summary actionable (#5526 - @magrathean-uk)
+- fix(grafana): drop the Releases panel from the home dashboard to end the CORS proxy dependency (#5548 - @JakobLichterfeld)
 
 #### Translations
 

--- a/grafana/dashboards/internal/home.json
+++ b/grafana/dashboards/internal/home.json
@@ -47,7 +47,7 @@
     {
       "gridPos": {
         "h": 20,
-        "w": 16,
+        "w": 18,
         "x": 6,
         "y": 0
       },
@@ -63,22 +63,6 @@
       },
       "pluginVersion": "13.0.1+security-01",
       "type": "text"
-    },
-    {
-      "gridPos": {
-        "h": 20,
-        "w": 2,
-        "x": 22,
-        "y": 0
-      },
-      "id": 3,
-      "options": {
-        "feedUrl": "https://api.cors.lol/?url=https://github.com/teslamate-org/teslamate/tags.atom",
-        "showImage": false
-      },
-      "pluginVersion": "13.0.1+security-01",
-      "title": "Releases",
-      "type": "news"
     }
   ],
   "preload": false,


### PR DESCRIPTION
The News panel fetched the tags Atom feed through the shared public CORS proxy api.cors.lol, which is rate-limited and returns HTTP 429, so the panel showed an RSS loading error. This is the second proxy to fail this way after corsproxy.io (#5143): every TeslaMate instance worldwide shares one free-tier quota, so swapping in a third proxy would reproduce the same failure.

Hosting the feed ourselves would be the only reliable alternative, but the panel is two grid columns wide and the information is already surfaced server-side and CORS-free by TeslaMate.Updater in the web UI. Remove the panel and widen the adjacent image panel from 16 to 18 columns to keep the row at 24.

Closes #5542
Supersedes #5546

🤖 PR drafted with [Claude Code](https://claude.com/claude-code) (Opus 5 high) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)