### PR TITLE
chore(i18n): refresh POT references for #5438

### DIFF
--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -395,7 +395,7 @@ msgstr ""
 msgid "≈ %{range} at 100%"
 msgstr ""
 
-#: lib/teslamate_web/live/charge_live/cost.ex:20
+#: lib/teslamate_web/live/charge_live/cost.ex:18
 #: lib/teslamate_web/live/charge_live/cost.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Charge Cost"
@@ -412,7 +412,7 @@ msgstr ""
 msgid "Enter charge cost"
 msgstr ""
 
-#: lib/teslamate_web/live/charge_live/cost.ex:87
+#: lib/teslamate_web/live/charge_live/cost.ex:85
 #, elixir-autogen, elixir-format
 msgid "Saved!"
 msgstr ""


### PR DESCRIPTION
## Summary

This is a one-file follow-up for #5438, targeting the existing feature branch.

The charge cost LiveView moved two Gettext calls, but `priv/gettext/default.pot` still points at the old lines. That is why the POT verification fails. This refreshes only those generated source references, with no runtime behaviour change.

## Checks

- `mix gettext.extract --check-up-to-date`
- `mix compile --warnings-as-errors`
- `mix ci`: 361 tests, 0 failures