### PR TITLE
feat(web): expose VIN in car summary

### DIFF
--- a/lib/teslamate_web/live/car_live/summary.ex
+++ b/lib/teslamate_web/live/car_live/summary.ex
@@ -131,6 +131,15 @@ defmodule TeslaMateWeb.CarLive.Summary do
 
   def format_tpms(_, _), do: "—"
 
+  def format_car_title(display_name, vin) when display_name in [nil, ""] do
+    label = "VIN #{vin}"
+    {label, label}
+  end
+
+  def format_car_title(display_name, vin) do
+    {display_name, "VIN #{String.slice(vin, -6, 6)}"}
+  end
+
   defp translate_state(:start), do: ""
   defp translate_state(:driving), do: gettext("driving")
   defp translate_state(:charging), do: gettext("charging")

--- a/lib/teslamate_web/live/car_live/summary.ex
+++ b/lib/teslamate_web/live/car_live/summary.ex
@@ -132,12 +132,12 @@ defmodule TeslaMateWeb.CarLive.Summary do
   def format_tpms(_, _), do: "—"
 
   def format_car_title(display_name, vin) when display_name in [nil, ""] do
-    label = "VIN #{vin}"
+    label = gettext("VIN %{vin}", vin: vin)
     {label, label}
   end
 
   def format_car_title(display_name, vin) do
-    {display_name, "VIN #{String.slice(vin, -6, 6)}"}
+    {display_name, gettext("VIN %{vin}", vin: String.slice(vin, -6, 6))}
   end
 
   defp translate_state(:start), do: ""

--- a/lib/teslamate_web/live/car_live/summary.html.heex
+++ b/lib/teslamate_web/live/car_live/summary.html.heex
@@ -37,13 +37,15 @@
   <div class="card-content">
     <div class="media is-flex mb-5">
       <div class="media-content">
+        <% {display_name, vin_label} = format_car_title(@summary.display_name, @car.vin) %>
         <p class="title is-5">
           <span
             class="has-tooltip-right has-tooltip-left-mobile"
             style="border-bottom: none;"
-            data-tooltip={@car.vin}
+            data-tooltip={vin_label}
+            title={vin_label}
           >
-            <%= @summary.display_name %>
+            <%= display_name %>
           </span>
         </p>
         <%= unless is_nil(@car.model) do %>

--- a/lib/teslamate_web/live/car_live/summary.html.heex
+++ b/lib/teslamate_web/live/car_live/summary.html.heex
@@ -43,9 +43,9 @@
             class="has-tooltip-right has-tooltip-left-mobile"
             style="border-bottom: none;"
             data-tooltip={vin_label}
-            title={vin_label}
           >
             <%= display_name %>
+            <span :if={display_name != vin_label} class="is-sr-only">, <%= vin_label %></span>
           </span>
         </p>
         <%= unless is_nil(@car.model) do %>

--- a/lib/teslamate_web/live/car_live/summary.html.heex
+++ b/lib/teslamate_web/live/car_live/summary.html.heex
@@ -37,7 +37,15 @@
   <div class="card-content">
     <div class="media is-flex mb-5">
       <div class="media-content">
-        <p class="title is-5"><%= @summary.display_name %></p>
+        <p class="title is-5">
+          <span
+            class="has-tooltip-right has-tooltip-left-mobile"
+            style="border-bottom: none;"
+            data-tooltip={@car.vin}
+          >
+            <%= @summary.display_name %>
+          </span>
+        </p>
         <%= unless is_nil(@car.model) do %>
           <p class="subtitle is-6 has-text-weight-light">
             Model <%= @car.model %>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -10,22 +10,22 @@
 msgid ""
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:268
+#: lib/teslamate_web/live/car_live/summary.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:423
+#: lib/teslamate_web/live/car_live/summary.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "Speed"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:413
+#: lib/teslamate_web/live/car_live/summary.html.heex:421
 #, elixir-autogen, elixir-format
 msgid "State of Charge"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:347
+#: lib/teslamate_web/live/car_live/summary.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "Charged"
 msgstr ""
@@ -60,12 +60,12 @@ msgstr ""
 msgid "updating"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:157
+#: lib/teslamate_web/live/car_live/summary.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Locked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:141
+#: lib/teslamate_web/live/car_live/summary.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Sentry Mode"
 msgstr ""
