### PR TITLE
fix(mqtt): avoid blocking startup on retained cleanup

### DIFF
--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -34,7 +34,13 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
         |> Enum.reject(&is_nil(&1))
         |> Enum.join("/")
 
-      call(publisher, :publish, [topic, "", [retain: true, qos: 1]])
+      case call(publisher, :publish, [topic, "", [retain: true, qos: 1]]) do
+        :ok ->
+          :ok
+
+        error ->
+          Logger.warning("MQTT retained cleanup failed for #{topic}: #{inspect(error)}")
+      end
     end)
   end
 
@@ -49,9 +55,17 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
     }
 
     :ok = call(deps.vehicles, :subscribe_to_summary, [car_id])
-    :ok = clear_retained(car_id, namespace, deps.publisher)
 
-    {:ok, %State{car_id: car_id, namespace: namespace, deps: deps}}
+    {:ok, %State{car_id: car_id, namespace: namespace, deps: deps}, {:continue, :clear_retained}}
+  end
+
+  @impl true
+  def handle_continue(
+        :clear_retained,
+        %State{car_id: car_id, namespace: namespace, deps: deps} = state
+      ) do
+    clear_retained(car_id, namespace, deps.publisher)
+    {:noreply, state}
   end
 
   @publish_if_nil ~w(charge_energy_added charger_actual_current charger_phases

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -66,9 +66,9 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     send(subscriber_pid, :continue)
 
     assert_receive {BlockingPublisher, {:publish, "teslamate/cars/0/healthy", message, opts},
-                    ^subscriber_pid}
+                    from_pid}
 
-    assert {message, opts} == {"", [retain: true, qos: 1]}
+    assert {message, opts, from_pid} == {"", [retain: true, qos: 1], subscriber_pid}
 
     assert_receive {BlockingPublisher,
                     {:publish, "teslamate/cars/0/healthy", "true", [retain: false, qos: 1]},

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -5,6 +5,20 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
   alias TeslaMate.Vehicles.Vehicle.Summary
   alias TeslaMate.Locations.GeoFence
 
+  defmodule BlockingPublisher do
+    def publish(test_pid, topic, message, opts) do
+      send(test_pid, {__MODULE__, {:publish, topic, message, opts}, self()})
+
+      if String.ends_with?(topic, "/healthy") and message == "" do
+        receive do
+          :continue -> :ok
+        end
+      else
+        :ok
+      end
+    end
+  end
+
   defp start_subscriber(name, car_id, namespace \\ nil, publisher_responses \\ %{}) do
     publisher_name = :"mqtt_publisher_#{name}"
     vehicles_name = :"vehicles_#{name}"
@@ -26,6 +40,57 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
          deps_vehicles: {VehiclesMock, vehicles_name}
        ]}
     )
+  end
+
+  test "starts before retained topic cleanup completes", %{test: name} do
+    vehicles_name = :"vehicles_#{name}"
+    {:ok, _pid} = start_supervised({VehiclesMock, name: vehicles_name, pid: self()})
+
+    test_pid = self()
+
+    task =
+      Task.async(fn ->
+        VehicleSubscriber.start_link(
+          car_id: 0,
+          namespace: nil,
+          deps_publisher: {BlockingPublisher, test_pid},
+          deps_vehicles: {VehiclesMock, vehicles_name}
+        )
+      end)
+
+    assert_receive {VehiclesMock, {:subscribe_to_summary, 0}}
+
+    assert {:ok, {:ok, subscriber_pid}} = Task.yield(task, 2_000)
+
+    send(subscriber_pid, %Summary{healthy: true})
+    send(subscriber_pid, :continue)
+
+    assert_receive {BlockingPublisher,
+                    {:publish, "teslamate/cars/0/healthy", "", [retain: true, qos: 1]},
+                    ^subscriber_pid}
+
+    assert_receive {BlockingPublisher,
+                    {:publish, "teslamate/cars/0/healthy", "true", [retain: false, qos: 1]},
+                    _publisher_pid}
+
+    :ok = GenServer.stop(subscriber_pid, :normal, 1_000)
+  end
+
+  @tag :capture_log
+  test "logs retained cleanup publish failures", %{test: name} do
+    topic = "teslamate/cars/0/healthy"
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        {:ok, pid} = start_subscriber(name, 0, nil, %{topic => [{:error, :disconnected}]})
+
+        assert_receive {MqttPublisherMock, {:publish, ^topic, "", [retain: true, qos: 1]}}
+
+        send(pid, %Summary{healthy: true})
+        assert_receive {MqttPublisherMock, {:publish, ^topic, "true", [retain: false, qos: 1]}}
+      end)
+
+    assert log =~ "MQTT retained cleanup failed for #{topic}: {:error, :disconnected}"
   end
 
   test "publishes vehicle data", %{test: name} do

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -65,9 +65,10 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     send(subscriber_pid, %Summary{healthy: true})
     send(subscriber_pid, :continue)
 
-    assert_receive {BlockingPublisher,
-                    {:publish, "teslamate/cars/0/healthy", "", [retain: true, qos: 1]},
+    assert_receive {BlockingPublisher, {:publish, "teslamate/cars/0/healthy", message, opts},
                     ^subscriber_pid}
+
+    assert {message, opts} == {"", [retain: true, qos: 1]}
 
     assert_receive {BlockingPublisher,
                     {:publish, "teslamate/cars/0/healthy", "true", [retain: false, qos: 1]},


### PR DESCRIPTION
## Summary

TeslaMate clears stale retained messages when each vehicle subscriber starts. If a broker accepts the connection but does not complete the publish, the old initialization path waits for the publisher's roughly 10-second call timeout per car and delays application startup.

This moves cleanup into `handle_continue/2`, so `start_link/1` returns before a slow publish completes. GenServer continuations run before queued mailbox messages, which preserves cleanup before the first vehicle summary is published.

Cleanup publish failures are now logged with their topic and error term instead of being silently discarded.

## Validation

- Proves `start_link/1` returns while retained cleanup is blocked
- Proves the retained `healthy` clear is published before a queued `healthy: true` summary
- Covers failed-cleanup logging and continued summary processing
- `mix ci` on Elixir 1.19.5 / OTP 28: 431 tests, 0 failures

Closes #5523

## Suggested labels

`fix`, `area:teslamate`