### PR TITLE
fix(vehicle): identify base Model 3 from model year 2022 as RWD instead of SR+

### DIFF
--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -43,6 +43,39 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   @drive_timeout_min 15
 
+  @vin_model_years %{
+    "A" => 2010,
+    "B" => 2011,
+    "C" => 2012,
+    "D" => 2013,
+    "E" => 2014,
+    "F" => 2015,
+    "G" => 2016,
+    "H" => 2017,
+    "J" => 2018,
+    "K" => 2019,
+    "L" => 2020,
+    "M" => 2021,
+    "N" => 2022,
+    "P" => 2023,
+    "R" => 2024,
+    "S" => 2025,
+    "T" => 2026,
+    "V" => 2027,
+    "W" => 2028,
+    "X" => 2029,
+    "Y" => 2030,
+    "1" => 2031,
+    "2" => 2032,
+    "3" => 2033,
+    "4" => 2034,
+    "5" => 2035,
+    "6" => 2036,
+    "7" => 2037,
+    "8" => 2038,
+    "9" => 2039
+  }
+
   # Static
   def interval(env_var, default) do
     System.get_env(env_var)
@@ -59,7 +92,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def charging_interval, do: interval("POLLING_CHARGING_INTERVAL", 5)
   def minimum_interval, do: interval("POLLING_MINIMUM_INTERVAL", 0)
 
-  def identify(%Vehicle{display_name: name, vehicle_config: config}) do
+  def identify(%Vehicle{display_name: name, vin: vin, vehicle_config: config}) do
     case config do
       %VehicleConfig{
         car_type: type,
@@ -96,7 +129,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
             {"3", "74D", _} -> "LR AWD"
             {"3", "74", _} -> "LR"
             {"3", "62", _} -> "MR"
-            {"3", "50", _} -> "SR+"
+            {"3", "50", _} -> model_3_base_trim(vin)
             {"X", "100D", "tamarind"} -> "LR"
             {"X", "P100D", "tamarind"} -> "Plaid"
             {"Y", "P74D", _} -> "LR AWD Performance"
@@ -119,6 +152,22 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
       nil ->
         {:error, :vehicle_config_not_available}
+    end
+  end
+
+  # Position 10 of a 17-character VIN encodes the model year. Codes repeat every
+  # 30 years; current Tesla VINs are resolved against the 2010-2039 cycle.
+  defp vin_model_year(<<_::binary-size(9), code::binary-size(1), _::binary-size(7)>>),
+    do: Map.get(@vin_model_years, code)
+
+  defp vin_model_year(_vin), do: nil
+
+  # Model year is only a proxy for the naming change. A MY2021 car renamed or
+  # sold later still falls back to SR+ because the API exposes no rename date.
+  defp model_3_base_trim(vin) do
+    case vin_model_year(vin) do
+      year when is_integer(year) and year >= 2022 -> "RWD"
+      _year -> "SR+"
     end
   end
 

--- a/test/support/vehicle_case.ex
+++ b/test/support/vehicle_case.ex
@@ -108,6 +108,7 @@ defmodule TeslaMate.VehicleCase do
     %TeslaApi.Vehicle{
       state: "online",
       display_name: Keyword.get(opts, :display_name),
+      vin: Keyword.get(opts, :vin),
       charge_state: struct(State.Charge, charge_state),
       drive_state: struct(State.Drive, drive_state),
       climate_state: struct(State.Climate, climate_state),

--- a/test/teslamate/vehicles/identification_test.exs
+++ b/test/teslamate/vehicles/identification_test.exs
@@ -23,6 +23,26 @@ defmodule TeslaMate.Vehicles.Vehicle.IdentificationTest do
     end)
   end
 
+  test "identifies a MY2022 base Model 3 through the vehicle update pipeline" do
+    now_ts = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+
+    events = [
+      {:ok,
+       online_event(
+         now_ts,
+         vin: "5YJ3E1EA1NF000000",
+         vehicle_config: %{car_type: "model3", trim_badging: "50"}
+       )}
+    ]
+
+    :ok = start_vehicles(events)
+
+    TestHelper.eventually(fn ->
+      assert %Car{model: "3", trim_badging: "50", marketing_name: "RWD"} =
+               Log.get_car_by(vid: 90211)
+    end)
+  end
+
   test "changes the car name" do
     ts = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
 

--- a/test/teslamate/vehicles/vehicle_identification_unit_test.exs
+++ b/test/teslamate/vehicles/vehicle_identification_unit_test.exs
@@ -1,0 +1,48 @@
+defmodule TeslaMate.Vehicles.Vehicle.IdentificationUnitTest do
+  use ExUnit.Case, async: true
+
+  alias TeslaMate.Vehicles.Vehicle
+
+  describe "identify/1" do
+    for {year, year_code} <- [{2019, "K"}, {2020, "L"}, {2021, "M"}] do
+      test "identifies a #{year} base Model 3 as SR+" do
+        assert "SR+" == identify_model_3_base(unquote(year_code))
+      end
+    end
+
+    for {year, year_code} <- [{2022, "N"}, {2023, "P"}, {2024, "R"}, {2039, "9"}] do
+      test "identifies a #{year} base Model 3 as RWD" do
+        assert "RWD" == identify_model_3_base(unquote(year_code))
+      end
+    end
+
+    test "falls back to SR+ for a malformed VIN" do
+      assert "SR+" == identify_model_3_base("invalid")
+    end
+
+    test "falls back to SR+ for an invalid model-year character" do
+      assert "SR+" == identify_model_3_base("Z")
+    end
+
+    test "falls back to SR+ when the VIN is missing" do
+      assert "SR+" == identify_model_3_base(nil)
+    end
+  end
+
+  defp identify_model_3_base(year_code) when byte_size(year_code) == 1 do
+    identify_model_3_base("5YJ3E1EA1#{year_code}F000000")
+  end
+
+  defp identify_model_3_base(vin) do
+    vehicle = %TeslaApi.Vehicle{
+      vin: vin,
+      vehicle_config: %TeslaApi.Vehicle.State.VehicleConfig{
+        car_type: "model3",
+        trim_badging: "50"
+      }
+    }
+
+    assert {:ok, %{marketing_name: marketing_name}} = Vehicle.identify(vehicle)
+    marketing_name
+  end
+end


### PR DESCRIPTION
## Summary

Recent base Model 3 vehicles still report trim code `50`, but the display name changed from SR+ to RWD from model year 2022.

This decodes position 10 of a complete VIN through a dedicated model-year helper, resolves valid codes against the 2010 to 2039 cycle, and keeps the 2022 cutoff visible at the Model 3 trim decision. Model year 2021 and older, plus missing, malformed, or invalid VINs, retain the existing SR+ fallback.

The code documents that model year is only a proxy for Tesla's naming change. It also keeps the VIN-year helper reusable for other model identification rules.

## Validation

- Covers older, cutoff, later, malformed, invalid-character, and missing VIN cases in an async unit test
- Exercises the real vehicle update pipeline and verifies a MY2022 base Model 3 is stored with `marketing_name: "RWD"`
- `mix ci` on Elixir 1.19.5 / OTP 28: 440 tests, 0 failures

Closes #3887

## Suggested labels

`fix`, `area:teslamate`