@@ -87,17 +87,17 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:362
+#: lib/teslamate_web/live/car_live/summary.html.heex:370
 #, elixir-autogen, elixir-format
 msgid "Scheduled Charging"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:100
+#: lib/teslamate_web/live/car_live/summary.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Plugged In"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:374
+#: lib/teslamate_web/live/car_live/summary.html.heex:382
 #, elixir-autogen, elixir-format
 msgid "Charge Limit"
 msgstr ""
@@ -210,7 +210,7 @@ msgid "Create"
 msgstr ""
 
 #: lib/teslamate_web/live/car_live/summary.ex:148
-#: lib/teslamate_web/live/car_live/summary.html.heex:68
+#: lib/teslamate_web/live/car_live/summary.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Preconditioning"
 msgstr ""
@@ -221,27 +221,27 @@ msgid "Sentry mode is enabled"
 msgstr ""
 
 #: lib/teslamate_web/live/car_live/summary.ex:150
-#: lib/teslamate_web/live/car_live/summary.html.heex:92
+#: lib/teslamate_web/live/car_live/summary.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Driver present"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:508
+#: lib/teslamate_web/live/car_live/summary.html.heex:516
 #, elixir-autogen, elixir-format
 msgid "cancel sleep attempt"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:499
+#: lib/teslamate_web/live/car_live/summary.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "try to sleep"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:334
+#: lib/teslamate_web/live/car_live/summary.html.heex:342
 #, elixir-autogen, elixir-format
 msgid "Range (est.)"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:273
+#: lib/teslamate_web/live/car_live/summary.html.heex:281
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr ""
@@ -256,12 +256,12 @@ msgstr ""
 msgid "Vehicle must be locked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:314
+#: lib/teslamate_web/live/car_live/summary.html.heex:322
 #, elixir-autogen, elixir-format
 msgid "Range (rated)"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:353
+#: lib/teslamate_web/live/car_live/summary.html.heex:361
 #, elixir-autogen, elixir-format
 msgid "Charger Power"
 msgstr ""
@@ -286,7 +286,7 @@ msgstr ""
 msgid "rated"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:313
+#: lib/teslamate_web/live/car_live/summary.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Range (ideal)"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Update in progress"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:125
+#: lib/teslamate_web/live/car_live/summary.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Windows open"
 msgstr ""
@@ -311,33 +311,33 @@ msgstr ""
 msgid "Delete '%{geo_fence}'?"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:448
+#: lib/teslamate_web/live/car_live/summary.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Inside Temperature"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:436
+#: lib/teslamate_web/live/car_live/summary.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "Outside Temperature"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:473
+#: lib/teslamate_web/live/car_live/summary.html.heex:481
 #: lib/teslamate_web/live/settings_live/index.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "Version"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:251
+#: lib/teslamate_web/live/car_live/summary.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "Health check failed"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:157
+#: lib/teslamate_web/live/car_live/summary.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Unlocked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:290
+#: lib/teslamate_web/live/car_live/summary.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "Remaining Time"
 msgstr ""
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Timeout"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:84
+#: lib/teslamate_web/live/car_live/summary.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Reduced Battery Range"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:407
+#: lib/teslamate_web/live/car_live/summary.html.heex:415
 #, elixir-autogen, elixir-format
 msgid "≈ %{range} at 100%"
 msgstr ""
@@ -417,7 +417,7 @@ msgstr ""
 msgid "Saved!"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:61
+#: lib/teslamate_web/live/car_live/summary.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Fetching vehicle data ..."
 msgstr ""
@@ -486,7 +486,7 @@ msgstr ""
 msgid "Session fee"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:133
+#: lib/teslamate_web/live/car_live/summary.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Doors open"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:461
+#: lib/teslamate_web/live/car_live/summary.html.heex:469
 #, elixir-autogen, elixir-format
 msgid "Mileage"
 msgstr ""
@@ -566,7 +566,7 @@ msgstr ""
 msgid "Per Minute"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:177
+#: lib/teslamate_web/live/car_live/summary.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Software Update available (%{version})"
 msgstr ""
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Tire Pressure"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:76
+#: lib/teslamate_web/live/car_live/summary.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Dog Mode"
 msgstr ""
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Dog mode is enabled"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:299
+#: lib/teslamate_web/live/car_live/summary.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Expected Finish Time"
 msgstr ""
