### PR TITLE
fix(nix): support configured database credentials in maintenance tools

### DIFF
--- a/lib/teslamate/log.ex
+++ b/lib/teslamate/log.ex
@@ -240,6 +240,13 @@ defmodule TeslaMate.Log do
     |> Repo.insert()
   end
 
+  def delete_drive(id) when is_integer(id) do
+    case Repo.get(Drive, id) do
+      nil -> :not_found
+      drive -> delete(drive)
+    end
+  end
+
   def close_drive(%Drive{id: id} = drive, opts \\ []) do
     drive = Repo.preload(drive, [:car])
 
@@ -405,6 +412,13 @@ defmodule TeslaMate.Log do
     charge
     |> ChargingProcess.changeset(attrs)
     |> Repo.update()
+  end
+
+  def delete_charging_process(id) when is_integer(id) do
+    case Repo.get(ChargingProcess, id) do
+      nil -> :not_found
+      charging_process -> delete(charging_process)
+    end
   end
 
   def start_charging_process(%Car{id: id}, %{latitude: _, longitude: _} = attrs, opts \\ []) do
@@ -707,5 +721,12 @@ defmodule TeslaMate.Log do
     %Update{car_id: id}
     |> Update.changeset(%{start_date: date, end_date: date, version: version})
     |> Repo.insert()
+  end
+
+  defp delete(struct) do
+    case Repo.delete(struct) do
+      {:ok, _struct} -> :ok
+      {:error, _changeset} = error -> error
+    end
   end
 end

--- a/nix/backup_and_restore.nix
+++ b/nix/backup_and_restore.nix
@@ -1,39 +1,118 @@
 {
   stdenv,
   lib,
-  pkgs,
+  coreutils,
+  gnused,
+  postgresql,
+  systemd,
   writeShellScript,
   databaseUser,
   databaseName,
+  databaseHost,
+  databasePort,
+  environmentFilePath,
   ...
 }:
 let
+  pgDump = lib.getExe' postgresql "pg_dump";
+  psql = lib.getExe' postgresql "psql";
+  sed = lib.getExe gnused;
+  systemctl = lib.getExe' systemd "systemctl";
+  tail = lib.getExe' coreutils "tail";
+  databaseArgs = lib.escapeShellArgs [
+    "--host=${databaseHost}"
+    "--port=${toString databasePort}"
+    "--username=${databaseUser}"
+    "--dbname=${databaseName}"
+    "--no-password"
+  ];
+  loadDatabasePassword = ''
+    load_database_password() {
+      if [ ! -r ${lib.escapeShellArg environmentFilePath} ]; then
+        printf '%s\n' ${lib.escapeShellArg "Environment file ${environmentFilePath} not found or not readable."} >&2
+        return 1
+      fi
+
+      database_password="$(
+        ${sed} -n 's/^DATABASE_PASS=//p' ${lib.escapeShellArg environmentFilePath} |
+          ${tail} -n 1
+      )"
+
+      case "$database_password" in
+        \"*\")
+          database_password="''${database_password#\"}"
+          database_password="''${database_password%\"}"
+          ;;
+      esac
+
+      if [ -z "$database_password" ]; then
+        printf '%s\n' ${lib.escapeShellArg "DATABASE_PASS must be set in ${environmentFilePath} (services.teslamate.secretsFile)."} >&2
+        return 1
+      fi
+    }
+
+    run_with_database_password() {
+      PGPASSWORD="$database_password" "$@"
+    }
+  '';
   backup = writeShellScript "teslamate-backup" ''
     set -euo pipefail
-    : ''${1?' Please specify a file to save backup'}
-    sudo -u teslamate pg_dump -U ${databaseUser} ${databaseName} > "$1"
+    : "''${1:?'Please specify a file to save backup'}"
+
+    ${loadDatabasePassword}
+    load_database_password
+    run_with_database_password ${pgDump} ${databaseArgs} > "$1"
   '';
   restore = writeShellScript "teslamate-restore" ''
     set -euo pipefail
-    : ''${1?' Please specify a file to restore from'}
+    : "''${1:?'Please specify a file to restore from'}"
 
