### PR TITLE
feat(import): continue past malformed rows and resume completed TeslaFi files

### DIFF
--- a/lib/teslamate/import.ex
+++ b/lib/teslamate/import.ex
@@ -8,14 +8,30 @@ defmodule TeslaMate.Import do
   alias TeslaMate.{Vehicles, Repair, Log}
   alias TeslaMate.Log.{Car, State}
 
-  alias __MODULE__.{Status, LineParser, FakeApi, CSV}
+  alias __MODULE__.{
+    Status,
+    RowValidator,
+    RejectedRow,
+    RejectionReport,
+    Checkpoint,
+    Run,
+    FakeApi,
+    CSV
+  }
 
   defstruct(
     path: nil,
+    source_key: nil,
     files: [],
     timezone: :utc,
     error: nil,
     completed: MapSet.new(),
+    rejection_report: %RejectionReport{},
+    run_id: nil,
+    run_timezone: nil,
+    run_car_id: nil,
+    date_limit: nil,
+    date_limit_captured: false,
     car: nil,
     pids: %{},
     deps: %{}
@@ -24,24 +40,53 @@ defmodule TeslaMate.Import do
   alias __MODULE__, as: Data
 
   defmodule Status do
-    defstruct(state: :idle, message: nil, files: [])
+    defstruct(
+      state: :idle,
+      message: nil,
+      files: [],
+      rejected_rows: 0,
+      rejection_examples: [],
+      rejection_examples_truncated: false,
+      rejection_example_limit: RejectionReport.max_examples(),
+      resume_timezone: nil
+    )
 
-    def into(state, %Data{files: files, completed: completed}) do
+    def into(
+          state,
+          %Data{
+            files: files,
+            completed: completed,
+            rejection_report: %RejectionReport{} = report,
+            run_timezone: run_timezone
+          }
+        ) do
       files =
-        Enum.map(files, fn %{date: date} = file ->
-          complete = MapSet.member?(completed, date)
-          Map.put(file, :complete, complete)
+        Enum.map(files, fn file ->
+          complete = MapSet.member?(completed, Checkpoint.file_id(file))
+
+          file
+          |> Map.drop([:fingerprint])
+          |> Map.put(:complete, complete)
         end)
 
+      status = %__MODULE__{
+        files: files,
+        rejected_rows: report.count,
+        rejection_examples: report.examples,
+        rejection_examples_truncated: RejectionReport.truncated?(report),
+        resume_timezone: run_timezone
+      }
+
       case state do
-        {:error, reason} -> %__MODULE__{state: :error, message: reason, files: files}
-        state when is_atom(state) -> %__MODULE__{state: state, files: files}
+        {:error, reason} -> %__MODULE__{status | state: :error, message: reason}
+        state when is_atom(state) -> %__MODULE__{status | state: state}
       end
     end
   end
 
   @name __MODULE__
   @topic "#{@name}/state"
+  @process_stop_timeout 5_000
 
   def start_link(opts) do
     GenStateMachine.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, @name))
@@ -53,25 +98,34 @@ defmodule TeslaMate.Import do
   def valid_file_name?(fname), do: parse_fname(fname) != nil
   def get_status, do: GenStateMachine.call(@name, :get_status)
   def reload_directory, do: GenStateMachine.call(@name, :reload_directory)
+  def discard_interrupted_run, do: GenStateMachine.call(@name, :discard_interrupted_run)
   def subscribe, do: Phoenix.PubSub.subscribe(TeslaMate.PubSub, @topic)
 
   @impl true
   def init(opts) do
     Process.flag(:trap_exit, true)
     path = Keyword.fetch!(opts, :directory)
-    {:ok, :idle, %Data{path: path}, {:next_event, :internal, :read_directory}}
+
+    {:ok, :idle, %Data{path: path, source_key: Checkpoint.source_key(path)},
+     {:next_event, :internal, :read_directory}}
   end
 
   ## Calls
 
   @impl true
   def handle_event({:call, from}, {:run, tz}, :idle, %Data{} = data) do
-    {:next_state, :running, %{data | timezone: tz},
-     [
-       {:reply, from, :ok},
-       {:next_event, :internal, :broadcast},
-       {:next_event, :internal, :import}
-     ]}
+    case prepare_run(data, tz) do
+      {:ok, data} ->
+        {:next_state, :running, data,
+         [
+           {:reply, from, :ok},
+           {:next_event, :internal, :broadcast},
+           {:next_event, :internal, :import}
+         ]}
+
+      {:error, reason} ->
+        {:keep_state_and_data, {:reply, from, {:error, reason}}}
+    end
   end
 
   def handle_event({:call, from}, {:run, _tz}, _, _data) do
@@ -86,6 +140,30 @@ defmodule TeslaMate.Import do
     {:keep_state_and_data, {:reply, from, Status.into(state, data)}}
   end
 
+  def handle_event(
+        {:call, from},
+        :discard_interrupted_run,
+        :idle,
+        %Data{run_id: run_id} = data
+      )
+      when is_integer(run_id) do
+    discard_run(from, data)
+  end
+
+  def handle_event(
+        {:call, from},
+        :discard_interrupted_run,
+        {:error, _reason},
+        %Data{run_id: run_id} = data
+      )
+      when is_integer(run_id) do
+    discard_run(from, data)
+  end
+
+  def handle_event({:call, from}, :discard_interrupted_run, _state, _data) do
+    {:keep_state_and_data, {:reply, from, {:error, :not_allowed}}}
+  end
+
   def handle_event({:call, from}, :reload_directory, _state, _data) do
     {:keep_state_and_data, [{:reply, from, :ok}, {:next_event, :internal, :read_directory}]}
   end
@@ -97,19 +175,27 @@ defmodule TeslaMate.Import do
     :keep_state_and_data
   end
 
-  def handle_event(:internal, :read_directory, :idle, %Data{path: path} = data) do
+  def handle_event(
+        :internal,
+        :read_directory,
+        :idle,
+        %Data{path: path, source_key: source_key} = data
+      ) do
     case File.ls(path) do
       {:error, reason} ->
         {:next_state, {:error, reason}, data, {:next_event, :internal, :broadcast}}
 
-      {:ok, files} ->
-        files =
-          files
-          |> Enum.map(fn n -> %{date: parse_fname(n), path: Path.join([path, n])} end)
-          |> Enum.reject(fn %{date: date} -> is_nil(date) end)
-          |> Enum.sort_by(fn %{date: date} -> date end)
+      {:ok, names} ->
+        :ok = Checkpoint.cleanup_unreachable_runs(source_key)
 
-        {:keep_state, %Data{data | files: files}, {:next_event, :internal, :broadcast}}
+        case build_files(path, names) do
+          {:ok, files} ->
+            data = restore_active_run(%Data{data | files: files})
+            {:keep_state, data, {:next_event, :internal, :broadcast}}
+
+          {:error, reason} ->
+            {:next_state, {:error, reason}, data, {:next_event, :internal, :broadcast}}
+        end
     end
   end
 
@@ -118,52 +204,73 @@ defmodule TeslaMate.Import do
   end
 
   def handle_event(:internal, :import, :running, %Data{files: files} = data) do
-    Logger.info("Importing #{length(files)} file(s) ...")
+    pending = Enum.reject(files, &completed_file?(data, &1))
+    Logger.info("Importing #{length(pending)} of #{length(files)} file(s) ...")
 
-    case create_event_streams(data) do
-      {:error, reason} ->
-        {:next_state, {:error, reason}, data, {:next_event, :internal, :broadcast}}
+    cond do
+      pending == [] ->
+        complete_resumed_run(data)
 
-      {:ok, streams} ->
-        car = create_car(streams)
-        {:ok, streams} = create_event_streams(data, car)
+      is_integer(data.run_car_id) ->
+        data.run_car_id
+        |> Log.get_car!()
+        |> import_car()
+        |> then(&start_import(data, &1))
 
-        :ok = Log.complete_current_state(car)
+      true ->
+        case create_event_streams(data) do
+          {:error, reason} ->
+            {:next_state, {:error, reason}, data, {:next_event, :internal, :broadcast}}
 
-        date_limit =
-          with %State{start_date: date} <- Log.get_earliest_state(car) do
-            date
-          end
+          {:ok, streams} ->
+            case create_car(streams, data.run_id) do
+              {:error, reason, _rejection_report} ->
+                report = Checkpoint.rejection_report(data.run_id, current_file_ids(data))
+                data = %Data{data | rejection_report: report}
 
-        api_name = :"api_#{car.name}"
+                {:next_state, {:error, reason}, data, {:next_event, :internal, :broadcast}}
 
-        {:ok, api} =
-          FakeApi.start_link(
-            name: api_name,
-            event_streams: streams,
-            date_limit: date_limit,
-            pid: self()
-          )
+              {:ok, car} ->
+                :ok = Checkpoint.set_car(data.run_id, car.id)
+                report = Checkpoint.rejection_report(data.run_id, current_file_ids(data))
 
-        {:ok, veh} =
-          Vehicle.start_link(
-            name: :"import_#{car.name}",
-            car: car,
-            import?: true,
-            deps_api: {FakeApi, api_name}
-          )
-
-        {:keep_state, %Data{data | car: car, pids: %{veh: veh, api: api}},
-         {:next_event, :internal, :broadcast}}
+                start_import(
+                  %Data{data | run_car_id: car.id, rejection_report: report},
+                  car
+                )
+            end
+        end
     end
   end
 
   ## Info
 
-  def handle_event(:info, {:done, chunk}, :running, %Data{completed: completed} = data) do
+  def handle_event(
+        :info,
+        {:rejected_row, %RejectedRow{} = rejected_row},
+        _state,
+        %Data{run_id: run_id, rejection_report: report} = data
+      ) do
+    case Checkpoint.record_rejection(run_id, rejected_row) do
+      :inserted ->
+        {:keep_state,
+         %Data{data | rejection_report: RejectionReport.record(report, rejected_row)}}
+
+      :existing ->
+        :keep_state_and_data
+    end
+  end
+
+  def handle_event(
+        :info,
+        {:done, file_id},
+        :running,
+        %Data{run_id: run_id, completed: completed} = data
+      ) do
+    :ok = Checkpoint.complete_file(run_id, file_id)
     :ok = Repair.trigger_run()
 