@@ -671,12 +671,12 @@ msgstr ""
 msgid "LFP Battery"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:149
+#: lib/teslamate_web/live/car_live/summary.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Sentry Mode recording"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:118
+#: lib/teslamate_web/live/car_live/summary.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "View car location on Google Maps"
 msgstr ""
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Theme"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:108
+#: lib/teslamate_web/live/car_live/summary.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Service Mode"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:174
+#: lib/teslamate_web/live/car_live/summary.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "Downloading %{percent}%"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:170
+#: lib/teslamate_web/live/car_live/summary.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Installing %{percent}%"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -10,62 +10,62 @@
 msgid ""
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:276
+#: lib/teslamate_web/live/car_live/summary.html.heex:278
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:431
+#: lib/teslamate_web/live/car_live/summary.html.heex:433
 #, elixir-autogen, elixir-format
 msgid "Speed"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:421
+#: lib/teslamate_web/live/car_live/summary.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "State of Charge"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:355
+#: lib/teslamate_web/live/car_live/summary.html.heex:357
 #, elixir-autogen, elixir-format
 msgid "Charged"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:141
+#: lib/teslamate_web/live/car_live/summary.ex:150
 #, elixir-autogen, elixir-format
 msgid "asleep"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:136
+#: lib/teslamate_web/live/car_live/summary.ex:145
 #, elixir-autogen, elixir-format
 msgid "charging"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:135
+#: lib/teslamate_web/live/car_live/summary.ex:144
 #, elixir-autogen, elixir-format
 msgid "driving"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:140
+#: lib/teslamate_web/live/car_live/summary.ex:149
 #, elixir-autogen, elixir-format
 msgid "offline"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:139
+#: lib/teslamate_web/live/car_live/summary.ex:148
 #, elixir-autogen, elixir-format
 msgid "online"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:137
+#: lib/teslamate_web/live/car_live/summary.ex:146
 #, elixir-autogen, elixir-format
 msgid "updating"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:165
+#: lib/teslamate_web/live/car_live/summary.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Locked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:149
+#: lib/teslamate_web/live/car_live/summary.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Sentry Mode"
 msgstr ""
@@ -87,27 +87,27 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:370
+#: lib/teslamate_web/live/car_live/summary.html.heex:372
 #, elixir-autogen, elixir-format
 msgid "Scheduled Charging"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:108
+#: lib/teslamate_web/live/car_live/summary.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Plugged In"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:382
+#: lib/teslamate_web/live/car_live/summary.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Charge Limit"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:138
+#: lib/teslamate_web/live/car_live/summary.ex:147
 #, elixir-autogen, elixir-format
 msgid "falling asleep"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:142
+#: lib/teslamate_web/live/car_live/summary.ex:151
 #, elixir-autogen, elixir-format
 msgid "unavailable"
 msgstr ""
@@ -199,7 +199,7 @@ msgstr ""
 msgid "Signed in successfully"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:144
+#: lib/teslamate_web/live/car_live/summary.ex:153
 #, elixir-autogen, elixir-format
 msgid "Car is unlocked"
 msgstr ""
@@ -209,39 +209,39 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:148
-#: lib/teslamate_web/live/car_live/summary.html.heex:76
+#: lib/teslamate_web/live/car_live/summary.ex:157
+#: lib/teslamate_web/live/car_live/summary.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Preconditioning"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:147
+#: lib/teslamate_web/live/car_live/summary.ex:156
 #, elixir-autogen, elixir-format
 msgid "Sentry mode is enabled"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:150
-#: lib/teslamate_web/live/car_live/summary.html.heex:100
+#: lib/teslamate_web/live/car_live/summary.ex:159
+#: lib/teslamate_web/live/car_live/summary.html.heex:102
 #, elixir-autogen, elixir-format
 msgid "Driver present"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:516
+#: lib/teslamate_web/live/car_live/summary.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "cancel sleep attempt"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:507
+#: lib/teslamate_web/live/car_live/summary.html.heex:509
 #, elixir-autogen, elixir-format
 msgid "try to sleep"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:342
+#: lib/teslamate_web/live/car_live/summary.html.heex:344
 #, elixir-autogen, elixir-format
 msgid "Range (est.)"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:281
+#: lib/teslamate_web/live/car_live/summary.html.heex:283
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr ""
@@ -256,12 +256,12 @@ msgstr ""
 msgid "Vehicle must be locked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:322