-    # Stop the teslamate service to avoid write conflicts
-    systemctl stop teslamate.service
+    if [ ! -f "$1" ]; then
+      printf 'Restore file %q does not exist, is not a regular file, or is not readable.\n' "$1" >&2
+      exit 1
+    fi
+    if ! exec 3< "$1"; then
+      printf 'Restore file %q does not exist, is not a regular file, or is not readable.\n' "$1" >&2
+      exit 1
+    fi
+
+    ${loadDatabasePassword}
+    load_database_password
+
+    restart_teslamate() {
+      original_status="$?"
+      trap - EXIT
+
+      if ${systemctl} start teslamate.service 3<&-; then
+        restart_status=0
+      else
+        restart_status="$?"
+      fi
+
+      if [ "$original_status" -ne 0 ]; then
+        exit "$original_status"
+      fi
+
+      exit "$restart_status"
+    }
+
+    # Restart TeslaMate on every exit after this point. If reset or restore
+    # fails, preserve that original status even when restarting also fails.
+    trap restart_teslamate EXIT
+
+    ${systemctl} stop teslamate.service 3<&-
 
     # Drop existing data and reinitialize
-    sudo -u teslamate psql -U ${databaseUser} -d ${databaseName} << .
-      DROP SCHEMA IF EXISTS public cascade;
-      DROP SCHEMA IF EXISTS private CASCADE;
-      CREATE SCHEMA public;
-      CREATE EXTENSION cube WITH SCHEMA public;
-      CREATE EXTENSION earthdistance WITH SCHEMA public;
-    .
+    run_with_database_password ${psql} ${databaseArgs} --set=ON_ERROR_STOP=1 <<'SQL'
+    DROP SCHEMA IF EXISTS public CASCADE;
+    DROP SCHEMA IF EXISTS private CASCADE;
+    CREATE SCHEMA public;
+    CREATE EXTENSION cube WITH SCHEMA public;
+    CREATE EXTENSION earthdistance WITH SCHEMA public;
+    SQL
 
     # Restore
-    sudo -u teslamate psql -U ${databaseUser} -d ${databaseName} < "$1"
-
-    # Restart the teslamate container
-    systemctl start teslamate.service
+    run_with_database_password ${psql} ${databaseArgs} --set=ON_ERROR_STOP=1 <&3
   '';
 in
 stdenv.mkDerivation {

--- a/nix/flake-modules/checks.nix
+++ b/nix/flake-modules/checks.nix
@@ -9,6 +9,241 @@
     }:
     let
       inherit (inputs) nixpkgs;