-    {:keep_state, %Data{data | completed: MapSet.put(completed, chunk)},
+    {:keep_state, %Data{data | completed: MapSet.put(completed, file_id)},
      {:next_event, :internal, :broadcast}}
   end
 
@@ -176,19 +283,246 @@ defmodule TeslaMate.Import do
     :ok = Log.complete_current_state(car)
     :ok = Log.create_current_state(car)
     :ok = Repair.trigger_run()
+    :ok = Checkpoint.complete_run(data.run_id)
 
     {:next_state, :complete, data, {:next_event, :internal, :broadcast}}
+  end
+
+  def handle_event(
+        :info,
+        {:import_aborted, reason},
+        :running,
+        %Data{pids: %{api: api, veh: veh}} = data
+      ) do
+    ref = Process.monitor(veh)
+    true = Process.exit(veh, :kill)
+
+    receive do
+      {:DOWN, ^ref, :process, ^veh, _reason} ->
+        :ok
+    after
+      @process_stop_timeout ->
+        Process.demonitor(ref, [:flush])
+        Logger.warning("Timed out waiting for the import vehicle process to stop")
+    end
+
+    :ok = GenServer.stop(api, :normal)
+
+    {:next_state, {:error, reason}, %Data{data | pids: %{}}, {:next_event, :internal, :broadcast}}
   end
 
   def handle_event(:info, {:EXIT, _from, :normal}, _state, _data), do: :keep_state_and_data
   def handle_event(:info, {:EXIT, _from, :killed}, _state, _data), do: :keep_state_and_data
 
-  def handle_event(:info, {:EXIT, _from, reason}, _state, data) do
+  def handle_event(:info, {:EXIT, from, reason}, _state, data) do
     Logger.warning("Import failed: #{inspect(reason, pretty: true)}")
-    {:next_state, {:error, reason}, data, {:next_event, :internal, :broadcast}}
+
+    {:next_state, {:error, reason}, stop_import_processes(data, from),
+     {:next_event, :internal, :broadcast}}
   end
 
   ## Private
+
+  defp prepare_run(%Data{files: []}, _timezone), do: {:error, :no_files}
+
+  defp prepare_run(%Data{source_key: source_key} = data, timezone) do
+    case Checkpoint.get_active_run(source_key) do
+      nil ->
+        with {:ok, %Run{} = run} <- Checkpoint.start_run(source_key, timezone) do
+          {:ok, apply_run(data, run)}
+        end
+
+      %Run{} = run ->
+        {:ok, apply_run(data, run)}
+    end
+  end
+
+  defp apply_run(%Data{} = data, %Run{} = run) do
+    completed = Checkpoint.completed_files(run.id)
+    report = Checkpoint.rejection_report(run.id, current_file_ids(data))
+
+    %Data{
+      data
+      | timezone: run.timezone,
+        completed: completed,
+        rejection_report: report,
+        run_id: run.id,
+        run_timezone: run.timezone,
+        run_car_id: run.car_id,
+        date_limit: run.date_limit,
+        date_limit_captured: run.date_limit_captured
+    }
+  end
+
+  defp restore_active_run(%Data{source_key: source_key} = data) do
+    case Checkpoint.get_active_run(source_key) do
+      %Run{} = run ->
+        apply_run(data, run)
+
+      nil ->
+        data
+        |> clear_run()
+        |> restore_last_completed_report()
+    end
+  end
+
+  defp clear_run(%Data{} = data) do
+    %Data{
+      data
+      | completed: MapSet.new(),
+        rejection_report: %RejectionReport{},
+        run_id: nil,
+        run_timezone: nil,
+        run_car_id: nil,
+        date_limit: nil,
+        date_limit_captured: false,
+        car: nil,
+        pids: %{}
+    }
+  end
+
+  defp discard_run(from, %Data{run_id: run_id} = data) do
+    :ok = Checkpoint.abandon_run(run_id)
+
+    {:next_state, :idle, clear_run(data),
+     [{:reply, from, :ok}, {:next_event, :internal, :broadcast}]}
+  end
+
+  defp stop_import_processes(%Data{pids: pids} = data, exited_pid) do
+    pids
+    |> Map.values()
+    |> Enum.reject(&(&1 == exited_pid))
+    |> Enum.filter(&Process.alive?/1)
+    |> Enum.each(&Process.exit(&1, :kill))
+
+    %Data{data | pids: %{}}
+  end
+
+  defp restore_last_completed_report(%Data{source_key: source_key} = data) do
+    case Checkpoint.get_last_completed_run(source_key) do
+      %Run{id: run_id} ->
+        %Data{
+          data
+          | rejection_report: Checkpoint.rejection_report(run_id, current_file_ids(data))
+        }
+
+      nil ->
+        data
+    end
+  end
+
+  defp build_files(path, names) do
+    # Content hashing is deliberately paid before status restoration. Size or mtime shortcuts
+    # could mark replaced files complete, and completed-run reports use the same identity.
+    names
+    |> Enum.map(fn name -> %{date: parse_fname(name), path: Path.join([path, name])} end)
+    |> Enum.reject(fn %{date: date} -> is_nil(date) end)
+    |> Enum.reduce_while({:ok, []}, fn %{path: file_path} = file, {:ok, files} ->
+      case Checkpoint.file_fingerprint(file_path) do
+        {:ok, fingerprint} ->
+          {:cont, {:ok, [Map.put(file, :fingerprint, fingerprint) | files]}}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, files} ->
+        {:ok, Enum.sort_by(files, fn %{date: date, path: file_path} -> {date, file_path} end)}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp current_file_ids(%Data{files: files}), do: Enum.map(files, &Checkpoint.file_id/1)
+
+  defp completed_file?(%Data{completed: completed}, file) do
+    MapSet.member?(completed, Checkpoint.file_id(file))
+  end
+
+  defp import_car(%Car{} = car) do
+    settings = %CarSettings{
+      suspend_min: 0,
+      suspend_after_idle_min: 99999,
+      use_streaming_api: false,
+      enabled: true
+    }
+
+    %Car{car | settings: settings}
+  end
+
+  defp original_date_limit(%Data{date_limit_captured: true} = data, _car) do
+    {data.date_limit, data}
+  end
+
+  defp original_date_limit(%Data{run_id: run_id} = data, %Car{} = car) do
+    date_limit =
+      with %State{start_date: date} <- Log.get_earliest_state(car) do
+        date
+      end
+
+    :ok = Checkpoint.capture_date_limit(run_id, date_limit)
+
+    {date_limit,
+     %Data{data | date_limit: date_limit, date_limit_captured: true, run_car_id: car.id}}
+  end
+
+  defp complete_resumed_run(%Data{run_id: run_id, run_car_id: car_id} = data) do
+    Logger.info("Import complete after restoring file checkpoints")
+
+    data =
+      with car_id when is_integer(car_id) <- car_id do
+        car = car_id |> Log.get_car!() |> import_car()
+        :ok = Log.complete_current_state(car)
+        :ok = Log.create_current_state(car)
+        %Data{data | car: car}
+      else
+        _ -> data
+      end
+
+    :ok = Repair.trigger_run()
+    :ok = Checkpoint.complete_run(run_id)
+
+    {:next_state, :complete, data, {:next_event, :internal, :broadcast}}
+  end
+
+  defp start_import(%Data{} = data, %Car{} = car) do
+    case create_event_streams(data, car) do
+      {:ok, streams} ->
+        start_import(data, car, streams)
+
+      {:error, reason} ->
+        {:next_state, {:error, reason}, data, {:next_event, :internal, :broadcast}}
+    end
+  end
+
+  defp start_import(%Data{} = data, %Car{} = car, streams) do
+    :ok = Log.complete_current_state(car)
+
+    {date_limit, data} = original_date_limit(data, car)
+
+    api_name = :"api_#{car.name}"
+
+    {:ok, api} =
+      FakeApi.start_link(
+        name: api_name,
+        event_streams: streams,
+        date_limit: date_limit,
+        pid: self()
+      )
+
+    {:ok, veh} =
+      Vehicle.start_link(
+        name: :"import_#{car.name}",
+        car: car,
+        import?: true,
+        deps_api: {FakeApi, api_name}
+      )
+
+    {:keep_state, %Data{data | car: car, pids: %{veh: veh, api: api}},
+     {:next_event, :internal, :broadcast}}
+  end
 
   defp parse_fname(name) do
     case name do
@@ -215,15 +549,19 @@ defmodule TeslaMate.Import do
     end
   end
 
-  defp create_event_streams(%Data{files: files, timezone: tz}, car \\ nil) do
+  defp create_event_streams(
+         %Data{files: files, timezone: tz, completed: completed},
+         car \\ nil
+       ) do
     alias TeslaApi.Vehicle.State.Drive
     alias TeslaApi.Vehicle, as: Veh
 
     try do
       event_streams =
         files
-        |> Enum.sort_by(fn %{date: date} -> date end)
-        |> Enum.map(fn %{date: date, path: path} ->
+        |> Enum.reject(fn file -> MapSet.member?(completed, Checkpoint.file_id(file)) end)
+        |> Enum.sort_by(fn %{date: date, path: path} -> {date, path} end)
+        |> Enum.map(fn %{path: path, fingerprint: fingerprint} = file ->
           path
           |> File.stream!(read_ahead: 64 * 4096)
           |> CSV.parse()
@@ -232,23 +570,47 @@ defmodule TeslaMate.Import do
               raise "Unsupported delimiter"
 
             {:error, :no_contents} ->
-              {date, Stream.map([], & &1)}
+              {Checkpoint.file_id(file), Stream.map([], & &1)}
 
             {:ok, rows} ->
               stream =
                 rows
-                |> Task.async_stream(&LineParser.parse(&1, tz), timeout: :infinity, ordered: true)
-                |> Stream.map(fn {:ok, vehicle} -> vehicle end)
+                |> Task.async_stream(
+                  fn
+                    {:ok, row_number, row} ->
+                      case RowValidator.parse(row, tz) do
+                        {:ok, vehicle} ->
+                          classify_vehicle(
+                            vehicle,
+                            car,
+                            path,
+                            row_number,
+                            fingerprint
+                          )
+
+                        {:error, reason, fields} ->
+                          {:reject,
+                           RejectedRow.new(path, row_number, reason, fields, fingerprint)}
+                      end
+
+                    {:error, row_number, reason, fields} ->
+                      {:reject, RejectedRow.new(path, row_number, reason, fields, fingerprint)}
+                  end,
+                  timeout: :infinity,
+                  ordered: true
+                )
+                |> Stream.map(fn {:ok, event} -> event end)
                 |> Stream.filter(fn
-                  %Veh{state: "unknown"} ->
+                  {:reject, %RejectedRow{}} ->
+                    true
+
+                  {:vehicle, %Veh{state: "unknown"}} ->
                     false
 
-                  %Veh{drive_state: %Drive{timestamp: nil}} ->
+                  {:vehicle, %Veh{drive_state: %Drive{timestamp: nil}}} ->
                     false
 
-                  %Veh{vin: vin, vehicle_id: vid, id: eid} = v
-                  when car != nil and nil not in [vin, vid, eid] and
-                         vin != car.vin and vid != car.vid and eid != car.eid ->
+                  {:vehicle_changed, %Veh{} = v} ->
                     Logger.warning(
                       "'#{path}' contains data for more than one vehicle: #{car.name}" <>
                         " -> #{v.display_name}!"
@@ -256,14 +618,14 @@ defmodule TeslaMate.Import do
 
                     throw(:vehicle_changed)
 
-                  %Veh{state: "online", drive_state: %Drive{} = d} ->
+                  {:vehicle, %Veh{state: "online", drive_state: %Drive{} = d}} ->
                     d.latitude != nil and d.longitude != nil
 
-                  %Veh{} ->
+                  {:vehicle, %Veh{}} ->
                     true
                 end)
 
-              {date, stream}
+              {Checkpoint.file_id(file), stream}
           end
         end)
 
@@ -274,28 +636,63 @@ defmodule TeslaMate.Import do
     end
   end
 
-  defp create_car([]), do: raise("vehicle data is incomplete")
+  defp classify_vehicle(vehicle, nil, _path, _row_number, _fingerprint),
+    do: {:vehicle, vehicle}
 
-  defp create_car([{_date, %Stream{} = stream} | rest]) do
+  defp classify_vehicle(
+         %TeslaApi.Vehicle{vin: vin, vehicle_id: vehicle_id} = vehicle,
+         %Car{} = car,
+         path,
+         row_number,
+         fingerprint
+       ) do
+    # Some TeslaFi variants omit VINs and use a configured vehicle ID fallback. A differing
+    # VIN and vehicle ID together establish a change; a lone VIN conflict is quarantined.
+    cond do
+      vin == nil or vin == car.vin ->
+        {:vehicle, vehicle}
+
+      vehicle_id != nil and vehicle_id != car.vid ->
+        {:vehicle_changed, vehicle}
+
+      true ->
+        {:reject, RejectedRow.new(path, row_number, :vehicle_conflict, [], fingerprint)}
+    end
+  end
+
+  defp create_car(streams, run_id), do: create_car(streams, run_id, %RejectionReport{})
+
+  defp create_car([], _run_id, %RejectionReport{} = report),
+    do: {:error, :vehicle_data_incomplete, report}
+
+  defp create_car(
+         [{_file, %Stream{} = stream} | rest],
+         run_id,
+         %RejectionReport{} = report
+       ) do
     alias TeslaApi.Vehicle, as: Veh
 
     stream
-    |> Enum.find(fn %Veh{} = v -> v.vin != nil and v.vehicle_id != nil and v.id != nil end)
-    |> case do
-      nil ->
-        create_car(rest)
+    |> Enum.reduce_while(report, fn
+      {:vehicle, %Veh{} = vehicle}, _report
+      when vehicle.vin != nil and vehicle.vehicle_id != nil and vehicle.id != nil ->
+        {:halt, {:vehicle, vehicle}}
 
-      vehicle ->
+      {:vehicle, %Veh{}}, report ->
+        {:cont, report}
+
+      {:reject, %RejectedRow{} = rejected_row}, report ->
+        _ = Checkpoint.record_rejection(run_id, rejected_row)
+        {:cont, RejectionReport.record(report, rejected_row)}
+    end)
+    |> case do
+      %RejectionReport{} = report ->
+        create_car(rest, run_id, report)
+
+      {:vehicle, vehicle} ->
         car = Vehicles.create_or_update!(vehicle)
 
-        settings = %CarSettings{
-          suspend_min: 0,
-          suspend_after_idle_min: 99999,
-          use_streaming_api: false,
-          enabled: true
-        }
-
-        %Car{car | settings: settings}
+        {:ok, import_car(car)}
     end
   end
 end

--- a/lib/teslamate/import/checkpoint.ex
+++ b/lib/teslamate/import/checkpoint.ex
@@ -1,0 +1,230 @@
+defmodule TeslaMate.Import.Checkpoint do
+  @moduledoc false
+
+  import Ecto.Query
+
+  alias TeslaMate.Import.{FileCheckpoint, RejectedRow, Rejection, RejectionReport, Run}
+  alias TeslaMate.Repo
+
+  def source_key(path) do
+    path
+    |> Path.expand()
+    |> hash()
+  end
+
+  def file_fingerprint(path) do
+    try do
+      digest =
+        path
+        |> File.stream!(64 * 1024, [])
+        |> Enum.reduce(:crypto.hash_init(:sha256), &:crypto.hash_update(&2, &1))
+        |> :crypto.hash_final()
+        |> Base.encode16(case: :lower)
+
+      {:ok, digest}
+    rescue
+      e in File.Error -> {:error, e.reason}
+    end
+  end
+
+  def file_id(%{path: path, fingerprint: fingerprint}) do
+    {Path.basename(path), fingerprint}
+  end
+
+  def get_active_run(source_key) do
+    Run
+    |> where(source_key: ^source_key, status: :running)
+    |> order_by(desc: :id)
+    |> limit(1)
+    |> Repo.one()
+  end
+
+  def get_last_completed_run(source_key) do
+    Run
+    |> where(source_key: ^source_key, status: :complete)
+    |> order_by(desc: :id)
+    |> limit(1)
+    |> Repo.one()
+  end
+
+  def cleanup_unreachable_runs(source_key) do
+    {_, _} =
+      Run
+      |> where([r], r.source_key != ^source_key and r.status != :running)
+      |> Repo.delete_all()
+
+    :ok
+  end
+
+  def start_run(source_key, timezone) do
+    now = DateTime.utc_now()
+
+    Repo.transaction(fn ->
+      Run
+      |> where([r], r.source_key == ^source_key and r.status != :running)
+      |> Repo.delete_all()
+
+      result =
+        %Run{
+          source_key: source_key,
+          status: :running,
+          timezone: timezone,
+          inserted_at: now,
+          updated_at: now
+        }
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.unique_constraint(:source_key,
+          name: :import_runs_one_running_per_source
+        )
+        |> Repo.insert()
+
+      case result do
+        {:ok, run} -> run
+        {:error, changeset} -> Repo.rollback(changeset)
+      end
+    end)
+  end
+
+  def abandon_run(run_id), do: set_run_status(run_id, :abandoned)
+  def complete_run(run_id), do: set_run_status(run_id, :complete)
+
+  def set_car(run_id, car_id) do
+    now = DateTime.utc_now()
+
+    {1, _} =
+      Run
+      |> where(id: ^run_id)
+      |> Repo.update_all(set: [car_id: car_id, updated_at: now])
+
+    :ok
+  end
+
+  def capture_date_limit(run_id, date_limit) do
+    now = DateTime.utc_now()
+
+    {1, _} =
+      Run
+      |> where(id: ^run_id, date_limit_captured: false)
+      |> Repo.update_all(
+        set: [date_limit: date_limit, date_limit_captured: true, updated_at: now]
+      )
+
+    :ok
+  end
+
+  def completed_files(run_id) do
+    FileCheckpoint
+    |> where(run_id: ^run_id)
+    |> select([f], {f.file_name, f.file_fingerprint})
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  def complete_file(run_id, {file_name, file_fingerprint}) do
+    now = DateTime.utc_now()
+
+    {_, _} =
+      Repo.insert_all(
+        FileCheckpoint,
+        [
+          %{
+            run_id: run_id,
+            file_name: file_name,
+            file_fingerprint: file_fingerprint,
+            completed_at: now,
+            inserted_at: now,
+            updated_at: now
+          }
+        ],
+        on_conflict: [set: [completed_at: now, updated_at: now]],
+        conflict_target: [:run_id, :file_name, :file_fingerprint]
+      )
+
+    :ok
+  end
+
+  def record_rejection(run_id, %RejectedRow{file_fingerprint: fingerprint} = rejected_row)
+      when is_binary(fingerprint) do
+    now = DateTime.utc_now()
+
+    {count, _} =
+      Repo.insert_all(
+        Rejection,
+        [
+          %{
+            run_id: run_id,
+            file_name: rejected_row.file,
+            file_fingerprint: fingerprint,
+            row: rejected_row.row,
+            reason: rejected_row.reason,
+            fields: rejected_row.fields,
+            inserted_at: now,
+            updated_at: now
+          }
+        ],
+        on_conflict: :nothing,
+        conflict_target: [:run_id, :file_name, :file_fingerprint, :row]
+      )
+
+    if count == 1, do: :inserted, else: :existing
+  end
+
+  def rejection_report(_run_id, []), do: %RejectionReport{}
+
+  def rejection_report(run_id, file_ids) do
+    max_examples = RejectionReport.max_examples()
+
+    identities =
+      file_ids
+      |> Enum.uniq()
+      |> Enum.map(fn {file_name, file_fingerprint} ->
+        %{file_name: file_name, file_fingerprint: file_fingerprint}
+      end)
+
+    types = %{file_name: :string, file_fingerprint: :string}
+
+    query =
+      from r in Rejection,
+        join: identity in values(identities, types),
+        on:
+          r.file_name == identity.file_name and
+            r.file_fingerprint == identity.file_fingerprint,
+        where: r.run_id == ^run_id
+
+    count = Repo.aggregate(query, :count, :id)
+
+    examples =
+      query
+      |> order_by(asc: :id)
+      |> limit(^max_examples)
+      |> Repo.all()
+      |> Enum.map(fn rejection ->
+        RejectedRow.new(
+          rejection.file_name,
+          rejection.row,
+          rejection.reason,
+          rejection.fields,
+          rejection.file_fingerprint
+        )
+      end)
+
+    %RejectionReport{count: count, examples: examples}
+  end
+
+  defp set_run_status(run_id, status) do
+    now = DateTime.utc_now()
+
+    {1, _} =
+      Run
+      |> where(id: ^run_id)
+      |> Repo.update_all(set: [status: status, updated_at: now])
+
+    :ok
+  end
+
+  defp hash(value) do
+    :sha256
+    |> :crypto.hash(value)
+    |> Base.encode16(case: :lower)
+  end
+end

--- a/lib/teslamate/import/csv.ex
+++ b/lib/teslamate/import/csv.ex
@@ -16,12 +16,21 @@ defmodule TeslaMate.Import.CSV do
         {:error, :no_contents}
 
       [headers, _] ->
+        column_count = length(headers)
+
         rows =
           file_stream
           |> Parser.parse_stream()
+          |> Stream.with_index(2)
           |> Stream.flat_map(fn
-            [""] -> []
-            row -> [headers |> Enum.zip(row) |> Enum.into(%{})]
+            {[""], _row_number} ->
+              []
+
+            {row, row_number} when length(row) == column_count ->
+              [{:ok, row_number, headers |> Enum.zip(row) |> Enum.into(%{})}]
+
+            {_row, row_number} ->
+              [{:error, row_number, :column_count_mismatch, ["columns"]}]
           end)
 
         {:ok, rows}

--- a/lib/teslamate/import/fake_api.ex
+++ b/lib/teslamate/import/fake_api.ex
@@ -4,15 +4,18 @@ defmodule TeslaMate.Import.FakeApi do
   require Logger
 
   alias TeslaApi.Vehicle
+  alias TeslaMate.Import.RejectedRow
 
   defmodule State do
     defstruct pid: nil,
-              from: nil,
+              waiters: :queue.new(),
               events: [],
               event_chunks: {%{}, _idx = nil, _max_idx = nil},
               event_streams: [],
               current_chunk: nil,
-              date_limit: nil
+              date_limit: nil,
+              finished?: false,
+              abort_reason: nil
   end
 
   # API
@@ -50,59 +53,44 @@ defmodule TeslaMate.Import.FakeApi do
   end
 
   @impl true
+  def handle_call(_action, _from, %State{finished?: true} = state) do
+    {:reply, {:error, :import_complete}, state}
+  end
+
   def handle_call(_action, from, %State{} = state) do
-    case pop(state) do
-      {:error, :chunk_not_yet_received, %State{} = state} ->
-        {:noreply, %{state | from: from}}
-
-      {:done, state} ->
-        processing_complete(state)
-        {:noreply, state}
-
-      {:event, %Vehicle{} = vehicle, state}
-      when vehicle.drive_state.timestamp >= state.date_limit ->
-        processing_complete(state)
-        {:noreply, state}
-
-      {:event, %Vehicle{} = vehicle, state} ->
-        {:reply, {:ok, vehicle}, state}
-    end
+    state = %State{state | waiters: :queue.in(from, state.waiters)}
+    {:noreply, serve_waiters(state)}
   end
 
   @impl true
   def handle_info({:processed_events, max_idx}, %State{} = state) do
-    {:noreply, %State{state | event_chunks: set_max_chunk_idx(state.event_chunks, max_idx)}}
-  end
-
-  def handle_info({:events, events, idx}, %State{from: nil} = state) do
-    {:noreply, %State{state | event_chunks: insert_event_chunk(state.event_chunks, idx, events)}}
-  end
-
-  def handle_info({:events, events, idx}, %State{from: from} = state) do
     state = %State{
       state
-      | event_chunks: insert_event_chunk(state.event_chunks, idx, events),
-        from: nil
+      | event_chunks: set_max_chunk_idx(state.event_chunks, max_idx)
     }
 
-    case pop(state) do
-      {:done, state} ->
-        processing_complete(state)
-        {:noreply, state}
+    {:noreply, serve_waiters(state)}
+  end
 
-      {:event, %Vehicle{} = vehicle, state}
-      when vehicle.drive_state.timestamp >= state.date_limit ->
-        processing_complete(state)
-        {:noreply, state}
+  def handle_info({:events, events, idx}, %State{} = state) do
+    state = %State{
+      state
+      | event_chunks: insert_event_chunk(state.event_chunks, idx, events)
+    }
 
-      {:event, %Vehicle{} = vehicle, state} ->
-        GenServer.reply(from, {:ok, vehicle})
-        {:noreply, state}
-    end
+    {:noreply, serve_waiters(state)}
   end
 
   def handle_info(:abort, %State{} = state) do
-    {:noreply, %State{state | events: [], event_chunks: {%{}, 0, 0}, event_streams: []}}
+    state = %State{
+      state
+      | events: [],
+        event_chunks: {%{}, 0, 0},
+        event_streams: [],
+        abort_reason: :vehicle_changed
+    }
+
+    {:noreply, serve_waiters(state)}
   end
 
   ## Private
@@ -138,14 +126,20 @@ defmodule TeslaMate.Import.FakeApi do
 
     receive do
       :abort ->
-        pop(%State{state | events: [], event_chunks: {%{}, 0, 0}, event_streams: []})
+        pop(%State{
+          state
+          | events: [],
+            event_chunks: {%{}, 0, 0},
+            event_streams: [],
+            abort_reason: :vehicle_changed
+        })
 
       :no_events ->
         Logger.warning("Processed empty chunk: #{inspect(c)}")
-        pop(%State{state | events: [], event_chunks: {%{}, nil, nil}})
+        pop(%State{state | events: [], event_chunks: {%{}, 0, 0}})
 
       {:events, [event | events], 0} ->
-        {:event, event, %State{state | events: events, event_chunks: {%{}, 0, nil}}}
+        pop(%State{state | events: [event | events], event_chunks: {%{}, 0, nil}})
     end
   end
 
@@ -159,8 +153,13 @@ defmodule TeslaMate.Import.FakeApi do
     end
   end
 
-  defp pop(%State{events: [event | events]} = state) do
-    {:event, event, %State{state | events: events}}
+  defp pop(%State{events: [{:reject, %RejectedRow{} = rejected_row} | events]} = state) do
+    send(state.pid, {:rejected_row, rejected_row})
+    pop(%State{state | events: events})
+  end
+
+  defp pop(%State{events: [{:vehicle, %Vehicle{} = vehicle} | events]} = state) do
+    {:event, vehicle, %State{state | events: events}}
   end
 
   defp insert_event_chunk({chunks, chunk_idx, chunk_max_idx}, idx, events) do
@@ -171,8 +170,47 @@ defmodule TeslaMate.Import.FakeApi do
     {chunks, chunk_idx, chunk_max_idx}
   end
 
+  defp serve_waiters(%State{finished?: true} = state), do: state
+
+  defp serve_waiters(%State{waiters: waiters} = state) do
+    case :queue.peek(waiters) do
+      :empty ->
+        state
+
+      {:value, from} ->
+        case pop(state) do
+          {:done, %State{} = state} ->
+            processing_complete(state)
+
+          {:event, %Vehicle{} = vehicle, %State{} = state}
+          when vehicle.drive_state.timestamp >= state.date_limit ->
+            processing_complete(state)
+
+          {:event, %Vehicle{} = vehicle, %State{} = state} ->
+            GenServer.reply(from, {:ok, vehicle})
+
+            state = %State{state | waiters: :queue.drop(state.waiters)}
+            serve_waiters(state)
+
+          {:error, :chunk_not_yet_received, %State{} = state} ->
+            state
+        end
+    end
+  end
+
+  defp processing_complete(%State{abort_reason: reason} = state) when not is_nil(reason) do
+    send(state.pid, {:import_aborted, reason})
+    finish_processing(state)
+  end
+
   defp processing_complete(%State{} = state) do
     send(state.pid, {:done, state.current_chunk})
     send(state.pid, :done)
+    finish_processing(state)
+  end
+
+  defp finish_processing(%State{waiters: waiters} = state) do
+    Enum.each(:queue.to_list(waiters), &GenServer.reply(&1, {:error, :import_complete}))
+    %State{state | waiters: :queue.new(), finished?: true}
   end
 end

--- a/lib/teslamate/import/file_checkpoint.ex
+++ b/lib/teslamate/import/file_checkpoint.ex
@@ -1,0 +1,17 @@
+defmodule TeslaMate.Import.FileCheckpoint do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  alias TeslaMate.Import.Run
+
+  schema "import_file_checkpoints" do
+    field :file_name, :string
+    field :file_fingerprint, :string
+    field :completed_at, :utc_datetime_usec
+
+    belongs_to :run, Run
+
+    timestamps(type: :utc_datetime_usec)
+  end
+end

--- a/lib/teslamate/import/line_parser.ex
+++ b/lib/teslamate/import/line_parser.ex
@@ -15,11 +15,31 @@ defmodule TeslaMate.Import.LineParser do
     "vehicle_state" => %{}
   }
 
-  def parse(line, tz) when is_map(line) do
+  def parse(line, _tz, timestamp) when is_map(line) and is_integer(timestamp) do
     line
-    |> Enum.reduce(@default_vehicle, &into_vehicle(&1, &2, tz))
+    |> Enum.reduce(@default_vehicle, &into_vehicle(&1, &2, timestamp))
     |> Vehicle.result()
   end
+
+  def parse_timestamp(value, tz) when is_binary(value) do
+    with {:ok, datetime} <- parse_datetime(value) do
+      case DateTime.from_naive(datetime, tz) do
+        {:ok, datetime} ->
+          {:ok, DateTime.to_unix(datetime, :millisecond)}
+
+        {:ambiguous, _first_dt, _second_dt} ->
+          {:error, :ambiguous_local_time}
+
+        {:gap, _first_dt, _second_dt} ->
+          {:error, :nonexistent_local_time}
+
+        {:error, _reason} ->
+          {:error, :invalid_timezone}
+      end
+    end
+  end
+
+  def parse_timestamp(_value, _tz), do: {:error, :invalid_date}
 
   @charge_state %Charge{} |> Map.keys() |> Enum.map(&to_string/1)
   @climate_state %Climate{} |> Map.keys() |> Enum.map(&to_string/1)
@@ -27,6 +47,10 @@ defmodule TeslaMate.Import.LineParser do
   @vehicle %Vehicle{} |> Map.keys() |> Enum.map(&to_string/1)
   @vehicle_config %VehicleConfig{} |> Map.keys() |> Enum.map(&to_string/1)
   @vehicle_state %VehicleState{} |> Map.keys() |> Enum.map(&to_string/1)
+
+  @boolean ~w(battery_heater battery_heater_no_power battery_heater_on fast_charger_present
+              is_climate_on is_front_defroster_on is_rear_defroster_on
+              not_enough_power_to_heat)
 
   defp map_value(_, ""), do: nil
   defp map_value(_, "None"), do: nil
@@ -53,12 +77,11 @@ defmodule TeslaMate.Import.LineParser do
 
   defp map_value("scheduled_charging_start_time", _val), do: nil
 
-  @boolean ~w(battery_heater_on is_climate_on is_front_defroster_on is_rear_defroster_on
-              fast_charger_present not_enough_power_to_heat)
-
   defp map_value(key, val) when key in @boolean do
-    with v when v not in [nil, false, true] <- map_value(nil, val) do
-      nil
+    case Integer.parse(val) do
+      {0, ""} -> false
+      {_nonzero, ""} -> true
+      _ -> map_value(nil, val)
     end
   end
 
@@ -78,7 +101,7 @@ defmodule TeslaMate.Import.LineParser do
     end
   end
 
-  defp into_vehicle({key, val}, acc, tz) do
+  defp into_vehicle({key, val}, acc, timestamp) do
     case {key, val} do
       {"id", _val} ->
         Map.put(acc, "id", :rand.uniform(65536))
@@ -86,34 +109,9 @@ defmodule TeslaMate.Import.LineParser do
       {"vehicle_id", ""} ->
         Map.put(acc, "vehicle_id", System.get_env("TESLAFI_IMPORT_VEHICLE_ID", "1"))
 
-      {"Date", val} ->
-        {:ok, datetime} =
-          with {:error, _reason} <- Timex.parse(val, "{YYYY}-{M}-{D} {h24}:{m}:{s}"),
-               {:error, _reason} <- Timex.parse(val, "{M}/{D}/{YYYY} {h12}:{m}:{s} {AM}"),
-               {:error, _reason} <- Timex.parse(val, "{M}/{D}/{YYYY} {h24}:{m}") do
-            {:error, {:invalid_date_format, val}}
-          end
-
-        ts =
-          case DateTime.from_naive(datetime, tz) do
-            {:ok, datetime} ->
-              DateTime.to_unix(datetime, :millisecond)
-
-            {kind, _first_dt, _second_dt} when kind in [:ambiguous, :gap] ->
-              # To keep things simple, return nil to ignore these ambiguous responses
-              nil
-
-            {:error, reason} ->
-              Logger.warning("""
-              Could not convert date #{inspect(datetime)} w/ time zone #{inspect(tz)}:
-              #{inspect(reason)}
-              """)
-
-              nil
-          end
-
+      {"Date", _val} ->
         ["vehicle_config", "vehicle_state", "drive_state", "climate_state", "charge_state"]
-        |> Enum.reduce(acc, fn key, acc -> put_in(acc, [key, "timestamp"], ts) end)
+        |> Enum.reduce(acc, fn key, acc -> put_in(acc, [key, "timestamp"], timestamp) end)
 
       {key, val} when key in @charge_state ->
         put_in(acc, ["charge_state", key], map_value(key, val))
@@ -133,9 +131,17 @@ defmodule TeslaMate.Import.LineParser do
       {key, val} when key in @vehicle ->
         Map.put(acc, key, map_value(key, val))
 
-      {key, val} ->
-        Logger.debug("unhandled: #{inspect({key, val})}")
+      {key, _val} ->
+        Logger.debug("Unhandled import column: #{inspect(key)}")
         acc
+    end
+  end
+
+  defp parse_datetime(value) do
+    with {:error, _reason} <- Timex.parse(value, "{YYYY}-{M}-{D} {h24}:{m}:{s}"),
+         {:error, _reason} <- Timex.parse(value, "{M}/{D}/{YYYY} {h12}:{m}:{s} {AM}"),
+         {:error, _reason} <- Timex.parse(value, "{M}/{D}/{YYYY} {h24}:{m}") do
+      {:error, :invalid_date}
     end
   end
 end

--- a/lib/teslamate/import/rejected_row.ex
+++ b/lib/teslamate/import/rejected_row.ex
@@ -1,0 +1,23 @@
+defmodule TeslaMate.Import.RejectedRow do
+  @moduledoc false
+
+  @max_fields 8
+
+  @enforce_keys [:file, :row, :reason]
+  defstruct [:file, :file_fingerprint, :row, :reason, fields: []]
+
+  def new(path, row, reason, fields \\ [], file_fingerprint \\ nil) do
+    %__MODULE__{
+      file: Path.basename(path),
+      file_fingerprint: file_fingerprint,
+      row: row,
+      reason: reason,
+      fields:
+        fields
+        |> Enum.map(&to_string/1)
+        |> Enum.uniq()
+        |> Enum.sort()
+        |> Enum.take(@max_fields)
+    }
+  end
+end

--- a/lib/teslamate/import/rejection.ex
+++ b/lib/teslamate/import/rejection.ex
@@ -1,0 +1,31 @@
+defmodule TeslaMate.Import.Rejection do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  alias TeslaMate.Import.Run
+
+  schema "import_rejections" do
+    field :file_name, :string
+    field :file_fingerprint, :string
+    field :row, :integer
+
+    field :reason, Ecto.Enum,
+      values: [
+        :invalid_fields,
+        :parse_error,
+        :invalid_date,
+        :ambiguous_local_time,
+        :nonexistent_local_time,
+        :invalid_timezone,
+        :column_count_mismatch,
+        :vehicle_conflict
+      ]
+
+    field :fields, {:array, :string}, default: []
+
+    belongs_to :run, Run
+
+    timestamps(type: :utc_datetime_usec)
+  end
+end

--- a/lib/teslamate/import/rejection_report.ex
+++ b/lib/teslamate/import/rejection_report.ex
@@ -1,0 +1,24 @@
+defmodule TeslaMate.Import.RejectionReport do
+  @moduledoc false
+
+  alias TeslaMate.Import.RejectedRow
+
+  @max_examples 100
+
+  defstruct count: 0, examples: []
+
+  def max_examples, do: @max_examples
+
+  def record(%__MODULE__{} = report, %RejectedRow{} = rejected_row) do
+    examples =
+      if length(report.examples) < @max_examples do
+        report.examples ++ [rejected_row]
+      else
+        report.examples
+      end
+
+    %__MODULE__{report | count: report.count + 1, examples: examples}
+  end
+
+  def truncated?(%__MODULE__{count: count, examples: examples}), do: count > length(examples)
+end

--- a/lib/teslamate/import/row_validator.ex
+++ b/lib/teslamate/import/row_validator.ex
@@ -1,0 +1,104 @@
+defmodule TeslaMate.Import.RowValidator do
+  @moduledoc false
+
+  alias TeslaMate.Import.LineParser
+
+  @field_types [
+    {[:id], :integer},
+    {[:vehicle_id], :castable_integer},
+    {[:vin], :string},
+    {[:state], :string},
+    {[:display_name], :string},
+    {[:vehicle_config, :car_type], :string},
+    {[:vehicle_config, :trim_badging], :string},
+    {[:vehicle_config, :exterior_color], :string},
+    {[:vehicle_config, :wheel_type], :string},
+    {[:vehicle_config, :spoiler_type], :string},
+    {[:drive_state, :timestamp], :integer},
+    {[:drive_state, :latitude], :number},
+    {[:drive_state, :longitude], :number},
+    {[:drive_state, :speed], :number},
+    {[:drive_state, :power], :integer},
+    {[:drive_state, :shift_state], :string},
+    {[:charge_state, :timestamp], :integer},
+    {[:charge_state, :battery_level], :integer},
+    {[:charge_state, :usable_battery_level], :integer},
+    {[:charge_state, :battery_range], :number},
+    {[:charge_state, :ideal_battery_range], :number},
+    {[:charge_state, :est_battery_range], :number},
+    {[:charge_state, :charge_energy_added], :number},
+    {[:charge_state, :charger_actual_current], :integer},
+    {[:charge_state, :charger_phases], :integer},
+    {[:charge_state, :charger_pilot_current], :integer},
+    {[:charge_state, :charger_power], :integer},
+    {[:charge_state, :charger_voltage], :integer},
+    {[:charge_state, :conn_charge_cable], :string},
+    {[:charge_state, :fast_charger_brand], :string},
+    {[:charge_state, :fast_charger_type], :string},
+    {[:charge_state, :charging_state], :string},
+    {[:charge_state, :battery_heater_on], :boolean},
+    {[:charge_state, :fast_charger_present], :boolean},
+    {[:charge_state, :not_enough_power_to_heat], :boolean},
+    {[:climate_state, :timestamp], :integer},
+    {[:climate_state, :outside_temp], :number},
+    {[:climate_state, :inside_temp], :number},
+    {[:climate_state, :fan_status], :integer},
+    {[:climate_state, :driver_temp_setting], :number},
+    {[:climate_state, :passenger_temp_setting], :number},
+    {[:climate_state, :battery_heater], :boolean},
+    {[:climate_state, :battery_heater_no_power], :boolean},
+    {[:climate_state, :is_climate_on], :boolean},
+    {[:climate_state, :is_rear_defroster_on], :boolean},
+    {[:climate_state, :is_front_defroster_on], :boolean},
+    {[:vehicle_state, :timestamp], :integer},
+    {[:vehicle_state, :odometer], :number},
+    {[:vehicle_state, :tpms_pressure_fl], :number},
+    {[:vehicle_state, :tpms_pressure_fr], :number},
+    {[:vehicle_state, :tpms_pressure_rl], :number},
+    {[:vehicle_state, :tpms_pressure_rr], :number}
+  ]
+
+  def parse(row, timezone) when is_map(row) do
+    with {:ok, timestamp} <- LineParser.parse_timestamp(Map.get(row, "Date"), timezone) do
+      vehicle = LineParser.parse(row, timezone, timestamp)
+
+      case invalid_fields(vehicle) do
+        [] -> {:ok, vehicle}
+        fields -> {:error, :invalid_fields, fields}
+      end
+    else
+      {:error, reason} -> {:error, reason, ["Date"]}
+    end
+  rescue
+    _error in [
+      ArgumentError,
+      ArithmeticError,
+      BadMapError,
+      FunctionClauseError,
+      KeyError,
+      MatchError
+    ] ->
+      {:error, :parse_error, []}
+  end
+
+  defp invalid_fields(vehicle) do
+    @field_types
+    |> Enum.reject(fn {path, type} -> valid_value?(type, value_at(vehicle, path)) end)
+    |> Enum.map(fn {path, _type} -> Enum.join(path, ".") end)
+  end
+
+  defp value_at(value, []), do: value
+  defp value_at(nil, _path), do: nil
+  defp value_at(value, [key | path]) when is_map(value), do: value_at(Map.get(value, key), path)
+  defp value_at(_value, _path), do: nil
+
+  defp valid_value?(_type, nil), do: true
+  defp valid_value?(:integer, value), do: is_integer(value)
+  defp valid_value?(:number, value), do: is_number(value) or match?(%Decimal{}, value)
+  defp valid_value?(:boolean, value), do: is_boolean(value)
+  defp valid_value?(:string, value), do: is_binary(value)
+
+  defp valid_value?(:castable_integer, value) do
+    match?({:ok, _integer}, Ecto.Type.cast(:integer, value))
+  end
+end

--- a/lib/teslamate/import/run.ex
+++ b/lib/teslamate/import/run.ex
@@ -1,0 +1,19 @@
+defmodule TeslaMate.Import.Run do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  alias TeslaMate.Log.Car
+
+  schema "import_runs" do
+    field :source_key, :string
+    field :status, Ecto.Enum, values: [:running, :complete, :abandoned]
+    field :timezone, :string
+    field :date_limit, :utc_datetime_usec
+    field :date_limit_captured, :boolean, default: false
+
+    belongs_to :car, Car
+
+    timestamps(type: :utc_datetime_usec)
+  end
+end

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -452,6 +452,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         {:keep_state, data, [broadcast_fetch(false), schedule_fetch(data)]}
 
+      {:error, :import_complete} when data.import? ->
+        {:keep_state, data, broadcast_fetch(false)}
+
       {:error, :closed} ->
         Logger.warning("Error / connection closed", car_id: data.car.id)
         {:keep_state, data, [broadcast_fetch(false), schedule_fetch(5, data)]}

--- a/lib/teslamate_web/live/import_live/index.ex
+++ b/lib/teslamate_web/live/import_live/index.ex
@@ -12,6 +12,7 @@ defmodule TeslaMateWeb.ImportLive.Index do
   end
 
   alias TeslaMate.Import
+  alias TeslaMate.Import.RejectedRow
 
   on_mount {TeslaMateWeb.InitAssigns, :locale}
 
@@ -25,11 +26,14 @@ defmodule TeslaMateWeb.ImportLive.Index do
 
     if Import.enabled?() do
       timezones = Timex.timezones()
-      timezone = get_timezone() || Enum.find(timezones, &match?(^tz, &1))
+      status = Import.get_status()
+
+      timezone =
+        status.resume_timezone || get_timezone() || Enum.find(timezones, &match?(^tz, &1))
 
       socket =
         socket
-        |> assign(status: Import.get_status())
+        |> assign(status: status)
         |> assign(changeset: Settings.changeset(%{timezone: timezone}))
         |> assign(timezones: timezones, page_title: gettext("Import"))
 
@@ -54,9 +58,28 @@ defmodule TeslaMateWeb.ImportLive.Index do
       |> Settings.changeset()
       |> Settings.apply()
 
-    :ok = Import.run(tz)
+    case Import.run(tz) do
+      :ok ->
+        {:noreply, assign(socket, status: %{status | state: :running})}
 
-    {:noreply, assign(socket, status: %{status | state: :running})}
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, import_start_error(reason))}
+    end
+  end
+
+  def handle_event("discard-interrupted-import", _params, socket) do
+    case Import.discard_interrupted_run() do
+      :ok ->
+        socket =
+          socket
+          |> assign(status: Import.get_status())
+          |> put_flash(:info, gettext("Interrupted import discarded."))
+
+        {:noreply, socket}
+
+      {:error, _reason} ->
+        {:noreply, put_flash(socket, :error, gettext("The import can no longer be discarded."))}
+    end
   end
 
   def handle_event("reload", _params, socket) do