+#: lib/teslamate_web/live/car_live/summary.html.heex:324
 #, elixir-autogen, elixir-format
 msgid "Range (rated)"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:361
+#: lib/teslamate_web/live/car_live/summary.html.heex:363
 #, elixir-autogen, elixir-format
 msgid "Charger Power"
 msgstr ""
@@ -286,7 +286,7 @@ msgstr ""
 msgid "rated"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:321
+#: lib/teslamate_web/live/car_live/summary.html.heex:323
 #, elixir-autogen, elixir-format
 msgid "Range (ideal)"
 msgstr ""
@@ -296,12 +296,12 @@ msgstr ""
 msgid "The car's estimate of remaining range is based on a fixed energy consumption in Wh/km. The Wh/km factor is determined by Tesla and is not country specific whereas the rated range is based on regulatory tests in the different markets for that vehicle."
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:152
+#: lib/teslamate_web/live/car_live/summary.ex:161
 #, elixir-autogen, elixir-format
 msgid "Update in progress"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:133
+#: lib/teslamate_web/live/car_live/summary.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Windows open"
 msgstr ""
@@ -311,33 +311,33 @@ msgstr ""
 msgid "Delete '%{geo_fence}'?"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:456
+#: lib/teslamate_web/live/car_live/summary.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Inside Temperature"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:444
+#: lib/teslamate_web/live/car_live/summary.html.heex:446
 #, elixir-autogen, elixir-format
 msgid "Outside Temperature"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:481
+#: lib/teslamate_web/live/car_live/summary.html.heex:483
 #: lib/teslamate_web/live/settings_live/index.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "Version"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:259
+#: lib/teslamate_web/live/car_live/summary.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Health check failed"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:165
+#: lib/teslamate_web/live/car_live/summary.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Unlocked"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:298
+#: lib/teslamate_web/live/car_live/summary.html.heex:300
 #, elixir-autogen, elixir-format
 msgid "Remaining Time"
 msgstr ""
@@ -375,22 +375,22 @@ msgstr ""
 msgid "Geo-fence \"%{name}\" updated"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:154
+#: lib/teslamate_web/live/car_live/summary.ex:163
 #, elixir-autogen, elixir-format
 msgid "An error occurred"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:153
+#: lib/teslamate_web/live/car_live/summary.ex:162
 #, elixir-autogen, elixir-format
 msgid "Timeout"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:92
+#: lib/teslamate_web/live/car_live/summary.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "Reduced Battery Range"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:415
+#: lib/teslamate_web/live/car_live/summary.html.heex:417
 #, elixir-autogen, elixir-format
 msgid "≈ %{range} at 100%"
 msgstr ""
@@ -417,7 +417,7 @@ msgstr ""
 msgid "Saved!"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:69
+#: lib/teslamate_web/live/car_live/summary.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Fetching vehicle data ..."
 msgstr ""
@@ -486,7 +486,7 @@ msgstr ""
 msgid "Session fee"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:141
+#: lib/teslamate_web/live/car_live/summary.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Doors open"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:469
+#: lib/teslamate_web/live/car_live/summary.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "Mileage"
 msgstr ""
@@ -550,12 +550,12 @@ msgstr ""
 msgid "Update available"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:145
+#: lib/teslamate_web/live/car_live/summary.ex:154
 #, elixir-autogen, elixir-format
 msgid "Doors are open"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:146
+#: lib/teslamate_web/live/car_live/summary.ex:155
 #, elixir-autogen, elixir-format
 msgid "Trunk is open"
 msgstr ""
@@ -566,7 +566,7 @@ msgstr ""
 msgid "Per Minute"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:185
+#: lib/teslamate_web/live/car_live/summary.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "Software Update available (%{version})"
 msgstr ""
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Your Tesla account is locked due to too many failed sign in attempts. To unlock your account, reset your password"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:151
+#: lib/teslamate_web/live/car_live/summary.ex:160
 #, elixir-autogen, elixir-format
 msgid "Downloading update"
 msgstr ""
@@ -636,17 +636,17 @@ msgstr ""
 msgid "Tire Pressure"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:84
+#: lib/teslamate_web/live/car_live/summary.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Dog Mode"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.ex:149
+#: lib/teslamate_web/live/car_live/summary.ex:158
 #, elixir-autogen, elixir-format
 msgid "Dog mode is enabled"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:307