+      fakeTeslaMate = pkgs.writeShellApplication {
+        name = "teslamate";
+        text = ''
+          case "$*" in
+            *"(404)"*) printf '%s\n' ':not_found' ;;
+            *"(500)"*) printf '%s\n' '{:error, :failed}' ;;
+            *) printf '%s\n' ':ok' ;;
+          esac
+        '';
+      };
+      maintenance = pkgs.callPackage ../maintenance.nix {
+        environmentFilePath = pkgs.writeText "teslamate.env" "RELEASE_COOKIE=test\n";
+        getExe = lib.getExe;
+        teslamate = fakeTeslaMate;
+      };
+      maintenanceScriptsTest = pkgs.runCommand "maintenance-scripts-test" { } ''
+        ${maintenance}/bin/teslamate-delete-drive 1 | grep -F "Successfully deleted drive with ID 1."
+        ${maintenance}/bin/teslamate-delete-drive 404 2> drive-missing.log
+        grep -F "Warning: Drive with ID 404 does not exist. Nothing to delete." drive-missing.log
+
+        ${maintenance}/bin/teslamate-delete-charge 1 | grep -F "Successfully deleted charging process with ID 1."
+        ${maintenance}/bin/teslamate-delete-charge 404 2> charge-missing.log
+        grep -F "Warning: Charging process with ID 404 does not exist. Nothing to delete." charge-missing.log
+
+        if ${maintenance}/bin/teslamate-delete-drive 500 2> drive-error.log; then
+          echo "delete drive unexpectedly succeeded" >&2
+          exit 1
+        fi
+        grep -F "Error: Failed to delete drive with ID 500." drive-error.log
+
+        touch $out
+      '';
+      testDatabasePassword = "test pass:$dollar:quote':colon\\backslash";
+      backupRestoreSecrets = pkgs.writeText "teslamate-backup-test.env" ''
+        DATABASE_PASS="${testDatabasePassword}"
+      '';
+      missingPasswordSecrets = pkgs.writeText "teslamate-backup-test-missing-password.env" ''
+        RELEASE_COOKIE=test
+      '';
+      fakePostgresql = pkgs.symlinkJoin {
+        name = "fake-postgresql";
+        paths = [
+          (pkgs.writeShellScriptBin "pg_dump" ''
+            set -euo pipefail
+            : "''${FAKE_PG_LOG:?'FAKE_PG_LOG must be set'}"
+            : "''${EXPECTED_DATABASE_PASSWORD:?'EXPECTED_DATABASE_PASSWORD must be set'}"
+
+            if [ "''${PGPASSWORD:-}" != "$EXPECTED_DATABASE_PASSWORD" ]; then
+              echo "pg_dump did not receive the expected database password" >&2
+              exit 90
+            fi
+
+            printf '%s\n' "pg_dump-call" >> "$FAKE_PG_LOG"
+            for argument in "$@"; do
+              printf 'pg_dump-arg=%s\n' "$argument" >> "$FAKE_PG_LOG"
+            done
+            printf '%s\n' "backup data"
+          '')
+          (pkgs.writeShellScriptBin "psql" ''
+            set -euo pipefail
+            : "''${FAKE_PG_LOG:?'FAKE_PG_LOG must be set'}"
+            : "''${EXPECTED_DATABASE_PASSWORD:?'EXPECTED_DATABASE_PASSWORD must be set'}"
+
+            if [ "''${PGPASSWORD:-}" != "$EXPECTED_DATABASE_PASSWORD" ]; then
+              echo "psql did not receive the expected database password" >&2
+              exit 91
+            fi
+
+            input="$(cat)"
+            if [[ "$input" == *"DROP SCHEMA"* ]]; then
+              operation=reset
+            else
+              operation=restore
+            fi
+
+            printf 'psql-call=%s\n' "$operation" >> "$FAKE_PG_LOG"
+            for argument in "$@"; do
+              printf 'psql-arg=%s\n' "$argument" >> "$FAKE_PG_LOG"
+            done
+
+            if [ "''${FAKE_PSQL_FAIL:-}" = "$operation" ]; then
+              exit "''${FAKE_PSQL_STATUS:-23}"
+            fi
+          '')
+        ];
+      };
+      fakeSystemd = pkgs.writeShellScriptBin "systemctl" ''
+        set -euo pipefail
+        : "''${FAKE_SYSTEMCTL_LOG:?'FAKE_SYSTEMCTL_LOG must be set'}"
+
+        printf 'systemctl-arg=%s\n' "$*" >> "$FAKE_SYSTEMCTL_LOG"
+
+        case "''${1:-}" in
+          stop) exit "''${FAKE_SYSTEMCTL_STOP_STATUS:-0}" ;;
+          start) exit "''${FAKE_SYSTEMCTL_START_STATUS:-0}" ;;
+          *) exit 92 ;;
+        esac
+      '';
+      makeBackupRestore =
+        environmentFilePath:
+        pkgs.callPackage ../backup_and_restore.nix {
+          postgresql = fakePostgresql;
+          systemd = fakeSystemd;
+          databaseUser = "custom_role";
+          databaseName = "custom_database";
+          databaseHost = "db.example.test";
+          databasePort = 6543;
+          inherit environmentFilePath;
+        };
+      backupRestore = makeBackupRestore backupRestoreSecrets;
+      backupRestoreMissingPassword = makeBackupRestore missingPasswordSecrets;
+      backupRestoreScriptsTest = pkgs.runCommand "backup-restore-scripts-test" { } ''
+        export EXPECTED_DATABASE_PASSWORD=${lib.escapeShellArg testDatabasePassword}
+        export FAKE_PG_LOG="$PWD/pg.log"
+        export FAKE_SYSTEMCTL_LOG="$PWD/systemctl.log"
+        touch "$FAKE_PG_LOG" "$FAKE_SYSTEMCTL_LOG"
+
+        if ${backupRestore}/bin/teslamate-restore "$PWD/does-not-exist.sql" 2> "$PWD/missing-file.log"; then
+          echo "restore unexpectedly succeeded with a missing input file" >&2
+          exit 1
+        fi
+        grep -F "does not exist, is not a regular file, or is not readable" "$PWD/missing-file.log"
+        test ! -s "$FAKE_PG_LOG"
+        test ! -s "$FAKE_SYSTEMCTL_LOG"
+
+        ${backupRestore}/bin/teslamate-backup "$PWD/backup.sql"
+        grep -Fx "backup data" "$PWD/backup.sql"
+        grep -Fx "pg_dump-arg=--host=db.example.test" "$FAKE_PG_LOG"
+        grep -Fx "pg_dump-arg=--port=6543" "$FAKE_PG_LOG"
+        grep -Fx "pg_dump-arg=--username=custom_role" "$FAKE_PG_LOG"
+        grep -Fx "pg_dump-arg=--dbname=custom_database" "$FAKE_PG_LOG"
+        grep -Fx "pg_dump-arg=--no-password" "$FAKE_PG_LOG"
+
+        printf '%s\n' "restored data" > "$PWD/restore.sql"
+        ${backupRestore}/bin/teslamate-restore "$PWD/restore.sql"
+        test "$(grep -Fc "psql-arg=--host=db.example.test" "$FAKE_PG_LOG")" -eq 2
+        test "$(grep -Fc "psql-arg=--port=6543" "$FAKE_PG_LOG")" -eq 2
+        test "$(grep -Fc "psql-arg=--username=custom_role" "$FAKE_PG_LOG")" -eq 2
+        test "$(grep -Fc "psql-arg=--dbname=custom_database" "$FAKE_PG_LOG")" -eq 2
+        test "$(grep -Fc "psql-arg=--no-password" "$FAKE_PG_LOG")" -eq 2
+        test "$(grep -Fc "psql-arg=--set=ON_ERROR_STOP=1" "$FAKE_PG_LOG")" -eq 2
+        test "$(grep -Fc "systemctl-arg=stop teslamate.service" "$FAKE_SYSTEMCTL_LOG")" -eq 1
+        test "$(grep -Fc "systemctl-arg=start teslamate.service" "$FAKE_SYSTEMCTL_LOG")" -eq 1
+
+        if grep -F "$EXPECTED_DATABASE_PASSWORD" "$FAKE_PG_LOG"; then
+          echo "database password leaked into PostgreSQL command arguments" >&2
+          exit 1
+        fi
+        if grep -F "$EXPECTED_DATABASE_PASSWORD" "$(readlink -f ${backupRestore}/bin/teslamate-backup)"; then
+          echo "database password leaked into the generated backup script" >&2
+          exit 1
+        fi
+        if grep -F "$EXPECTED_DATABASE_PASSWORD" "$(readlink -f ${backupRestore}/bin/teslamate-restore)"; then
+          echo "database password leaked into the generated restore script" >&2
+          exit 1
+        fi
+
+        : > "$FAKE_PG_LOG"
+        : > "$FAKE_SYSTEMCTL_LOG"
+        export FAKE_SYSTEMCTL_STOP_STATUS=43
+        if ${backupRestore}/bin/teslamate-restore "$PWD/restore.sql"; then
+          echo "restore unexpectedly succeeded when TeslaMate failed to stop" >&2
+          exit 1
+        else
+          status="$?"
+        fi
+        test "$status" -eq 43
+        test ! -s "$FAKE_PG_LOG"
+        grep -Fx "systemctl-arg=stop teslamate.service" "$FAKE_SYSTEMCTL_LOG"
+        grep -Fx "systemctl-arg=start teslamate.service" "$FAKE_SYSTEMCTL_LOG"
+        unset FAKE_SYSTEMCTL_STOP_STATUS
+
+        : > "$FAKE_PG_LOG"
+        : > "$FAKE_SYSTEMCTL_LOG"
+        export FAKE_SYSTEMCTL_START_STATUS=42
+        if ${backupRestore}/bin/teslamate-restore "$PWD/restore.sql"; then
+          echo "restore unexpectedly succeeded when TeslaMate failed to restart" >&2
+          exit 1
+        else
+          status="$?"
+        fi
+        test "$status" -eq 42
+        grep -Fx "systemctl-arg=stop teslamate.service" "$FAKE_SYSTEMCTL_LOG"
+        grep -Fx "systemctl-arg=start teslamate.service" "$FAKE_SYSTEMCTL_LOG"
+
+        : > "$FAKE_PG_LOG"
+        : > "$FAKE_SYSTEMCTL_LOG"
+        export FAKE_PSQL_FAIL=reset
+        export FAKE_PSQL_STATUS=23
+        export FAKE_SYSTEMCTL_START_STATUS=41
+        if ${backupRestore}/bin/teslamate-restore "$PWD/restore.sql"; then
+          echo "restore unexpectedly succeeded when database reset failed" >&2
+          exit 1
+        else
+          status="$?"
+        fi
+        test "$status" -eq 23
+        grep -Fx "systemctl-arg=stop teslamate.service" "$FAKE_SYSTEMCTL_LOG"
+        grep -Fx "systemctl-arg=start teslamate.service" "$FAKE_SYSTEMCTL_LOG"
+
+        : > "$FAKE_PG_LOG"
+        : > "$FAKE_SYSTEMCTL_LOG"
+        export FAKE_PSQL_FAIL=restore
+        export FAKE_PSQL_STATUS=24
+        unset FAKE_SYSTEMCTL_START_STATUS
+        if ${backupRestore}/bin/teslamate-restore "$PWD/restore.sql"; then
+          echo "restore unexpectedly succeeded when psql restore failed" >&2
+          exit 1
+        else
+          status="$?"
+        fi
+        test "$status" -eq 24
+        grep -Fx "systemctl-arg=stop teslamate.service" "$FAKE_SYSTEMCTL_LOG"
+        grep -Fx "systemctl-arg=start teslamate.service" "$FAKE_SYSTEMCTL_LOG"
+
+        : > "$FAKE_PG_LOG"
+        : > "$FAKE_SYSTEMCTL_LOG"
+        unset FAKE_PSQL_FAIL FAKE_PSQL_STATUS
+        if ${backupRestoreMissingPassword}/bin/teslamate-backup "$PWD/missing.sql" 2> "$PWD/missing-backup.log"; then
+          echo "backup unexpectedly succeeded without DATABASE_PASS" >&2
+          exit 1
+        fi
+        grep -F "DATABASE_PASS must be set" "$PWD/missing-backup.log"
+        test ! -s "$FAKE_PG_LOG"
+
+        if ${backupRestoreMissingPassword}/bin/teslamate-restore "$PWD/restore.sql" 2> "$PWD/missing-restore.log"; then
+          echo "restore unexpectedly succeeded without DATABASE_PASS" >&2
+          exit 1
+        fi
+        grep -F "DATABASE_PASS must be set" "$PWD/missing-restore.log"
+        test ! -s "$FAKE_PG_LOG"
+        test ! -s "$FAKE_SYSTEMCTL_LOG"
+
+        touch $out
+      '';
       moduleTest =
         (nixpkgs.lib.nixos.runTest {
           hostPkgs = pkgs;
@@ -44,7 +279,9 @@
       checks =
         if pkgs.stdenv.isLinux then
           {
+            backup-restore-scripts = backupRestoreScriptsTest;
             default = moduleTest;
+            maintenance-scripts = maintenanceScriptsTest;
           }
         else
           { };

--- a/nix/maintenance.nix
+++ b/nix/maintenance.nix
@@ -3,8 +3,6 @@
   lib,
   pkgs,
   writeShellScript,
-  databaseUser,
-  databaseName,
   getExe,
   teslamate,
   environmentFilePath,
@@ -75,15 +73,23 @@ let
       exit 1
     fi
 
-    # Check if drive exists
-    if [ "$(sudo -u teslamate psql -U ${databaseUser} -d ${databaseName} -tAc "SELECT 1 FROM drives WHERE id = ''${1};")" != "1" ]; then
-      echo "Warning: Drive with ID ''${1} does not exist. Nothing to delete." >&2
-      exit 0
-    fi
+    # load RELEASE_COOKIE from the env file
+    ${loadFromEnvFile "RELEASE_COOKIE"}
+    : ''${RELEASE_COOKIE:?'RELEASE_COOKIE must be set in the environment file'}
 
     echo "Attempt to delete the drive with ID ''${1}."
-    sudo -u teslamate psql -U ${databaseUser} -d ${databaseName} -c "DELETE FROM drives WHERE id = ''${1};"
-    echo "Successfully deleted drive with ID ''${1}."
+    case "$(${getExe teslamate} rpc "TeslaMate.Log.delete_drive(''${1})")" in
+      :ok)
+        echo "Successfully deleted drive with ID ''${1}."
+        ;;
+      :not_found)
+        echo "Warning: Drive with ID ''${1} does not exist. Nothing to delete." >&2
+        ;;
+      *)
+        echo "Error: Failed to delete drive with ID ''${1}." >&2
+        exit 1
+        ;;
+    esac
   '';
 
   deleteCharge = writeShellScript "teslamate-delete-charge" ''