@@ -70,6 +93,56 @@ defmodule TeslaMateWeb.ImportLive.Index do
   end
 
   ## Private
+
+  defp rejection_reason(%RejectedRow{reason: :invalid_fields, fields: fields}) do
+    gettext("invalid values for %{fields}", fields: Enum.join(fields, ", "))
+  end
+
+  defp rejection_reason(%RejectedRow{reason: :invalid_date}) do
+    gettext("invalid date")
+  end
+
+  defp rejection_reason(%RejectedRow{reason: :ambiguous_local_time}) do
+    gettext("ambiguous local time")
+  end
+
+  defp rejection_reason(%RejectedRow{reason: :nonexistent_local_time}) do
+    gettext("nonexistent local time")
+  end
+
+  defp rejection_reason(%RejectedRow{reason: :invalid_timezone}) do
+    gettext("date could not be converted in the selected time zone")
+  end
+
+  defp rejection_reason(%RejectedRow{reason: :column_count_mismatch}) do
+    gettext("column count does not match the header")
+  end
+
+  defp rejection_reason(%RejectedRow{reason: :vehicle_conflict}) do
+    gettext("row belongs to a different vehicle")
+  end
+
+  defp rejection_reason(%RejectedRow{}) do
+    gettext("row could not be parsed")
+  end
+
+  defp import_error(:vehicle_data_incomplete) do
+    gettext("No complete vehicle data was found in the import files.")
+  end
+
+  defp import_error(:vehicle_changed) do
+    gettext("The import files contain data for more than one vehicle.")
+  end
+
+  defp import_error(message), do: inspect(message, pretty: true)
+
+  defp import_start_error(:no_files), do: gettext("No import files were found.")
+
+  defp import_start_error(:not_allowed) do
+    gettext("The import is no longer idle. Reload and try again.")
+  end
+
+  defp import_start_error(_reason), do: gettext("The import could not be started.")
 
   defp get_timezone do
     case Timex.local() do