+#: lib/teslamate_web/live/car_live/summary.html.heex:309
 #, elixir-autogen, elixir-format
 msgid "Expected Finish Time"
 msgstr ""
@@ -671,12 +671,12 @@ msgstr ""
 msgid "LFP Battery"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:157
+#: lib/teslamate_web/live/car_live/summary.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Sentry Mode recording"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:126
+#: lib/teslamate_web/live/car_live/summary.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "View car location on Google Maps"
 msgstr ""
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Theme"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:116
+#: lib/teslamate_web/live/car_live/summary.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Service Mode"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:182
+#: lib/teslamate_web/live/car_live/summary.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Downloading %{percent}%"
 msgstr ""
 
-#: lib/teslamate_web/live/car_live/summary.html.heex:178
+#: lib/teslamate_web/live/car_live/summary.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "Installing %{percent}%"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -853,3 +853,9 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "row belongs to a different vehicle"
 msgstr ""
+
+#: lib/teslamate_web/live/car_live/summary.ex:135
+#: lib/teslamate_web/live/car_live/summary.ex:140
+#, elixir-autogen, elixir-format
+msgid "VIN %{vin}"
+msgstr ""

--- a/test/teslamate_web/controllers/car_controller_test.exs
+++ b/test/teslamate_web/controllers/car_controller_test.exs
@@ -37,6 +37,15 @@ defmodule TeslaMateWeb.CarControllerTest do
              |> Enum.find(&match?({"span", [_, {"data-tooltip", ^tooltip}], _}, &1))
   end
 