@@ -95,15 +101,23 @@ let
       exit 1
     fi
 
-    # Check if charging process exists
-    if [ "$(sudo -u teslamate psql -U ${databaseUser} -d ${databaseName} -tAc "SELECT 1 FROM charging_processes WHERE id = ''${1};")" != "1" ]; then
-      echo "Warning: Charging process with ID ''${1} does not exist. Nothing to delete." >&2
-      exit 0
-    fi
+    # load RELEASE_COOKIE from the env file
+    ${loadFromEnvFile "RELEASE_COOKIE"}
+    : ''${RELEASE_COOKIE:?'RELEASE_COOKIE must be set in the environment file'}
 
     echo "Attempt to delete the charge with ID ''${1}."
-    sudo -u teslamate psql -U ${databaseUser} -d ${databaseName} -c "DELETE FROM charging_processes WHERE id = ''${1};"
-    echo "Successfully deleted charging process with ID ''${1}."
+    case "$(${getExe teslamate} rpc "TeslaMate.Log.delete_charging_process(''${1})")" in
+      :ok)
+        echo "Successfully deleted charging process with ID ''${1}."
+        ;;
+      :not_found)
+        echo "Warning: Charging process with ID ''${1} does not exist. Nothing to delete." >&2
+        ;;
+      *)
+        echo "Error: Failed to delete charging process with ID ''${1}." >&2
+        exit 1
+        ;;
+    esac
   '';
 in
 stdenv.mkDerivation {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -238,10 +238,12 @@ in
         (callPackage ./backup_and_restore.nix {
           databaseUser = cfg.postgres.user;
           databaseName = cfg.postgres.database;
+          databaseHost = cfg.postgres.host;
+          databasePort = cfg.postgres.port;
+          environmentFilePath = cfg.secretsFile;
+          postgresql = cfg.postgres.package;
         })
         (callPackage ./maintenance.nix {
-          databaseUser = cfg.postgres.user;
-          databaseName = cfg.postgres.database;
           environmentFilePath = cfg.secretsFile;
           getExe = getExe;
           teslamate = teslamate;

--- a/test/teslamate/log/log_charging_test.exs
+++ b/test/teslamate/log/log_charging_test.exs
@@ -125,6 +125,21 @@ defmodule TeslaMate.LogChargingTest do
     end
   end
 
+  test "delete_charging_process/1 deletes the charging process and its charges" do
+    car = car_fixture()
+
+    assert {:ok, cproc} = Log.start_charging_process(car, @valid_pos_attrs)
+    assert {:ok, charge} = Log.insert_charge(cproc, @valid_attrs)
+
+    assert :ok = Log.delete_charging_process(cproc.id)
+    assert nil == Repo.get(ChargingProcess, cproc.id)
+    assert nil == Repo.get(Charge, charge.id)
+  end
+
+  test "delete_charging_process/1 returns :not_found for an unknown charging process" do
+    assert :not_found = Log.delete_charging_process(0)
+  end
+
   describe "insert_charge/2" do
     test "with valid data creates a position" do
       car = car_fixture()

--- a/test/teslamate/log/log_drive_test.exs
+++ b/test/teslamate/log/log_drive_test.exs
@@ -21,6 +21,18 @@ defmodule TeslaMate.LogDriveTest do
     assert {:ok, %Drive{car_id: ^id}} = Log.start_drive(car)
   end
 
+  test "delete_drive/1 deletes the drive" do
+    car = car_fixture()
+
+    assert {:ok, %Drive{} = drive} = Log.start_drive(car)
+    assert :ok = Log.delete_drive(drive.id)
+    assert nil == Repo.get(Drive, drive.id)
+  end
+
+  test "delete_drive/1 returns :not_found for an unknown drive" do
+    assert :not_found = Log.delete_drive(0)
+  end
+
   describe "insert_position/1" do
     test "with valid data creates a position" do
       car = car_fixture()


### PR DESCRIPTION
## Summary

The Nix maintenance scripts currently assume default local PostgreSQL peer authentication. That breaks custom `postgres.user` values and external database configurations.

This update:

- Passes the configured host, port, database, and role to PostgreSQL tools
- Loads the password from `secretsFile` into the child `PGPASSWORD` environment without putting it in command arguments
- Uses the running TeslaMate release and existing Log APIs for drive and charge deletion
- Enables `ON_ERROR_STOP` for restore failures
- Validates the restore file before stopping TeslaMate
- Restarts the service after failures while preserving the original failure status

## Validation

- Focused Log tests: 42 tests, 0 failures
- Nix backup and restore check: passed
- Nix maintenance check: passed
- Nix formatting and ShellCheck: passed
- Full branch and clean `origin/main` runs both reproduced the same three existing `SuspendTest` timing failures in the Docker and macOS test setup

Closes #5533

## Suggested labels

`nix`, `enhancement`