--- a/lib/teslamate_web/live/import_live/index.html.heex
+++ b/lib/teslamate_web/live/import_live/index.html.heex
@@ -73,14 +73,75 @@
   </table>
 </div>
 
+<p class="help mb-4">
+  <%= gettext(
+    "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+  ) %>
+</p>
+
+<%= if @status.rejected_rows > 0 do %>
+  <article class="message is-warning">
+    <div class="message-body">
+      <p class="has-text-weight-semibold">
+        <%= ngettext(
+          "Skipped %{count} malformed row. Valid rows continued.",
+          "Skipped %{count} malformed rows. Valid rows continued.",
+          @status.rejected_rows,
+          count: @status.rejected_rows
+        ) %>
+      </p>
+      <p>
+        <%= gettext(
+          "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+        ) %>
+      </p>
+      <p>
+        <%= gettext(
+          "Rejected-row details are stored without source values so this report survives an interrupted import."
+        ) %>
+      </p>
+      <ul class="mt-2">
+        <%= for rejection <- @status.rejection_examples do %>
+          <li>
+            <%= gettext("%{file}, row %{row}: %{reason}",
+              file: rejection.file,
+              row: rejection.row,
+              reason: rejection_reason(rejection)
+            ) %>
+          </li>
+        <% end %>
+      </ul>
+      <%= if @status.rejection_examples_truncated do %>
+        <p class="mt-2">
+          <%= gettext("Showing the first %{count} malformed rows.",
+            count: @status.rejection_example_limit
+          ) %>
+        </p>
+      <% end %>
+    </div>
+  </article>
+<% end %>
+
 <%= if @status.state == :idle do %>
   <.form :let={f} for={@changeset} phx-change="change" phx-submit="import">
     <div class="field mb-6">
       <%= label(f, :timezone, gettext("Time zone"), class: "label is-medium ") %>
       <div class="control">
-        <div class="select is-fullwidth">
-          <%= select(f, :timezone, @timezones, disabled: @status.state != :idle) %>
-        </div>
+        <%= if @status.resume_timezone do %>
+          <%= hidden_input(f, :timezone, id: "settings_resume_timezone") %>
+          <p id="saved-import-timezone" class="input is-static">
+            <%= @status.resume_timezone %>
+          </p>
+          <p class="help">
+            <%= gettext(
+              "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+            ) %>
+          </p>
+        <% else %>
+          <div class="select is-fullwidth">
+            <%= select(f, :timezone, @timezones, disabled: @status.state != :idle) %>
+          </div>
+        <% end %>
       </div>
     </div>
 
@@ -97,8 +158,27 @@
   </.form>
 <% end %>
 
+<%= if @status.resume_timezone && @status.state in [:idle, :error] do %>
+  <div class="field mt-4">
+    <div class="control">
+      <button
+        type="button"
+        class="button is-danger is-light"
+        phx-click="discard-interrupted-import"
+        data-confirm={
+          gettext(
+            "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+          )
+        }
+      >
+        <%= gettext("Discard interrupted import") %>
+      </button>
+    </div>
+  </div>
+<% end %>
+
 <%= if @status.state == :error do %>
   <code class="box has-text-danger">
-    <%= inspect(@status.message, pretty: true) %>
+    <%= import_error(@status.message) %>
   </code>
 <% end %>

--- a/priv/gettext/ca/LC_MESSAGES/default.po
+++ b/priv/gettext/ca/LC_MESSAGES/default.po
@@ -450,13 +450,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "S'ha trobat %{count} fitxer"
 msgstr[1] "S'han trobat %{count} fitxers"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importa"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Zona horària"
@@ -733,4 +733,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/da/LC_MESSAGES/default.po
+++ b/priv/gettext/da/LC_MESSAGES/default.po
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "Fandt %{count} fil"
 msgstr[1] "Fandt %{count} filer"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importér"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Tidszone"
@@ -730,4 +730,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "%{count} Datei gefunden"
 msgstr[1] "%{count} Dateien gefunden"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Zeitzone"
@@ -730,4 +730,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr ""
@@ -730,4 +730,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr ""
@@ -730,4 +730,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "Encontrado %{count} archivo"
 msgstr[1] "Encontrados %{count} archivos"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importar"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Zona horaria"
@@ -730,4 +730,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/fi/LC_MESSAGES/default.po
+++ b/priv/gettext/fi/LC_MESSAGES/default.po
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "Löytyi %{count} tiedosto"
 msgstr[1] "Löytyi %{count} tiedostoa"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Tuo"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Aikavyöhyke"
@@ -730,4 +730,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "Trouvé %{count} fichier"
 msgstr[1] "Trouvé %{count} fichiers"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importer"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Fuseau horaire"
@@ -730,4 +730,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/hu/LC_MESSAGES/default.po
+++ b/priv/gettext/hu/LC_MESSAGES/default.po
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "%{count} fájl található"
 msgstr[1] "%{count} fájl található"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importálás"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Időzóna"
@@ -730,4 +730,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "Trovato %{count} file"
 msgstr[1] "Trovati %{count} file"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importare"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Fuso orario"
@@ -730,4 +730,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/ja/LC_MESSAGES/default.po
+++ b/priv/gettext/ja/LC_MESSAGES/default.po
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "%{count} 個のファイルが見つかりました"
 msgstr[1] "%{count} 個のファイルが見つかりました"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "インポート"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "タイムゾーン"
@@ -730,4 +730,125 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/ko/LC_MESSAGES/default.po
+++ b/priv/gettext/ko/LC_MESSAGES/default.po
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "%{count} 파일을 찾았습니다."
 msgstr[1] "%{count} 파일들을 찾았습니다."
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "가져오기"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "시간대"
@@ -730,4 +730,125 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/nb/LC_MESSAGES/default.po
+++ b/priv/gettext/nb/LC_MESSAGES/default.po
@@ -450,13 +450,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "%{count} fil"
 msgstr[1] "%{count} filer"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importere"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Tidssone"
@@ -731,4 +731,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/nl/LC_MESSAGES/default.po
+++ b/priv/gettext/nl/LC_MESSAGES/default.po
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "%{count} bestand gevonden"
 msgstr[1] "%{count} bestanden gevonden"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importeren"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Tijdzone"
@@ -730,4 +730,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/sv/LC_MESSAGES/default.po
+++ b/priv/gettext/sv/LC_MESSAGES/default.po
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "%{count} fil hittades"
 msgstr[1] "%{count} filer hittades"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importera"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Tidszon"
@@ -730,4 +730,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/th/LC_MESSAGES/default.po
+++ b/priv/gettext/th/LC_MESSAGES/default.po
@@ -448,13 +448,13 @@ msgid "Found %{count} file"
 msgid_plural "Found %{count} files"
 msgstr[0] "พบ %{count} ไฟล์"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "นำเข้า"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "เขตเวลา"
@@ -729,4 +729,125 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/tr/LC_MESSAGES/default.po
+++ b/priv/gettext/tr/LC_MESSAGES/default.po
@@ -449,13 +449,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "%{count} dosya bulundu"
 msgstr[1] "%{count} dosya bulundu"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Saat dilimi"
@@ -730,4 +730,126 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/uk/LC_MESSAGES/default.po
+++ b/priv/gettext/uk/LC_MESSAGES/default.po
@@ -450,13 +450,13 @@ msgstr[0] "Знайдено %{count} файл"
 msgstr[1] "Знайдено %{count} файли"
 msgstr[2] "Знайдено %{count} файли"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Імпорт"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Часовий пояс"
@@ -732,4 +732,127 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/zh_Hans/LC_MESSAGES/default.po
+++ b/priv/gettext/zh_Hans/LC_MESSAGES/default.po
@@ -450,13 +450,13 @@ msgid_plural "Found %{count} files"
 msgstr[0] "找到了 %{count} 个文件"
 msgstr[1] "找到了 %{count} 个文件"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "导入"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "时区"
@@ -731,4 +731,125 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
 msgstr ""

--- a/priv/gettext/zh_Hant/LC_MESSAGES/default.po
+++ b/priv/gettext/zh_Hant/LC_MESSAGES/default.po
@@ -448,13 +448,13 @@ msgid "Found %{count} file"
 msgid_plural "Found %{count} files"
 msgstr[0] "找到了 %{count} 個檔案"
 
-#: lib/teslamate_web/live/import_live/index.ex:34
-#: lib/teslamate_web/live/import_live/index.html.heex:89
+#: lib/teslamate_web/live/import_live/index.ex:38
+#: lib/teslamate_web/live/import_live/index.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "匯入"
 
-#: lib/teslamate_web/live/import_live/index.html.heex:79
+#: lib/teslamate_web/live/import_live/index.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "時區"
@@ -729,3 +729,124 @@ msgstr "放大地圖"
 #, elixir-autogen, elixir-format
 msgid "Minimize map"
 msgstr "縮小地圖"
+
+#: lib/teslamate_web/live/import_live/index.ex:98
+#, elixir-autogen, elixir-format
+msgid "invalid values for %{fields}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:126
+#, elixir-autogen, elixir-format
+msgid "row could not be parsed"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} malformed row. Valid rows continued."
+msgid_plural "Skipped %{count} malformed rows. Valid rows continued."
+msgstr[0] ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Skipped rows were not imported. Nearby drive or charge summaries may be incomplete."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:106
+#, elixir-autogen, elixir-format
+msgid "%{file}, row %{row}: %{reason}"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:106
+#, elixir-autogen, elixir-format
+msgid "ambiguous local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:118
+#, elixir-autogen, elixir-format
+msgid "column count does not match the header"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:114
+#, elixir-autogen, elixir-format
+msgid "date could not be converted in the selected time zone"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:102
+#, elixir-autogen, elixir-format
+msgid "invalid date"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:110
+#, elixir-autogen, elixir-format
+msgid "nonexistent local time"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "After a restart, unchanged completed files are skipped. The file active during a crash starts again from its beginning and may replay rows already stored; row-exact crash resume is not provided."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Rejected-row details are stored without source values so this report survives an interrupted import."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Discard interrupted import"
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Discard this interrupted import? Its completed-file checkpoints and rejection report will no longer be used. Imported TeslaMate data is kept."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:76
+#, elixir-autogen, elixir-format
+msgid "Interrupted import discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:130
+#, elixir-autogen, elixir-format
+msgid "No complete vehicle data was found in the import files."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:139
+#, elixir-autogen, elixir-format
+msgid "No import files were found."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Showing the first %{count} malformed rows."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:81
+#, elixir-autogen, elixir-format
+msgid "The import can no longer be discarded."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:145
+#, elixir-autogen, elixir-format
+msgid "The import could not be started."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:134
+#, elixir-autogen, elixir-format
+msgid "The import files contain data for more than one vehicle."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:142
+#, elixir-autogen, elixir-format
+msgid "The import is no longer idle. Reload and try again."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "This interrupted import will resume with its saved time zone. The time zone cannot be changed while resuming this run."
+msgstr ""
+
+#: lib/teslamate_web/live/import_live/index.ex:122
+#, elixir-autogen, elixir-format
+msgid "row belongs to a different vehicle"
+msgstr ""

--- a/priv/repo/migrations/20260716110000_add_import_checkpoints.exs
+++ b/priv/repo/migrations/20260716110000_add_import_checkpoints.exs
@@ -1,0 +1,59 @@
+defmodule TeslaMate.Repo.Migrations.AddImportCheckpoints do
+  use Ecto.Migration
+
+  def change do
+    create table(:import_runs) do
+      add :source_key, :string, null: false
+      add :status, :string, null: false
+      add :timezone, :string, null: false
+      add :date_limit, :utc_datetime_usec
+      add :date_limit_captured, :boolean, null: false, default: false
+      add :car_id, references(:cars, on_delete: :nilify_all)
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(
+      unique_index(:import_runs, [:source_key],
+        where: "status = 'running'",
+        name: :import_runs_one_running_per_source
+      )
+    )
+
+    create table(:import_file_checkpoints) do
+      add :run_id, references(:import_runs, on_delete: :delete_all), null: false
+      add :file_name, :string, null: false
+      add :file_fingerprint, :string, null: false
+      add :completed_at, :utc_datetime_usec, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(
+      unique_index(
+        :import_file_checkpoints,
+        [:run_id, :file_name, :file_fingerprint],
+        name: :import_file_checkpoints_identity
+      )
+    )
+
+    create table(:import_rejections) do
+      add :run_id, references(:import_runs, on_delete: :delete_all), null: false
+      add :file_name, :string, null: false
+      add :file_fingerprint, :string, null: false
+      add :row, :integer, null: false
+      add :reason, :string, null: false
+      add :fields, {:array, :string}, null: false, default: []
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(
+      unique_index(
+        :import_rejections,
+        [:run_id, :file_name, :file_fingerprint, :row],
+        name: :import_rejections_row_identity
+      )
+    )
+  end
+end

--- a/test/fixtures/import/08_resilient/TeslaFi12018.csv
+++ b/test/fixtures/import/08_resilient/TeslaFi12018.csv
@@ -1,0 +1,4 @@
+Date,vehicle_id,display_name,vin,id,state,latitude,longitude,shift_state,speed,power,odometer,battery_level,usable_battery_level,ideal_battery_range,est_battery_range,battery_range,outside_temp,inside_temp,fan_status,driver_temp_setting,passenger_temp_setting,car_type,trim_badging,wheel_type
+2018-01-01 10:00:00,1111111111,Resilient,1YYSA1YYYFF08YYYY,42,online,51.5000,-0.1200,D,10,1,1000.0,60,60,200.0,195.0,198.0,8.0,20.0,1,21.0,21.0,model3,74D,AeroTurbine19
+2018-01-01 10:01:00,1111111111,Resilient,1YYSA1YYYFF08YYYY,42,online,PRIVATE_COORDINATE_SENTINEL,PRIVATE_LONGITUDE_SENTINEL,D,11,1,1000.1,60,60,199.9,194.9,197.9,8.0,20.0,1,21.0,21.0,model3,74D,AeroTurbine19
+2018-01-01 10:02:00,1111111111,Resilient,1YYSA1YYYFF08YYYY,42,online,51.5100,-0.1100,D,12,2,1000.2,59,59,199.8,194.8,197.8,8.0,20.0,1,21.0,21.0,model3,74D,AeroTurbine19

--- a/test/fixtures/import/09_identity_conflicts/TeslaFi12018.csv
+++ b/test/fixtures/import/09_identity_conflicts/TeslaFi12018.csv
@@ -1,0 +1,6 @@
+Date,vehicle_id,display_name,vin,id,state,latitude,longitude,shift_state,speed,power,odometer,battery_level,usable_battery_level,ideal_battery_range,est_battery_range,battery_range,outside_temp,inside_temp,fan_status,driver_temp_setting,passenger_temp_setting,car_type,trim_badging,wheel_type
+2018-01-01 10:00:00,1111111111,Identity,1YYSA1YYYFF08YYYY,42,online,51.5000,-0.1200,D,10,1,1000.0,60,60,200.0,195.0,198.0,8.0,20.0,1,21.0,21.0,model3,74D,AeroTurbine19
+2018-01-01 10:01:00,2222222222,Identity,1YYSA1YYYFF08YYYY,42,online,51.5010,-0.1210,D,11,1,1000.1,60,60,199.9,194.9,197.9,8.0,20.0,1,21.0,21.0,model3,74D,AeroTurbine19
+2018-01-01 10:02:00,1111111111,Identity,DIFFERENTVIN00001,42,online,51.5020,-0.1220,D,12,1,1000.2,59,59,199.8,194.8,197.8,8.0,20.0,1,21.0,21.0,model3,74D,AeroTurbine19
+2018-01-01 10:03:00,3333333333,Identity,,42,online,51.5030,-0.1230,D,13,1,1000.3,59,59,199.7,194.7,197.7,8.0,20.0,1,21.0,21.0,model3,74D,AeroTurbine19
+2018-01-01 10:04:00,1111111111,Identity,1YYSA1YYYFF08YYYY,42,online,51.5040,-0.1240,D,14,1,1000.4,58,58,199.6,194.6,197.6,8.0,20.0,1,21.0,21.0,model3,74D,AeroTurbine19

--- a/test/teslamate/import/csv_test.exs
+++ b/test/teslamate/import/csv_test.exs
@@ -1,0 +1,28 @@
+defmodule TeslaMate.Import.CSVTest do
+  use ExUnit.Case, async: true
+
+  alias TeslaMate.Import.CSV
+
+  test "marks short and long rows as column-count errors" do
+    csv = ["a,b\n", "1,2\n", "3\n", "4,5,6\n"]
+
+    assert {:ok, rows} = CSV.parse(csv)
+
+    assert [
+             {:ok, 2, %{"a" => "1", "b" => "2"}},
+             {:error, 3, :column_count_mismatch, ["columns"]},
+             {:error, 4, :column_count_mismatch, ["columns"]}
+           ] = Enum.to_list(rows)
+  end
+
+  test "preserves source row numbers after blank lines" do
+    csv = ["a,b\n", "1,2\n", "\n", "3\n"]
+
+    assert {:ok, rows} = CSV.parse(csv)
+
+    assert [
+             {:ok, 2, %{"a" => "1", "b" => "2"}},
+             {:error, 4, :column_count_mismatch, ["columns"]}
+           ] = Enum.to_list(rows)
+  end
+end

--- a/test/teslamate/import/fake_api_test.exs
+++ b/test/teslamate/import/fake_api_test.exs
@@ -1,0 +1,172 @@
+defmodule TeslaMate.Import.FakeApiTest do
+  use ExUnit.Case, async: true
+
+  alias TeslaApi.Vehicle
+  alias TeslaApi.Vehicle.State.Drive
+  alias TeslaMate.Import.{FakeApi, RejectedRow}
+
+  test "continues across reject-only chunks and reports every rejection once" do
+    name = :"fake_api_#{System.unique_integer([:positive])}"
+
+    rejections =
+      Enum.map(1..1000, fn row ->
+        {:reject, RejectedRow.new("TeslaFi12018.csv", row, :parse_error)}
+      end)
+
+    vehicle = %Vehicle{drive_state: %Drive{timestamp: 1}}
+    stream = Stream.map(rejections ++ [{:vehicle, vehicle}], & &1)
+
+    start_supervised!(
+      {FakeApi,
+       name: name,
+       event_streams: [{[2018, 1], stream}],
+       date_limit: ~U[2100-01-01 00:00:00Z],
+       pid: self()}
+    )
+
+    caller = Task.async(fn -> FakeApi.get_vehicle(name, 1) end)
+
+    Enum.each(1..1000, fn row ->
+      assert_receive {:rejected_row, %RejectedRow{row: ^row}}, 1000
+    end)
+
+    assert {:ok, ^vehicle} = Task.await(caller, 1000)
+    refute_receive {:rejected_row, _rejected_row}
+  end
+
+  test "serves callers in FIFO order while the next chunk is pending" do
+    name = :"fake_api_#{System.unique_integer([:positive])}"
+    parent = self()
+
+    rejections =
+      Enum.map(1..500, fn row ->
+        {:reject, RejectedRow.new("TeslaFi12018.csv", row, :parse_error)}
+      end)
+
+    first_vehicle = %Vehicle{drive_state: %Drive{timestamp: 1}}
+    second_vehicle = %Vehicle{drive_state: %Drive{timestamp: 2}}
+
+    delayed_vehicles =
+      Stream.resource(
+        fn ->
+          send(parent, {:tail_waiting, self()})
+
+          receive do
+            :release_tail -> [{:vehicle, first_vehicle}, {:vehicle, second_vehicle}]
+          end
+        end,
+        fn
+          [] -> {:halt, []}
+          vehicles -> {vehicles, []}
+        end,
+        fn _ -> :ok end
+      )
+
+    stream = Stream.concat(rejections, delayed_vehicles)
+
+    start_supervised!(
+      {FakeApi,
+       name: name,
+       event_streams: [{"TeslaFi12018.csv", stream}],
+       date_limit: ~U[2100-01-01 00:00:00Z],
+       pid: self()}
+    )
+
+    first_caller = Task.async(fn -> FakeApi.get_vehicle(name, 1) end)
+
+    Enum.each(1..500, fn row ->
+      assert_receive {:rejected_row, %RejectedRow{row: ^row}}, 1000
+    end)
+
+    assert_receive {:tail_waiting, producer}, 1000
+
+    second_caller = Task.async(fn -> FakeApi.get_vehicle_with_state(name, 1) end)
+
+    TestHelper.eventually(
+      fn -> assert :queue.len(:sys.get_state(name).waiters) == 2 end,
+      delay: 10,
+      attempts: 100
+    )
+
+    send(producer, :release_tail)
+
+    assert {:ok, ^first_vehicle} = Task.await(first_caller, 1000)
+    assert {:ok, ^second_vehicle} = Task.await(second_caller, 1000)
+  end
+
+  test "marks the final file complete only after the next fetch boundary" do
+    name = :"fake_api_#{System.unique_integer([:positive])}"
+    file_id = {"TeslaFi12018.csv", "fingerprint"}
+    vehicle = %Vehicle{drive_state: %Drive{timestamp: 1}}
+
+    start_supervised!(
+      {FakeApi,
+       name: name,
+       event_streams: [{file_id, Stream.map([{:vehicle, vehicle}], & &1)}],
+       date_limit: ~U[2100-01-01 00:00:00Z],
+       pid: self()}
+    )
+
+    assert {:ok, ^vehicle} = FakeApi.get_vehicle(name, 1)
+    refute_receive {:done, _file_id}
+    refute_receive :done
+
+    next_fetch = Task.async(fn -> FakeApi.get_vehicle(name, 1) end)
+
+    assert_receive {:done, ^file_id}, 1000
+    assert_receive :done, 1000
+    assert {:error, :import_complete} = Task.await(next_fetch, 1000)
+  end
+
+  test "finishes cleanly when the final event stream is empty" do
+    name = :"fake_api_#{System.unique_integer([:positive])}"
+    file_id = {"TeslaFi12018.csv", "fingerprint"}
+
+    child_spec =
+      Supervisor.child_spec(
+        {FakeApi,
+         name: name,
+         event_streams: [{file_id, Stream.map([], & &1)}],
+         date_limit: ~U[2100-01-01 00:00:00Z],
+         pid: self()},
+        restart: :temporary
+      )
+
+    fake_api = start_supervised!(child_spec)
+    ref = Process.monitor(fake_api)
+    next_fetch = Task.async(fn -> FakeApi.get_vehicle(name, 1) end)
+
+    assert_receive {:done, ^file_id}, 1000
+    assert_receive :done, 1000
+    refute_receive {:DOWN, ^ref, :process, ^fake_api, _reason}
+    assert %{finished?: true, waiters: waiters} = :sys.get_state(name)
+    assert :queue.is_empty(waiters)
+    assert {:error, :import_complete} = Task.await(next_fetch, 1000)
+    assert {:error, :import_complete} = FakeApi.get_vehicle(name, 1)
+  end
+
+  test "releases queued callers when the import aborts" do
+    name = :"fake_api_#{System.unique_integer([:positive])}"
+
+    stream =
+      Stream.map([:event], fn _event ->
+        throw(:vehicle_changed)
+      end)
+
+    start_supervised!(
+      {FakeApi,
+       name: name,
+       event_streams: [{"TeslaFi12018.csv", stream}],
+       date_limit: ~U[2100-01-01 00:00:00Z],
+       pid: self()}
+    )
+
+    caller = Task.async(fn -> FakeApi.get_vehicle(name, 1) end)
+
+    assert_receive {:import_aborted, :vehicle_changed}, 1000
+    assert {:error, :import_complete} = Task.await(caller, 1000)
+    assert %{finished?: true, waiters: waiters} = :sys.get_state(name)
+    assert :queue.is_empty(waiters)
+    assert {:error, :import_complete} = FakeApi.get_vehicle_with_state(name, 1)
+  end
+end

--- a/test/teslamate/import/line_parser_test.exs
+++ b/test/teslamate/import/line_parser_test.exs
@@ -10,7 +10,8 @@ defmodule TeslaMate.Import.LineParserTest do
            } =
              LineParser.parse(
                %{"battery_level" => "28.01", "usable_battery_level" => "28.5"},
-               "Etc/UTC"
+               "Etc/UTC",
+               0
              )
 
     assert %TeslaApi.Vehicle{
@@ -18,7 +19,13 @@ defmodule TeslaMate.Import.LineParserTest do
            } =
              LineParser.parse(
                %{"battery_level" => "29", "usable_battery_level" => "30"},
-               "Etc/UTC"
+               "Etc/UTC",
+               0
              )
+  end
+
+  test "requires a prevalidated timestamp" do
+    Code.ensure_loaded!(LineParser)
+    refute function_exported?(LineParser, :parse, 2)
   end
 end

--- a/test/teslamate/import/row_validator_test.exs
+++ b/test/teslamate/import/row_validator_test.exs
@@ -1,0 +1,161 @@
+defmodule TeslaMate.Import.RowValidatorTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias TeslaMate.Import.{RejectedRow, RejectionReport, RowValidator}
+
+  @valid_row %{
+    "Date" => "2018-01-01 10:00:00",
+    "vehicle_id" => "1111111111",
+    "display_name" => "Resilient",
+    "vin" => "1YYSA1YYYFF08YYYY",
+    "id" => "42",
+    "state" => "online",
+    "latitude" => "51.5000",
+    "longitude" => "-0.1200",
+    "shift_state" => "D",
+    "speed" => "10.5",
+    "power" => "1",
+    "odometer" => "1000.0",
+    "battery_level" => "60",
+    "usable_battery_level" => "60",
+    "ideal_battery_range" => "200.0",
+    "est_battery_range" => "195.0",
+    "battery_range" => "198.0"
+  }
+
+  test "accepts a row with values used by the importer" do
+    assert {:ok, %TeslaApi.Vehicle{}} = RowValidator.parse(@valid_row, "Etc/UTC")
+  end
+
+  test "rounds fractional battery levels after validating the row date" do
+    assert {:ok, vehicle} =
+             @valid_row
+             |> Map.put("battery_level", "28.01")
+             |> Map.put("usable_battery_level", "28.5")
+             |> RowValidator.parse("Etc/UTC")
+
+    assert vehicle.charge_state.battery_level == 28
+    assert vehicle.charge_state.usable_battery_level == 29
+  end
+
+  test "reports invalid typed fields without retaining their values" do
+    private_value = "PRIVATE_COORDINATE_SENTINEL"
+
+    assert {:error, :invalid_fields, fields} =
+             @valid_row
+             |> Map.put("latitude", private_value)
+             |> Map.put("longitude", "PRIVATE_LONGITUDE_SENTINEL")
+             |> RowValidator.parse("Etc/UTC")
+
+    assert "drive_state.latitude" in fields
+    assert "drive_state.longitude" in fields
+    refute inspect(fields) =~ private_value
+  end
+
+  test "reports an invalid date without retaining its value" do
+    assert {:error, :invalid_date, ["Date"]} =
+             @valid_row
+             |> Map.put("Date", "PRIVATE_INVALID_DATE_SENTINEL")
+             |> RowValidator.parse("Etc/UTC")
+  end
+
+  test "rejects invalid booleans instead of converting them to nil" do
+    assert {:error, :invalid_fields, fields} =
+             @valid_row
+             |> Map.put("battery_heater_on", "PRIVATE_BOOLEAN_SENTINEL")
+             |> RowValidator.parse("Etc/UTC")
+
+    assert fields == ["charge_state.battery_heater_on"]
+    refute inspect(fields) =~ "PRIVATE_BOOLEAN_SENTINEL"
+  end
+
+  test "accepts legacy numeric boolean flags" do
+    assert {:ok, vehicle} =
+             @valid_row
+             |> Map.put("is_front_defroster_on", "3")
+             |> Map.put("battery_heater", "1")
+             |> Map.put("battery_heater_no_power", "0")
+             |> RowValidator.parse("Etc/UTC")
+
+    assert vehicle.climate_state.is_front_defroster_on
+    assert vehicle.climate_state.battery_heater
+    refute vehicle.climate_state.battery_heater_no_power
+  end
+
+  test "rejects ambiguous local timestamps" do
+    assert {:error, :ambiguous_local_time, ["Date"]} =
+             @valid_row
+             |> Map.put("Date", "2018-10-28 02:30:00")
+             |> RowValidator.parse("Europe/Berlin")
+  end
+
+  test "rejects nonexistent local timestamps" do
+    assert {:error, :nonexistent_local_time, ["Date"]} =
+             @valid_row
+             |> Map.put("Date", "2018-03-25 02:30:00")
+             |> RowValidator.parse("Europe/Berlin")
+  end
+
+  test "does not log unknown source values" do
+    private_value = "PRIVATE_UNKNOWN_COLUMN_SENTINEL"
+    previous_level = Logger.level()
+    Logger.configure(level: :debug)
+
+    log =
+      try do
+        capture_log([level: :debug], fn ->
+          assert {:ok, %TeslaApi.Vehicle{}} =
+                   @valid_row
+                   |> Map.put("unknown_column", private_value)
+                   |> RowValidator.parse("Etc/UTC")
+        end)
+      after
+        Logger.configure(level: previous_level)
+      end
+
+    assert log =~ "unknown_column"
+    refute log =~ private_value
+  end
+
+  test "keeps exact totals while bounding report details" do
+    report =
+      Enum.reduce(1..105, %RejectionReport{}, fn row, report ->
+        RejectionReport.record(
+          report,
+          RejectedRow.new("/private/import/TeslaFi12018.csv", row, :parse_error)
+        )
+      end)
+
+    assert report.count == 105
+    assert length(report.examples) == RejectionReport.max_examples()
+    assert RejectionReport.truncated?(report)
+    assert Enum.map(report.examples, & &1.row) == Enum.to_list(1..100)
+  end
+
+  test "rejected-row metadata contains no source values or directory path" do
+    rejected =
+      RejectedRow.new(
+        "/private/import/TeslaFi12018.csv",
+        3,
+        :invalid_fields,
+        ["drive_state.latitude"]
+      )
+
+    assert rejected.file == "TeslaFi12018.csv"
+    refute inspect(rejected) =~ "/private/import"
+    refute Map.has_key?(Map.from_struct(rejected), :raw_row)
+  end
+
+  test "bounds and normalizes invalid field names" do
+    fields = Enum.map(12..1//-1, &"field.#{&1}") ++ ["field.1"]
+
+    rejected =
+      RejectedRow.new("TeslaFi12018.csv", 3, :invalid_fields, fields)
+
+    assert length(rejected.fields) == 8
+    assert rejected.fields == Enum.sort(rejected.fields)
+    assert Enum.uniq(rejected.fields) == rejected.fields
+  end
+end

--- a/test/teslamate/import_test.exs
+++ b/test/teslamate/import_test.exs
@@ -1,11 +1,21 @@
 defmodule TeslaMate.ImportTest do
   use TeslaMate.DataCase
 
-  alias TeslaMate.Log.{Car, Drive, ChargingProcess, State, Update}
+  alias TeslaMate.Log.{Car, Drive, ChargingProcess, Position, State, Update}
   alias TeslaMate.{Repo, Log, Repair}
+  alias TeslaMate.Vehicles.Vehicle
 
-  alias TeslaMate.Import.Status
   alias TeslaMate.Import
+
+  alias TeslaMate.Import.{
+    Checkpoint,
+    FileCheckpoint,
+    RejectedRow,
+    Rejection,
+    RejectionReport,
+    Run,
+    Status
+  }
 
   import TestHelper, only: [decimal: 1]
   import Mock
@@ -459,11 +469,16 @@ defmodule TeslaMate.ImportTest do
 
       assert_receive %Status{files: [%{complete: false}], state: :running}, 1500
       assert_receive %Status{files: [%{complete: false}], state: :running}, 1500
-      assert_receive %Status{files: [%{complete: true}], state: :running}, 1500
-      assert_receive %Status{files: [%{complete: true}], state: :complete}, 1500
 
-      assert_receive :trigger_run
-      assert_receive :trigger_run
+      assert_receive %Status{
+                       files: [%{complete: false}],
+                       state: :error,
+                       message: :vehicle_changed
+                     },
+                     1500
+
+      refute Process.whereis(:"api_Car-A")
+      refute Process.whereis(:"import_Car-A")
 
       refute_receive _
     end
@@ -500,59 +515,466 @@ defmodule TeslaMate.ImportTest do
   end
 
   @tag :capture_log
-  test "captures errors of the vehicle process", %{pid: _pid} do
+  test "continues after a malformed row and reports it once", %{pid: _pid} do
+    {:ok, _pid} = start_supervised({Import, directory: "#{@dir}/08_resilient"})
+
+    with_mock Repair, trigger_run: fn -> :ok end do
+      assert :ok = Import.run("Etc/UTC")
+
+      TestHelper.eventually(
+        fn ->
+          assert %Status{
+                   state: :complete,
+                   rejected_rows: 1,
+                   rejection_examples: [
+                     %Import.RejectedRow{
+                       file: "TeslaFi12018.csv",
+                       row: 3,
+                       reason: :invalid_fields,
+                       fields: fields
+                     }
+                   ]
+                 } = Import.get_status()
+
+          assert "drive_state.latitude" in fields
+          assert "drive_state.longitude" in fields
+        end,
+        delay: 50,
+        attempts: 100
+      )
+    end
+
+    positions = all(Position)
+    assert Enum.any?(positions, &(&1.date == ~U[2018-01-01 10:02:00.000000Z]))
+    refute Enum.any?(positions, &(&1.date == ~U[2018-01-01 10:01:00.000000Z]))
+    refute inspect(Import.get_status()) =~ "PRIVATE_COORDINATE_SENTINEL"
+
+    assert %Rejection{
+             file_name: "TeslaFi12018.csv",
+             file_fingerprint: fingerprint,
+             row: 3,
+             reason: :invalid_fields,
+             fields: fields
+           } = Repo.one!(Rejection)
+
+    assert byte_size(fingerprint) == 64
+    assert "drive_state.latitude" in fields
+    assert "drive_state.longitude" in fields
+    refute inspect(Repo.one!(Rejection)) =~ "PRIVATE_COORDINATE_SENTINEL"
+    refute inspect(Repo.one!(Rejection)) =~ @dir
+
+    assert %FileCheckpoint{
+             file_name: "TeslaFi12018.csv",
+             file_fingerprint: ^fingerprint
+           } = Repo.one!(FileCheckpoint)
+  end
+
+  @tag :capture_log
+  test "reports deterministic row errors when no complete vehicle row remains", %{
+    pid: _pid
+  } do
     {:ok, _pid} = start_supervised({Import, directory: "#{@dir}/04_error"})
 
     assert %Import.Status{files: [_, _, _], message: nil, state: :idle} = Import.get_status()
 
-    assert :ok = Import.subscribe()
-    assert :ok = Import.run("Europe/Berlin")
+    with_mock Repair, trigger_run: fn -> :ok end do
+      assert :ok = Import.run("Europe/Berlin")
 
-    assert_receive %Status{
-                     files: [%{complete: false}, %{complete: false}, %{complete: false}],
-                     state: :running
-                   },
-                   1000
+      TestHelper.eventually(
+        fn ->
+          assert %Status{
+                   files: [
+                     %{complete: false},
+                     %{complete: false},
+                     %{complete: false}
+                   ],
+                   state: :error,
+                   message: :vehicle_data_incomplete,
+                   rejected_rows: 4,
+                   rejection_examples: examples
+                 } = Import.get_status()
 
-    assert_receive %Status{
-                     files: [%{complete: false}, %{complete: false}, %{complete: false}],
-                     state: :running
-                   },
-                   1000
+          assert length(examples) == 4
+          assert Enum.map(examples, & &1.row) == [2, 3, 4, 5]
+          assert Process.alive?(Process.whereis(Import))
+        end,
+        delay: 50,
+        attempts: 100
+      )
+    end
+  end
 
-    assert_receive %Status{
-                     files: [%{complete: true}, %{complete: false}, %{complete: false}],
-                     state: :running
-                   },
-                   1000
+  test "tracks completion by file identity when dates match" do
+    first = "/import/012018.csv"
+    second = "/import/TeslaFi12018.csv"
 
-    assert_receive %Status{
-                     files: [%{complete: true}, %{complete: true}, %{complete: false}],
-                     state: :running
-                   },
-                   1000
+    data = %Import{
+      files: [
+        %{date: [2018, 1], path: first, fingerprint: "first-fingerprint"},
+        %{date: [2018, 1], path: second, fingerprint: "second-fingerprint"}
+      ],
+      completed: MapSet.new([{"012018.csv", "first-fingerprint"}])
+    }
 
-    assert_receive %Status{
-                     files: [%{complete: true}, %{complete: true}, %{complete: false}],
-                     state: :error,
-                     message: msg
-                   },
-                   1000
+    assert %Status{files: [%{complete: true}, %{complete: false}]} =
+             Status.into(:running, data)
+  end
 
-    assert {{:badmatch,
-             {:error,
-              %Ecto.Changeset{
-                action: :insert,
-                changes: %{date: ~U[2017-12-01 13:36:14.000000Z]},
-                errors: [
-                  latitude: {"is invalid", [type: :decimal, validation: :cast]},
-                  longitude: {"is invalid", [type: :decimal, validation: :cast]}
-                ],
-                data: %Log.Position{},
-                valid?: false
-              }}}, [_ | _]} = msg
+  @tag :capture_log
+  test "quarantines a conflicting VIN without rejecting fallback vehicle IDs" do
+    {:ok, _pid} =
+      start_supervised({Import, directory: "#{@dir}/09_identity_conflicts"})
 
-    refute_receive _
+    with_mock Repair, trigger_run: fn -> :ok end do
+      assert :ok = Import.run("Etc/UTC")
+
+      TestHelper.eventually(
+        fn ->
+          assert %Status{
+                   state: :complete,
+                   rejected_rows: 1,
+                   rejection_examples: [
+                     %RejectedRow{row: 4, reason: :vehicle_conflict, fields: []}
+                   ]
+                 } = Import.get_status()
+        end,
+        delay: 50,
+        attempts: 100
+      )
+    end
+
+    position_dates = Position |> all() |> Enum.map(& &1.date)
+
+    assert ~U[2018-01-01 10:01:00.000000Z] in position_dates
+    assert ~U[2018-01-01 10:03:00.000000Z] in position_dates
+    assert ~U[2018-01-01 10:04:00.000000Z] in position_dates
+    refute ~U[2018-01-01 10:02:00.000000Z] in position_dates
+  end
+
+  test "filters rejection reports by exact file identities" do
+    {:ok, run} = Checkpoint.start_run(Checkpoint.source_key(tmp_import_dir!()), "Etc/UTC")
+
+    assert :inserted =
+             Checkpoint.record_rejection(
+               run.id,
+               RejectedRow.new("first.csv", 2, :parse_error, [], "fingerprint-1")
+             )
+
+    assert :inserted =
+             Checkpoint.record_rejection(
+               run.id,
+               RejectedRow.new("second.csv", 3, :parse_error, [], "fingerprint-2")
+             )
+
+    assert :inserted =
+             Checkpoint.record_rejection(
+               run.id,
+               RejectedRow.new("first.csv", 4, :parse_error, [], "fingerprint-2")
+             )
+
+    assert %RejectionReport{count: 2, examples: examples} =
+             Checkpoint.rejection_report(run.id, [
+               {"first.csv", "fingerprint-1"},
+               {"second.csv", "fingerprint-2"}
+             ])
+
+    assert Enum.map(examples, &{&1.file, &1.row}) == [{"first.csv", 2}, {"second.csv", 3}]
+  end
+
+  @tag :capture_log
+  test "reports a file error between car discovery and import startup" do
+    directory = tmp_import_dir!()
+    name = "TeslaFi12018.csv"
+    path = Path.join(directory, name)
+    File.cp!(Path.join([@dir, "08_resilient", name]), path)
+
+    {:ok, import} = start_supervised({Import, directory: directory})
+
+    with_mock Checkpoint, [:passthrough],
+      set_car: fn run_id, car_id ->
+        result = passthrough([run_id, car_id])
+        File.write!(path, "unsupported delimiter\nsecond row\n")
+        result
+      end do
+      assert :ok = Import.run("Etc/UTC")
+
+      TestHelper.eventually(
+        fn ->
+          assert %Status{
+                   state: :error,
+                   message: %RuntimeError{message: "Unsupported delimiter"}
+                 } = Import.get_status()
+
+          assert Process.alive?(import)
+        end,
+        delay: 50,
+        attempts: 100
+      )
+    end
+  end
+
+  @tag :capture_log
+  test "finishes abort cleanup when the vehicle process already exited" do
+    {:ok, import} = start_supervised({Import, directory: "#{@dir}/08_resilient"})
+
+    with_mock Vehicle, [:passthrough],
+      start_link: fn _opts ->
+        Task.start_link(fn -> Process.sleep(:infinity) end)
+      end do
+      assert :ok = Import.run("Etc/UTC")
+
+      TestHelper.eventually(
+        fn ->
+          assert {:running, %Import{pids: %{api: api, veh: veh}}} = :sys.get_state(import)
+          assert Process.alive?(api)
+          assert Process.alive?(veh)
+        end,
+        delay: 10,
+        attempts: 100
+      )
+
+      {:running, %Import{pids: %{api: api, veh: veh}}} = :sys.get_state(import)
+      vehicle_ref = Process.monitor(veh)
+      api_ref = Process.monitor(api)
+
+      Process.exit(veh, :kill)
+      assert_receive {:DOWN, ^vehicle_ref, :process, ^veh, :killed}, 1000
+
+      send(import, {:import_aborted, :vehicle_changed})
+
+      assert_receive {:DOWN, ^api_ref, :process, ^api, :normal}, 1000
+      assert %Status{state: :error, message: :vehicle_changed} = Import.get_status()
+    end
+  end
+
+  test "restores an interrupted run with its saved timezone and imports the remaining file" do
+    directory = tmp_import_dir!()
+    first_name = "TeslaFi62016.csv"
+    second_name = "TeslaFi72016.csv"
+
+    File.cp!(Path.join([@dir, "01_complete", first_name]), Path.join(directory, first_name))
+    File.cp!(Path.join([@dir, "01_complete", second_name]), Path.join(directory, second_name))
+
+    first_path = Path.join(directory, first_name)
+    {:ok, fingerprint} = Checkpoint.file_fingerprint(first_path)
+    {:ok, run} = Checkpoint.start_run(Checkpoint.source_key(directory), "America/Los_Angeles")
+    :ok = Checkpoint.complete_file(run.id, {first_name, fingerprint})
+
+    {:ok, _pid} = start_supervised({Import, directory: directory})
+
+    assert %Status{
+             state: :idle,
+             resume_timezone: "America/Los_Angeles",
+             files: [
+               %{path: ^first_path, complete: true},
+               %{path: second_path, complete: false}
+             ]
+           } = Import.get_status()
+
+    assert second_path == Path.join(directory, second_name)
+
+    with_mock Repair, trigger_run: fn -> :ok end do
+      assert :ok = Import.run("Europe/Berlin")
+
+      TestHelper.eventually(
+        fn ->
+          assert %Status{state: :complete, files: [%{complete: true}, %{complete: true}]} =
+                   Import.get_status()
+        end,
+        delay: 50,
+        attempts: 100
+      )
+    end
+
+    assert [%Run{status: :complete, timezone: "America/Los_Angeles"}] = Repo.all(Run)
+
+    positions = all(Position)
+    assert positions != []
+
+    assert Enum.all?(positions, fn position ->
+             DateTime.compare(position.date, ~U[2016-07-01 00:00:00Z]) != :lt
+           end)
+  end
+
+  test "does not restore a completed checkpoint after the file changes" do
+    directory = tmp_import_dir!()
+    name = "TeslaFi12018.csv"
+    path = Path.join(directory, name)
+    File.cp!(Path.join([@dir, "08_resilient", name]), path)
+
+    {:ok, old_fingerprint} = Checkpoint.file_fingerprint(path)
+    {:ok, run} = Checkpoint.start_run(Checkpoint.source_key(directory), "Etc/UTC")
+    :ok = Checkpoint.complete_file(run.id, {name, old_fingerprint})
+
+    File.write!(path, "\n", [:append])
+    {:ok, new_fingerprint} = Checkpoint.file_fingerprint(path)
+    refute new_fingerprint == old_fingerprint
+
+    {:ok, _pid} = start_supervised({Import, directory: directory})
+
+    assert %Status{state: :idle, files: [%{path: ^path, complete: false}]} =
+             Import.get_status()
+  end
+
+  test "discards an interrupted run and permits a fresh run" do
+    directory = tmp_import_dir!()
+    name = "TeslaFi12018.csv"
+    path = Path.join(directory, name)
+    File.cp!(Path.join([@dir, "08_resilient", name]), path)
+
+    source_key = Checkpoint.source_key(directory)
+    {:ok, fingerprint} = Checkpoint.file_fingerprint(path)
+    {:ok, run} = Checkpoint.start_run(source_key, "America/Los_Angeles")
+    :ok = Checkpoint.complete_file(run.id, {name, fingerprint})
+
+    assert :inserted =
+             Checkpoint.record_rejection(
+               run.id,
+               RejectedRow.new(path, 3, :parse_error, [], fingerprint)
+             )
+
+    {:ok, _pid} = start_supervised({Import, directory: directory})
+
+    assert %Status{
+             state: :idle,
+             resume_timezone: "America/Los_Angeles",
+             rejected_rows: 1,
+             files: [%{complete: true}]
+           } = Import.get_status()
+
+    assert :ok = Import.discard_interrupted_run()
+
+    assert %Status{
+             state: :idle,
+             resume_timezone: nil,
+             rejected_rows: 0,
+             files: [%{complete: false}]
+           } = Import.get_status()
+
+    assert %Run{status: :abandoned} = Repo.get!(Run, run.id)
+    assert Checkpoint.get_active_run(source_key) == nil
+
+    assert {:ok, %Run{timezone: "Etc/UTC"} = new_run} =
+             Checkpoint.start_run(source_key, "Etc/UTC")
+
+    assert Repo.get(Run, run.id) == nil
+    assert Repo.get!(Run, new_run.id).status == :running
+  end
+
+  test "restores the last completed rejection report after restart" do
+    directory = tmp_import_dir!()
+    name = "TeslaFi12018.csv"
+    path = Path.join(directory, name)
+    File.cp!(Path.join([@dir, "08_resilient", name]), path)
+
+    {:ok, fingerprint} = Checkpoint.file_fingerprint(path)
+    {:ok, run} = Checkpoint.start_run(Checkpoint.source_key(directory), "Etc/UTC")
+
+    assert :inserted =
+             Checkpoint.record_rejection(
+               run.id,
+               RejectedRow.new(path, 3, :parse_error, [], fingerprint)
+             )
+
+    :ok = Checkpoint.complete_run(run.id)
+    {:ok, _pid} = start_supervised({Import, directory: directory})
+
+    assert %Status{
+             state: :idle,
+             resume_timezone: nil,
+             rejected_rows: 1,
+             rejection_examples: [%RejectedRow{file: ^name, row: 3}]
+           } = Import.get_status()
+  end
+
+  test "rejects an empty import without creating a run" do
+    directory = tmp_import_dir!()
+    {:ok, _pid} = start_supervised({Import, directory: directory})
+
+    assert {:error, :no_files} = Import.run("Etc/UTC")
+    assert Repo.aggregate(Run, :count) == 0
+    assert %Status{state: :idle, files: []} = Import.get_status()
+  end
+
+  test "returns a safe error when a source already has an active run" do
+    source_key = Checkpoint.source_key(tmp_import_dir!())
+
+    assert {:ok, %Run{}} = Checkpoint.start_run(source_key, "Etc/UTC")
+    assert {:error, %Ecto.Changeset{} = changeset} = Checkpoint.start_run(source_key, "Etc/UTC")
+    assert {"has already been taken", _metadata} = changeset.errors[:source_key]
+  end
+
+  test "removes unreachable non-running runs and their dependent records on startup" do
+    directory = tmp_import_dir!()
+    current_source_key = Checkpoint.source_key(directory)
+
+    assert {:ok, current_run} = Checkpoint.start_run(current_source_key, "Etc/UTC")
+    assert :ok = Checkpoint.complete_run(current_run.id)
+
+    assert {:ok, old_run} = Checkpoint.start_run("old-source-key", "Etc/UTC")
+    assert :ok = Checkpoint.complete_file(old_run.id, {"old.csv", "old-fingerprint"})
+
+    assert :inserted =
+             Checkpoint.record_rejection(
+               old_run.id,
+               RejectedRow.new("old.csv", 2, :parse_error, [], "old-fingerprint")
+             )
+
+    old_checkpoint =
+      Repo.one!(from f in FileCheckpoint, where: f.run_id == ^old_run.id)
+
+    old_rejection =
+      Repo.one!(from r in Rejection, where: r.run_id == ^old_run.id)
+
+    assert :ok = Checkpoint.complete_run(old_run.id)
+    assert {:ok, active_other_run} = Checkpoint.start_run("active-other-source-key", "Etc/UTC")
+
+    assert {:ok, _pid} = start_supervised({Import, directory: directory})
+    assert %Status{state: :idle} = Import.get_status()
+
+    assert Repo.get(Run, old_run.id) == nil
+    assert Repo.get(FileCheckpoint, old_checkpoint.id) == nil
+    assert Repo.get(Rejection, old_rejection.id) == nil
+    assert Repo.get!(Run, current_run.id).status == :complete
+    assert Repo.get!(Run, active_other_run.id).status == :running
+  end
+
+  test "keeps prior runs when the configured source directory is unavailable" do
+    missing_directory = Path.join(tmp_import_dir!(), "missing")
+
+    assert {:ok, old_run} = Checkpoint.start_run("old-source-key", "Etc/UTC")
+    assert :ok = Checkpoint.complete_run(old_run.id)
+
+    assert {:ok, _pid} = start_supervised({Import, directory: missing_directory})
+    assert %Status{state: :error, message: :enoent} = Import.get_status()
+
+    assert Repo.get!(Run, old_run.id).status == :complete
+  end
+
+  @tag :capture_log
+  test "captures a runtime failure inside the vehicle process" do
+    {:ok, _pid} = start_supervised({Import, directory: "#{@dir}/01_complete"})
+
+    with_mock Repair, trigger_run: fn -> :ok end do
+      with_mock Log, [:passthrough],
+        insert_position: fn _car_or_drive, _attrs ->
+          raise "injected position insert failure"
+        end do
+        assert :ok = Import.run("America/Los_Angeles")
+
+        TestHelper.eventually(
+          fn ->
+            assert %Status{state: :error, message: message} = Import.get_status()
+            assert inspect(message) =~ "injected position insert failure"
+            assert Process.alive?(Process.whereis(Import))
+            refute Process.whereis(:api_82420)
+            refute Process.whereis(:import_82420)
+          end,
+          delay: 50,
+          attempts: 100
+        )
+      end
+    end
   end
 
   defp ok_fn(name, pid) do
@@ -564,5 +986,17 @@ defmodule TeslaMate.ImportTest do
     struct
     |> order_by(:id)
     |> Repo.all()
+  end
+
+  defp tmp_import_dir! do
+    directory =
+      Path.join(
+        System.tmp_dir!(),
+        "teslamate-import-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    File.mkdir_p!(directory)
+    on_exit(fn -> File.rm_rf!(directory) end)
+    directory
   end
 end

--- a/test/teslamate/vehicles/vehicle_test.exs
+++ b/test/teslamate/vehicles/vehicle_test.exs
@@ -6,6 +6,22 @@ defmodule TeslaMate.Vehicles.VehicleTest do
   alias TeslaMate.Log.{Car, Update}
 
   describe "starting" do
+    test "does not fetch again after an import completes", %{test: name} do
+      parent = self()
+
+      events = [
+        fn ->
+          send(parent, :import_fetch)
+          {:error, :import_complete}
+        end
+      ]
+
+      :ok = start_vehicle(name, events, import?: true)
+
+      assert_receive :import_fetch
+      refute_receive :import_fetch, 100
+    end
+
     @tag :capture_log
     test "handles unknown and faulty states", %{test: name} do
       events = [

--- a/test/teslamate_web/live/import_test.exs
+++ b/test/teslamate_web/live/import_test.exs
@@ -2,12 +2,16 @@ defmodule TeslaMateWeb.ImportLiveTest do
   use TeslaMateWeb.ConnCase
 
   alias TeslaMate.{Import, Repair}
+  alias TeslaMate.Import.Checkpoint
 
   test "imports files", %{conn: conn} do
     {:ok, _} = start_supervised({Import, directory: "./test/fixtures/import/01_complete"})
     {:ok, _} = start_supervised(Repair)
 
     assert {:ok, view, html} = live(conn, "/import")
+
+    assert html =~ "unchanged completed files are skipped"
+    assert html =~ "row-exact crash resume is not provided"
 
     # Table
     assert [
@@ -90,5 +94,116 @@ defmodule TeslaMateWeb.ImportLiveTest do
       delay: 250,
       attempts: 10
     )
+  end
+
+  test "shows a bounded safe report for malformed rows", %{conn: conn} do
+    {:ok, _} = start_supervised({Import, directory: "./test/fixtures/import/08_resilient"})
+    {:ok, _} = start_supervised(Repair)
+
+    assert {:ok, view, _html} = live(conn, "/import")
+
+    render_submit(view, :import, %{settings: %{timezone: "Etc/UTC"}})
+
+    TestHelper.eventually(
+      fn ->
+        html = render(view)
+
+        assert html =~ "Skipped 1 malformed row. Valid rows continued."
+        assert html =~ "stored without source values"
+        assert html =~ "survives an interrupted import"
+        assert html =~ "TeslaFi12018.csv, row 3"
+        assert html =~ "drive_state.latitude"
+        assert html =~ "drive_state.longitude"
+        refute html =~ "PRIVATE_COORDINATE_SENTINEL"
+        refute html =~ "PRIVATE_LONGITUDE_SENTINEL"
+      end,
+      delay: 50,
+      attempts: 100
+    )
+  end
+
+  test "shows a dedicated reason for rows from a different vehicle", %{conn: conn} do
+    {:ok, _} =
+      start_supervised({Import, directory: "./test/fixtures/import/09_identity_conflicts"})
+
+    {:ok, _} = start_supervised(Repair)
+
+    assert {:ok, view, _html} = live(conn, "/import")
+    render_submit(view, :import, %{settings: %{timezone: "Etc/UTC"}})
+
+    TestHelper.eventually(
+      fn ->
+        html = render(view)
+
+        assert html =~ "TeslaFi12018.csv, row 4: row belongs to a different vehicle"
+        refute html =~ "invalid values for vin"
+      end,
+      delay: 50,
+      attempts: 100
+    )
+  end
+
+  test "shows and submits the saved timezone for an interrupted run", %{conn: conn} do
+    directory = "./test/fixtures/import/01_complete"
+
+    assert {:ok, run} =
+             directory
+             |> Checkpoint.source_key()
+             |> Checkpoint.start_run("America/Los_Angeles")
+
+    {:ok, _} = start_supervised({Import, directory: directory})
+
+    assert {:ok, view, html} = live(conn, "/import")
+
+    assert html =~ "interrupted import will resume with its saved time zone"
+
+    assert html
+           |> Floki.parse_document!()
+           |> Floki.find("#settings_resume_timezone")
+           |> Floki.attribute("value") == ["America/Los_Angeles"]
+
+    assert html
+           |> Floki.parse_document!()
+           |> Floki.find("#saved-import-timezone")
+           |> Floki.text() =~ "America/Los_Angeles"
+
+    refute html |> Floki.parse_document!() |> Floki.find("#settings_timezone") |> Enum.any?()
+
+    assert has_element?(view, ~s|button[phx-click="discard-interrupted-import"]|)
+
+    html = render_click(view, "discard-interrupted-import")
+
+    refute html =~ "saved-import-timezone"
+    refute has_element?(view, ~s|button[phx-click="discard-interrupted-import"]|)
+    assert TeslaMate.Repo.get!(Import.Run, run.id).status == :abandoned
+  end
+
+  test "shows a friendly message for incomplete vehicle data", %{conn: conn} do
+    {:ok, _} = start_supervised({Import, directory: "./test/fixtures/import/04_error"})
+
+    assert {:ok, view, _html} = live(conn, "/import")
+    render_submit(view, :import, %{settings: %{timezone: "Europe/Berlin"}})
+
+    TestHelper.eventually(
+      fn ->
+        html = render(view)
+        assert html =~ "No complete vehicle data was found in the import files."
+        refute html =~ "vehicle_data_incomplete"
+      end,
+      delay: 50,
+      attempts: 100
+    )
+  end
+
+  test "handles a stale import submission without crashing", %{conn: conn} do
+    {:ok, _} = start_supervised({Import, directory: "./test/fixtures/import/08_resilient"})
+    {:ok, _} = start_supervised(Repair)
+
+    assert {:ok, view, _html} = live(conn, "/import")
+    assert :ok = Import.run("Etc/UTC")
+
+    render_submit(view, :import, %{settings: %{timezone: "Etc/UTC"}})
+
+    assert Process.alive?(Process.whereis(Import))
   end
 end

--- a/website/docs/import/teslafi.md
+++ b/website/docs/import/teslafi.md
@@ -222,6 +222,27 @@ go()
 4. After the import is complete, **empty the `import` directory** (or remove but ensure docker doesn't have a volume mapping) and **restart** the `teslamate` service.
 5. Reindex PostgreSQL data: `REINDEX TABLE positions;`
 
+:::caution
+If an individual CSV row cannot be parsed or contains values that TeslaMate cannot safely store,
+TeslaMate skips that row and continues with the remaining valid rows. The import page lists the
+source file, CSV row number, and invalid field names without displaying the row's values. Review
+that report before removing the import files. The raw-free rejection details persist if the import
+is interrupted. A skipped row can make a nearby drive or charging summary incomplete.
+:::
+
+:::note
+If TeslaMate restarts during an import, it skips only files that reached a committed file boundary
+and whose content fingerprint still matches. The file that was active during the interruption is
+processed again from its beginning. Rows already stored from that file may be imported again. This
+is file-level recovery, not row-exact or exactly-once recovery; keep the original CSV files
+unchanged until the import finishes. TeslaMate also keeps the time zone selected when the run
+started and reuses it after a restart so timestamps cannot shift partway through the import.
+
+If the saved time zone is wrong or the source files were replaced, use **Discard interrupted
+import** before starting again. The saved checkpoints and rejection report for that run are no
+longer used. Data already imported into TeslaMate is not deleted.
+:::
+
 :::note
 If there is an overlap between the already existing TeslaMate and TeslaFi data, only the data prior to the first TeslaMate data will be imported.
 :::


### PR DESCRIPTION
## Context

This brings back #5519 after the revert in #5531. The reproducible fractional battery regression is fixed by accepting and rounding fractional levels in the validated row path, with regression coverage.

## Included

- Restores the reviewed malformed-row quarantine and file-level resume flow from #5519
- Uses a dedicated vehicle conflict rejection reason
- Cleans up non-running import runs whose source directory is no longer reachable
- Removes the unsafe `LineParser.parse/2` entry point
- Keeps the documented file-level, at-least-once recovery boundary
- Keeps rejection data privacy-safe by storing no raw values or source paths

These also cover the three optional follow-ups from the final maintainer review on #5519.

## Validation

- `mix ci`: 427 tests, 0 failures
- Focused importer suite: 74 tests, 0 failures
- `mix gettext.extract --check-up-to-date`: passed
- Formatting and diff checks: passed

Closes #5528
Closes #5529
Closes #5530

## Suggested labels

`enhancement`, `area:teslamate`