+  defp assert_car_title(html, name) do
+    assert name ==
+             html
+             |> Floki.parse_document!()
+             |> Floki.find(".car .title")
+             |> Floki.text()
+             |> String.trim()
+  end
+
   defp car_fixture(settings) do
     {:ok, car} =
       Log.create_car(%{
@@ -123,7 +132,16 @@ defmodule TeslaMateWeb.CarControllerTest do
       conn = get(conn, Routes.car_path(conn, :index))
 
       assert html = response(conn, 200)
-      assert html =~ ~r/<p class="title is-5">FooCar<\/p>/
+
+      assert [{"span", attrs, content}] =
+               html
+               |> Floki.parse_document!()
+               |> Floki.find(".car .title [data-tooltip]")
+
+      assert content |> Floki.text() |> String.trim() == "FooCar"
+      assert {"data-tooltip", "xxxxx"} in attrs
+      assert {"class", "has-tooltip-right has-tooltip-left-mobile"} in attrs
+      assert_car_title(html, "FooCar")
       assert table_row(html, "Status", "asleep")
       assert table_row(html, "Range (rated)", "380.26 km")
       assert table_row(html, "Range (est.)", "401.52 km")
@@ -212,7 +230,7 @@ defmodule TeslaMateWeb.CarControllerTest do
       conn = get(conn, Routes.car_path(conn, :index))
 
       assert html = response(conn, 200)
-      assert html =~ ~r/<p class="title is-5">FooCar<\/p>/
+      assert_car_title(html, "FooCar")
 
       assert "Model S P90D" ==
                html
@@ -301,7 +319,7 @@ defmodule TeslaMateWeb.CarControllerTest do
       conn = get(conn, Routes.car_path(conn, :index))
 
       assert html = response(conn, 200)
-      assert html =~ ~r/<p class="title is-5">FooCar<\/p>/
+      assert_car_title(html, "FooCar")
       assert table_row(html, "Status", "charging")
       assert table_row(html, "Remaining Time", "1 h, 49 min")
       assert icon(html, "Plugged In", "power-plug")
@@ -375,7 +393,7 @@ defmodule TeslaMateWeb.CarControllerTest do
       conn = get(conn, Routes.car_path(conn, :index))
 
       assert html = response(conn, 200)
-      assert html =~ ~r/<p class="title is-5">FooCar<\/p>/
+      assert_car_title(html, "FooCar")
       assert table_row(html, "Status", "driving")
       assert table_row(html, "Speed", "48 km/h")
     end
@@ -403,7 +421,7 @@ defmodule TeslaMateWeb.CarControllerTest do
       conn = get(conn, Routes.car_path(conn, :index))
 
       assert html = response(conn, 200)
-      assert html =~ ~r/<p class="title is-5">FooCar<\/p>/
+      assert_car_title(html, "FooCar")
       assert table_row(html, "Status", "updating")
     end
 
@@ -418,7 +436,7 @@ defmodule TeslaMateWeb.CarControllerTest do
       conn = get(conn, Routes.car_path(conn, :index))
 
       assert html = response(conn, 200)
-      assert html =~ ~r/<p class="title is-5">FooCar<\/p>/
+      assert_car_title(html, "FooCar")
       assert table_row(html, "Status", "asleep")
     end
 
@@ -433,7 +451,7 @@ defmodule TeslaMateWeb.CarControllerTest do
       conn = get(conn, Routes.car_path(conn, :index))
 
       assert html = response(conn, 200)
-      assert html =~ ~r/<p class="title is-5">FooCar<\/p>/
+      assert_car_title(html, "FooCar")
       assert table_row(html, "Status", "offline")
     end
 
@@ -459,7 +477,7 @@ defmodule TeslaMateWeb.CarControllerTest do
       conn = get(conn, Routes.car_path(conn, :index))
 
       assert html = response(conn, 200)
-      assert html =~ ~r/<p class="title is-5">FooCar<\/p>/
+      assert_car_title(html, "FooCar")
       assert table_row(html, "Status", "falling asleep")
     end
 
@@ -475,7 +493,7 @@ defmodule TeslaMateWeb.CarControllerTest do
       conn = get(conn, Routes.car_path(conn, :index))
 
       assert html = response(conn, 200)
-      assert html =~ ~r/<p class="title is-5"><\/p>/
+      assert_car_title(html, "")
       assert table_row(html, "Status", "unavailable")
     end
 
@@ -512,7 +530,7 @@ defmodule TeslaMateWeb.CarControllerTest do
       conn = get(conn, Routes.car_path(conn, :index))
 
       assert html = response(conn, 200)
-      assert html =~ ~r/<p class="title is-5">FooCar<\/p>/
+      assert_car_title(html, "FooCar")
       assert table_row(html, "Range (rated)", "281.64 km")
       assert table_row(html, "Range (est.)", "289.68 km")
     end
@@ -561,7 +579,7 @@ defmodule TeslaMateWeb.CarControllerTest do
       conn = get(conn, Routes.car_path(conn, :index))
 
       assert html = response(conn, 200)
-      assert html =~ ~r/<p class="title is-5">FooCar<\/p>/
+      assert_car_title(html, "FooCar")
       assert table_row(html, "Status", "driving")
       assert table_row(html, "Range (rated)", "200.0 mi")
       assert table_row(html, "Range (est.)", "180.0 mi")

--- a/test/teslamate_web/controllers/car_controller_test.exs
+++ b/test/teslamate_web/controllers/car_controller_test.exs
@@ -46,6 +46,17 @@ defmodule TeslaMateWeb.CarControllerTest do
              |> String.trim()
   end
 
+  defp assert_car_title_vin(html, name, vin_label) do
+    assert [{"span", attrs, content}] =
+             html
+             |> Floki.parse_document!()
+             |> Floki.find(".car .title [data-tooltip]")
+
+    assert content |> Floki.text() |> String.trim() == name
+    assert Map.new(attrs)["data-tooltip"] == vin_label
+    assert Map.new(attrs)["title"] == vin_label
+  end
+
   defp car_fixture(settings) do
     {:ok, car} =
       Log.create_car(%{
@@ -132,15 +143,6 @@ defmodule TeslaMateWeb.CarControllerTest do
       conn = get(conn, Routes.car_path(conn, :index))
 
       assert html = response(conn, 200)
-
-      assert [{"span", attrs, content}] =
-               html
-               |> Floki.parse_document!()
-               |> Floki.find(".car .title [data-tooltip]")
-
-      assert content |> Floki.text() |> String.trim() == "FooCar"
-      assert {"data-tooltip", "xxxxx"} in attrs
-      assert {"class", "has-tooltip-right has-tooltip-left-mobile"} in attrs
       assert_car_title(html, "FooCar")
       assert table_row(html, "Status", "asleep")
       assert table_row(html, "Range (rated)", "380.26 km")
@@ -148,6 +150,31 @@ defmodule TeslaMateWeb.CarControllerTest do
       assert table_row(html, "State of Charge", "80%", tooltip: "≈ 475 km at 100%")
       assert table_row(html, "Outside Temperature", "20.1 °C")
       assert table_row(html, "Inside Temperature", "21.0 °C")
+    end
+
+    @tag :signed_in
+    test "shows the VIN suffix in an accessible car title tooltip", %{conn: conn} do
+      events = [
+        {:ok, %TeslaApi.Vehicle{state: "asleep", display_name: "FooCar"}}
+      ]
+
+      :ok = start_vehicles(events, vin: "5YJ3E1EA7KF317000")
+
+      conn = get(conn, Routes.car_path(conn, :index))
+
+      assert html = response(conn, 200)
+      assert_car_title_vin(html, "FooCar", "VIN 317000")
+    end
+
+    @tag :capture_log
+    @tag :signed_in
+    test "shows the full VIN when the car has no display name", %{conn: conn} do
+      :ok = start_vehicles([{:error, :unknown}], vin: "5YJ3E1EA7KF317000")
+
+      conn = get(conn, Routes.car_path(conn, :index))
+
+      assert html = response(conn, 200)
+      assert_car_title_vin(html, "VIN 5YJ3E1EA7KF317000", "VIN 5YJ3E1EA7KF317000")
     end
 
     @tag :signed_in
@@ -493,7 +520,7 @@ defmodule TeslaMateWeb.CarControllerTest do
       conn = get(conn, Routes.car_path(conn, :index))
 
       assert html = response(conn, 200)
-      assert_car_title(html, "")
+      assert_car_title(html, "VIN xxxxx")
       assert table_row(html, "Status", "unavailable")
     end
 
@@ -670,7 +697,7 @@ defmodule TeslaMateWeb.CarControllerTest do
     end
   end
 
-  def start_vehicles(events \\ []) do
+  def start_vehicles(events \\ [], opts \\ []) do
     {:ok, _pid} = start_supervised({ApiMock, name: :api_vehicle, events: events, pid: self()})
 
     {:ok, _pid} =
@@ -682,7 +709,7 @@ defmodule TeslaMateWeb.CarControllerTest do
              display_name: "foo",
              id: 4242,
              vehicle_id: 404,
-             vin: "xxxxx"
+             vin: Keyword.get(opts, :vin, "xxxxx")
            }
          ]}
       )

--- a/test/teslamate_web/controllers/car_controller_test.exs
+++ b/test/teslamate_web/controllers/car_controller_test.exs
@@ -42,6 +42,7 @@ defmodule TeslaMateWeb.CarControllerTest do
              html
              |> Floki.parse_document!()
              |> Floki.find(".car .title")
+             |> Floki.filter_out(".is-sr-only")
              |> Floki.text()
              |> String.trim()
   end
@@ -52,9 +53,20 @@ defmodule TeslaMateWeb.CarControllerTest do
              |> Floki.parse_document!()
              |> Floki.find(".car .title [data-tooltip]")
 
-    assert content |> Floki.text() |> String.trim() == name
-    assert Map.new(attrs)["data-tooltip"] == vin_label
-    assert Map.new(attrs)["title"] == vin_label
+    attrs = Map.new(attrs)
+
+    assert content |> Floki.filter_out(".is-sr-only") |> Floki.text() |> String.trim() == name
+    assert attrs["data-tooltip"] == vin_label
+    refute Map.has_key?(attrs, "title")
+
+    case name do
+      ^vin_label ->
+        assert [] == Floki.find(content, ".is-sr-only")
+
+      _name ->
+        assert content |> Floki.find(".is-sr-only") |> Floki.text() |> String.trim() ==
+                 ", #{vin_label}"
+    end
   end
 
   defp car_fixture(settings) do


### PR DESCRIPTION
## Summary

This refreshes #4861, whose original branch now conflicts with `main`. Credit for the original idea and implementation goes to @Helvio88 and is preserved in the commit history.

Named cars keep their display name and expose `VIN <last six>` through the existing responsive tooltip pattern. Cars without a display name now use the translated full VIN as the visible heading. This matches the convention already used by the Grafana dashboards.

For assistive technology, named cars include the VIN in an `is-sr-only` span. The duplicate native `title` tooltip is intentionally omitted. Clipboard behaviour remains out of scope.

## Checks

- Car controller tests: 20 passed
- `mix gettext.extract --check-up-to-date`
- `mix format --check-formatted`
- Full local suite: 388 passed with a larger ExUnit receive window for existing timing-sensitive tests