### PR TITLE
refactor(vehicle): move activity records into state data

### DIFF
--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -36,7 +36,17 @@ defmodule TeslaMate.Vehicles.Vehicle do
               #   :probing          – stream connected, waiting for first power reading
               #   :confirmed_fake   – stream reported power=nil, treating as fake online
               #   :confirmed_real   – stream reported numeric power, treating as real online
-              pre_online_check: :idle
+              pre_online_check: :idle,
+              # Future fields for extracting DB records from state tuples (not used yet)
+              # These will allow moving from {:driving, status, %Log.Drive{}} to :driving + data fields
+              # %Log.Drive{} | nil (will replace drive in {:driving, _, drive})
+              current_drive: nil,
+              # %Log.ChargingProcess{} | nil (will replace cproc in {:charging, cproc})  
+              current_charging_process: nil,
+              # %Log.Update{} | nil (will replace update in {:updating, update})
+              current_update: nil,
+              # :available | {:unavailable, n} | {:offline, last} (will replace status in {:driving, status, _})
+              driving_status: :available
   end
 
   @asleep_interval 30

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -527,18 +527,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
         end
 
         interval =
-          case {data.current_drive != nil, data.current_charging_process != nil} do
-            {true, _} ->
-              10
-
-            {_, true} ->
-              15
-
-            _ ->
-              case state do
-                :online -> 20
-                _ -> 30
-              end
+          case state do
+            :driving -> 10
+            :charging -> 15
+            :online -> 20
+            _ -> 30
           end
 
         {:keep_state, data,

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -37,15 +37,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
               #   :confirmed_fake   – stream reported power=nil, treating as fake online
               #   :confirmed_real   – stream reported numeric power, treating as real online
               pre_online_check: :idle,
-              # Future fields for extracting DB records from state tuples (not used yet)
-              # These will allow moving from {:driving, status, %Log.Drive{}} to :driving + data fields
-              # %Log.Drive{} | nil (will replace drive in {:driving, _, drive})
+              # DB records for active vehicle states (previously embedded in state tuples)
               current_drive: nil,
-              # %Log.ChargingProcess{} | nil (will replace cproc in {:charging, cproc})  
               current_charging_process: nil,
-              # %Log.Update{} | nil (will replace update in {:updating, update})
               current_update: nil,
-              # :available | {:unavailable, n} | {:offline, last} (will replace status in {:driving, status, _})
+              # Sub-state for driving: :available | {:unavailable, n} | {:offline, last_vehicle}
               driving_status: :available
   end
 
@@ -233,7 +229,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         healthy?: healthy?(data.car.id),
         elevation: data.elevation,
         geofence: data.geofence,
-        car: data.car
+        car: data.car,
+        driving_status: data.driving_status
       })
 
     {:keep_state_and_data, {:reply, from, summary}}
@@ -282,15 +279,15 @@ defmodule TeslaMate.Vehicles.Vehicle do
     {:keep_state_and_data, {:reply, from, :ok}}
   end
 
-  def handle_event({:call, from}, :suspend_logging, {:driving, _, _}, _data) do
+  def handle_event({:call, from}, :suspend_logging, :driving, _data) do
     {:keep_state_and_data, {:reply, from, {:error, :vehicle_not_parked}}}
   end
 
-  def handle_event({:call, from}, :suspend_logging, {:updating, _}, _data) do
+  def handle_event({:call, from}, :suspend_logging, :updating, _data) do
     {:keep_state_and_data, {:reply, from, {:error, :update_in_progress}}}
   end
 
-  def handle_event({:call, from}, :suspend_logging, {:charging, _}, _data) do
+  def handle_event({:call, from}, :suspend_logging, :charging, _data) do
     {:keep_state_and_data, {:reply, from, {:error, :charging_in_progress}}}
   end
 
@@ -470,7 +467,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         Logger.info("Vehicle is currently in service", car_id: data.car.id)
 
         case state do
-          {:driving, _, _} when data.current_drive != nil ->
+          :driving when data.current_drive != nil ->
             drive = data.current_drive
 
             {:ok, %Log.Drive{distance: km, duration_min: min}} =
@@ -643,7 +640,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         vehicle = merge(data.last_response, stream_data, time: true)
 
-        {:next_state, {:driving, :available, drive},
+        {:next_state, :driving,
          %Data{
            data
            | last_response: vehicle,
@@ -680,11 +677,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :info,
         {:stream, %Stream.Data{} = stream_data},
-        {:driving, status, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: :available, current_drive: drv} = data
       ) do
-    case {status, stream_data} do
-      {:available, %Stream.Data{shift_state: shift_state}} when shift_state in ~w(D N R) ->
+    case stream_data do
+      %Stream.Data{shift_state: shift_state} when shift_state in ~w(D N R) ->
         {:ok, %{elevation: elevation}} =
           call(data.deps.log, :insert_position, [drv, create_position(stream_data, data)])
 
@@ -694,7 +691,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {:keep_state, %{data | last_used: now, last_response: vehicle, elevation: elevation},
          broadcast_summary()}
 
-      {_status, %Stream.Data{}} ->
+      %Stream.Data{} ->
         {:keep_state_and_data, schedule_fetch(0, data)}
     end
   end
@@ -725,7 +722,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         vehicle = merge(data.last_response, stream_data, time: true)
 
-        {:next_state, {:driving, :available, drive},
+        {:next_state, :driving,
          %Data{
            data
            | last_response: vehicle,
@@ -905,7 +902,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         healthy?: healthy?(data.car.id),
         elevation: data.elevation,
         geofence: data.geofence,
-        car: data.car
+        car: data.car,
+        driving_status: data.driving_status
       })
 
     :ok =
@@ -1055,7 +1053,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         :ok = disconnect_stream(data)
 
-        {:next_state, {:updating, update},
+        {:next_state, :updating,
          %{
            data
            | last_state_change: DateTime.utc_now(),
@@ -1070,8 +1068,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {drive, data} = start_drive(create_position(vehicle, data), data)
         interval = if streaming?(data), do: default_interval(), else: driving_interval()
 
-        {:next_state, {:driving, :available, drive},
-         %{data | current_drive: drive, driving_status: :available},
+        {:next_state, :driving, %{data | current_drive: drive, driving_status: :available},
          [
            broadcast_summary(),
            schedule_fetch(interval, data)
@@ -1102,7 +1099,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         :ok = disconnect_stream(data)
 
-        {:next_state, {:charging, cproc},
+        {:next_state, :charging,
          %Data{
            data
            | last_state_change: DateTime.utc_now(),
@@ -1125,22 +1122,33 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   #### :charging
 
-  def handle_event(:internal, {:update, {:offline, _vehicle}}, {:charging, _}, data) do
+  def handle_event(:internal, {:update, {:offline, _vehicle}}, :charging, data) do
     Logger.warning("Vehicle went offline while charging", car_id: data.car.id)
 
     {:keep_state_and_data, schedule_fetch(data)}
   end
 
-  def handle_event(:internal, {:update, {:asleep, _vehicle}} = event, {:charging, cproc}, data) do
+  def handle_event(
+        :internal,
+        {:update, {:asleep, _vehicle}} = event,
+        :charging,
+        %Data{current_charging_process: cproc} = data
+      ) do
     Logger.warning("Vehicle went asleep while charging (?)", car_id: data.car.id)
 
     {:ok, _} = call(data.deps.log, :complete_charging_process, [cproc])
     Logger.info("Charging / Aborted", car_id: data.car.id)
 
-    {:next_state, :start, data, {:next_event, :internal, event}}
+    {:next_state, :start, %{data | current_charging_process: nil},
+     {:next_event, :internal, event}}
   end
 
-  def handle_event(:internal, {:update, {:online, vehicle}}, {:charging, cproc}, %Data{} = data) do
+  def handle_event(
+        :internal,
+        {:update, {:online, vehicle}},
+        :charging,
+        %Data{current_charging_process: cproc} = data
+      ) do
     data = %{data | last_used: DateTime.utc_now()}
 
     case vehicle do
@@ -1153,7 +1161,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
           |> Map.get(:charger_power)
           |> determince_interval()
 
-        {:next_state, {:charging, cproc}, %{data | current_charging_process: cproc},
+        {:next_state, :charging, %{data | current_charging_process: cproc},
          [broadcast_summary(), schedule_fetch(interval, data)]}
 
       %Vehicle{charge_state: %Charge{charging_state: state}} ->
@@ -1180,12 +1188,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, :available, drive},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: :available} = data
       ) do
     Logger.warning("Vehicle went offline while driving", car_id: data.car.id)
 
-    {:next_state, {:driving, {:unavailable, 0}, drive},
+    {:next_state, :driving,
      %{data | last_used: DateTime.utc_now(), driving_status: {:unavailable, 0}},
      schedule_fetch(5, data)}
   end
@@ -1193,11 +1201,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, {:unavailable, n}, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:unavailable, n}} = data
       )
       when n < 15 do
-    {:next_state, {:driving, {:unavailable, n + 1}, drv},
+    {:next_state, :driving,
      %{data | last_used: DateTime.utc_now(), driving_status: {:unavailable, n + 1}},
      schedule_fetch(5, data)}
   end
@@ -1205,10 +1213,10 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, {:unavailable, _n}, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:unavailable, _n}} = data
       ) do
-    {:next_state, {:driving, {:offline, data.last_response}, drv},
+    {:next_state, :driving,
      %{data | last_used: DateTime.utc_now(), driving_status: {:offline, data.last_response}},
      [broadcast_summary(), schedule_fetch(30, data)]}
   end
@@ -1216,8 +1224,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, {:offline, _last}, nil},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:offline, _}, current_drive: nil} = data
       ) do
     {:next_state, :start, %Data{data | last_used: DateTime.utc_now(), driving_status: nil},
      schedule_fetch(data)}
@@ -1226,8 +1234,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:offline, _}},
-        {:driving, {:offline, last}, drive},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:offline, last}, current_drive: drive} = data
       ) do
     offline_since = parse_timestamp(last.drive_state.timestamp)
 
@@ -1235,8 +1243,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
       min when min >= @drive_timeout_min ->
         timeout_drive(drive, data)
 
-        {:next_state, {:driving, {:offline, last}, nil},
-         %{data | last_used: DateTime.utc_now(), current_drive: nil},
+        {:next_state, :driving, %{data | last_used: DateTime.utc_now(), current_drive: nil},
          [broadcast_summary(), schedule_fetch(30, data)]}
 
       _min ->
@@ -1247,8 +1254,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:online, now}},
-        {:driving, {:offline, last}, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:offline, last}, current_drive: drv} = data
       ) do
     offline_start = parse_timestamp(last.drive_state.timestamp)
     offline_end = parse_timestamp(now.drive_state.timestamp)
@@ -1295,7 +1302,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
       not is_nil(drv) ->
         data = maybe_reconnect_stream(data)
 
-        {:next_state, {:driving, :available, drv},
+        {:next_state, :driving,
          %{data | last_used: DateTime.utc_now(), driving_status: :available},
          {:next_event, :internal, {:update, {:online, now}}}}
     end
@@ -1303,7 +1310,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   #### msg: asleep
 
-  def handle_event(:internal, {:update, {:asleep, _vehicle}}, {:driving, _, drv}, data) do
+  def handle_event(
+        :internal,
+        {:update, {:asleep, _vehicle}},
+        :driving,
+        %Data{current_drive: drv} = data
+      ) do
     unless is_nil(drv), do: timeout_drive(drv, data)
     {:next_state, :start, %{data | driving_status: nil}, schedule_fetch(data)}
   end
@@ -1313,23 +1325,22 @@ defmodule TeslaMate.Vehicles.Vehicle do
   def handle_event(
         :internal,
         {:update, {:online, _} = e},
-        {:driving, {:unavailable, _}, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: {:unavailable, _}} = data
       ) do
     Logger.info("Vehicle is back online", car_id: data.car.id)
 
     data = maybe_reconnect_stream(data)
 
-    {:next_state, {:driving, :available, drv},
-     %{data | last_used: DateTime.utc_now(), driving_status: :available},
+    {:next_state, :driving, %{data | last_used: DateTime.utc_now(), driving_status: :available},
      {:next_event, :internal, {:update, e}}}
   end
 
   def handle_event(
         :internal,
         {:update, {:online, vehicle}},
-        {:driving, :available, drv},
-        %Data{} = data
+        :driving,
+        %Data{driving_status: :available, current_drive: drv} = data
       ) do
     interval = if streaming?(data), do: default_interval(), else: driving_interval()
 
@@ -1375,12 +1386,17 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   #### :updating
 
-  def handle_event(:internal, {:update, {:offline, _}}, {:updating, _update_id}, %Data{} = data) do
+  def handle_event(:internal, {:update, {:offline, _}}, :updating, %Data{} = data) do
     Logger.warning("Vehicle went offline while updating", car_id: data.car.id)
     {:keep_state, %{data | last_used: DateTime.utc_now()}, schedule_fetch(data)}
   end
 
-  def handle_event(:internal, {:update, {:online, vehicle}}, {:updating, update}, data) do
+  def handle_event(
+        :internal,
+        {:update, {:online, vehicle}},
+        :updating,
+        %Data{current_update: update} = data
+      ) do
     alias VehicleState.SoftwareUpdate, as: SW
 
     case vehicle.vehicle_state do
@@ -1532,13 +1548,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
             :online ->
               true
 
-            {:driving, _, _} when data.current_drive != nil ->
+            :driving when data.current_drive != nil ->
               true
 
-            {:updating, _} when data.current_update != nil ->
+            :updating when data.current_update != nil ->
               true
 
-            {:charging, _} when data.current_charging_process != nil ->
+            :charging when data.current_charging_process != nil ->
               true
 
             :start ->
@@ -1564,9 +1580,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
         reachable? =
           case expected_state do
             :online -> true
-            {:driving, _, _} when data.current_drive != nil -> true
-            {:updating, _} when data.current_update != nil -> true
-            {:charging, _} when data.current_charging_process != nil -> true
+            :driving when data.current_drive != nil -> true
+            :updating when data.current_update != nil -> true
+            :charging when data.current_charging_process != nil -> true
             :start -> false
             {:offline, _} -> false
             {:asleep, _} -> false

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -470,7 +470,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
         Logger.info("Vehicle is currently in service", car_id: data.car.id)
 
         case state do
-          {:driving, _, %Log.Drive{} = drive} ->
+          {:driving, _, _} when data.current_drive != nil ->
+            drive = data.current_drive
+
             {:ok, %Log.Drive{distance: km, duration_min: min}} =
               call(data.deps.log, :close_drive, [drive])
 
@@ -480,7 +482,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
               car_id: data.car.id
             )
 
-            {:next_state, :start, %Data{data | last_used: DateTime.utc_now()},
+            {:next_state, :start,
+             %Data{data | last_used: DateTime.utc_now(), driving_status: nil, current_drive: nil},
              [
                broadcast_fetch(false),
                broadcast_summary(),
@@ -527,11 +530,18 @@ defmodule TeslaMate.Vehicles.Vehicle do
         end
 
         interval =
-          case state do
-            {:driving, _, _} -> 10
-            {:charging, _} -> 15
-            :online -> 20
-            _ -> 30
+          case {data.current_drive != nil, data.current_charging_process != nil} do
+            {true, _} ->
+              10
+
+            {_, true} ->
+              15
+
+            _ ->
+              case state do
+                :online -> 20
+                _ -> 30
+              end
           end
 
         {:keep_state, data,
@@ -1209,7 +1219,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {:driving, {:offline, _last}, nil},
         %Data{} = data
       ) do
-    {:next_state, :start, %Data{data | last_used: DateTime.utc_now()}, schedule_fetch(data)}
+    {:next_state, :start, %Data{data | last_used: DateTime.utc_now(), driving_status: nil},
+     schedule_fetch(data)}
   end
 
   def handle_event(
@@ -1272,13 +1283,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         Logger.info("Vehicle was charged while being offline: #{added} kWh", car_id: data.car.id)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now()},
+        {:next_state, :start, %{data | last_used: DateTime.utc_now(), driving_status: nil},
          {:next_event, :internal, {:update, {:online, now}}}}
 
       not has_gained_range? and offline_min >= @drive_timeout_min ->
         unless is_nil(drv), do: timeout_drive(drv, data)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now()},
+        {:next_state, :start, %{data | last_used: DateTime.utc_now(), driving_status: nil},
          {:next_event, :internal, {:update, {:online, now}}}}
 
       not is_nil(drv) ->
@@ -1294,7 +1305,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   def handle_event(:internal, {:update, {:asleep, _vehicle}}, {:driving, _, drv}, data) do
     unless is_nil(drv), do: timeout_drive(drv, data)
-    {:next_state, :start, data, schedule_fetch(data)}
+    {:next_state, :start, %{data | driving_status: nil}, schedule_fetch(data)}
   end
 
   #### msg: :online
@@ -1352,7 +1363,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         Logger.info("End of drive initiated by: #{inspect(vehicle.drive_state)}")
         Logger.info("Driving / Ended / #{km && round(km)} km – #{min} min", car_id: data.car.id)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now(), geofence: geofence},
+        {:next_state, :start,
+         %{data | last_used: DateTime.utc_now(), driving_status: nil, geofence: geofence},
          {:next_event, :internal, {:update, {:online, vehicle}}}}
 
       %Vehicle{drive_state: nil} ->
@@ -1520,13 +1532,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
             :online ->
               true
 
-            {:driving, _, _} ->
+            {:driving, _, _} when data.current_drive != nil ->
               true
 
-            {:updating, _} ->
+            {:updating, _} when data.current_update != nil ->
               true
 
-            {:charging, _} ->
+            {:charging, _} when data.current_charging_process != nil ->
               true
 
             :start ->
@@ -1552,9 +1564,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
         reachable? =
           case expected_state do
             :online -> true
-            {:driving, _, _} -> true
-            {:updating, _} -> true
-            {:charging, _} -> true
+            {:driving, _, _} when data.current_drive != nil -> true
+            {:updating, _} when data.current_update != nil -> true
+            {:charging, _} when data.current_charging_process != nil -> true
             :start -> false
             {:offline, _} -> false
             {:asleep, _} -> false

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1541,13 +1541,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
             :online ->
               true
 
-            :driving when data.current_drive != nil ->
+            :driving ->
               true
 
-            :updating when data.current_update != nil ->
+            :updating ->
               true
 
-            :charging when data.current_charging_process != nil ->
+            :charging ->
               true
 
             :start ->
@@ -1573,9 +1573,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
         reachable? =
           case expected_state do
             :online -> true
-            :driving when data.current_drive != nil -> true
-            :updating when data.current_update != nil -> true
-            :charging when data.current_charging_process != nil -> true
+            :driving -> true
+            :updating -> true
+            :charging -> true
             :start -> false
             {:offline, _} -> false
             {:asleep, _} -> false

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -634,8 +634,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
         vehicle = merge(data.last_response, stream_data, time: true)
 
         {:next_state, {:driving, :available, drive},
-         %Data{data | last_response: vehicle, elevation: elevation},
-         [broadcast_summary(), schedule_fetch(0, data)]}
+         %Data{
+           data
+           | last_response: vehicle,
+             elevation: elevation,
+             current_drive: drive,
+             driving_status: :available
+         }, [broadcast_summary(), schedule_fetch(0, data)]}
 
       %Stream.Data{shift_state: nil, power: power} when is_number(power) and power < 0 ->
         vehicle = merge(data.last_response, stream_data, time: true)
@@ -711,8 +716,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
         vehicle = merge(data.last_response, stream_data, time: true)
 
         {:next_state, {:driving, :available, drive},
-         %Data{data | last_response: vehicle, elevation: elevation},
-         [broadcast_summary(), schedule_fetch(0, data)]}
+         %Data{
+           data
+           | last_response: vehicle,
+             elevation: elevation,
+             current_drive: drive,
+             driving_status: :available
+         }, [broadcast_summary(), schedule_fetch(0, data)]}
 
       %Stream.Data{shift_state: s, power: power}
       when s in [nil, "P"] and is_number(power) and power < 0 ->
@@ -1040,7 +1050,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
            data
            | last_state_change: DateTime.utc_now(),
              last_used: DateTime.utc_now(),
-             stream_pid: nil
+             stream_pid: nil,
+             current_update: update
          }, [broadcast_summary(), schedule_fetch(15, data)]}
 
       %V{drive_state: %Drive{shift_state: shift_state}} when shift_state in ~w(D N R) ->
@@ -1049,7 +1060,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {drive, data} = start_drive(create_position(vehicle, data), data)
         interval = if streaming?(data), do: default_interval(), else: driving_interval()
 
-        {:next_state, {:driving, :available, drive}, data,
+        {:next_state, {:driving, :available, drive},
+         %{data | current_drive: drive, driving_status: :available},
          [
            broadcast_summary(),
            schedule_fetch(interval, data)
@@ -1085,7 +1097,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
            data
            | last_state_change: DateTime.utc_now(),
              last_used: DateTime.utc_now(),
-             stream_pid: nil
+             stream_pid: nil,
+             current_charging_process: cproc
          }, [broadcast_summary(), schedule_fetch(5, data), schedule_position_storing()]}
 
       _ ->
@@ -1130,7 +1143,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
           |> Map.get(:charger_power)
           |> determince_interval()
 
-        {:next_state, {:charging, cproc}, data,
+        {:next_state, {:charging, cproc}, %{data | current_charging_process: cproc},
          [broadcast_summary(), schedule_fetch(interval, data)]}
 
       %Vehicle{charge_state: %Charge{charging_state: state}} ->
@@ -1162,7 +1175,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
       ) do
     Logger.warning("Vehicle went offline while driving", car_id: data.car.id)
 
-    {:next_state, {:driving, {:unavailable, 0}, drive}, %{data | last_used: DateTime.utc_now()},
+    {:next_state, {:driving, {:unavailable, 0}, drive},
+     %{data | last_used: DateTime.utc_now(), driving_status: {:unavailable, 0}},
      schedule_fetch(5, data)}
   end
 
@@ -1173,7 +1187,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         %Data{} = data
       )
       when n < 15 do
-    {:next_state, {:driving, {:unavailable, n + 1}, drv}, %{data | last_used: DateTime.utc_now()},
+    {:next_state, {:driving, {:unavailable, n + 1}, drv},
+     %{data | last_used: DateTime.utc_now(), driving_status: {:unavailable, n + 1}},
      schedule_fetch(5, data)}
   end
 
@@ -1184,7 +1199,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         %Data{} = data
       ) do
     {:next_state, {:driving, {:offline, data.last_response}, drv},
-     %{data | last_used: DateTime.utc_now()}, [broadcast_summary(), schedule_fetch(30, data)]}
+     %{data | last_used: DateTime.utc_now(), driving_status: {:offline, data.last_response}},
+     [broadcast_summary(), schedule_fetch(30, data)]}
   end
 
   def handle_event(
@@ -1208,7 +1224,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
       min when min >= @drive_timeout_min ->
         timeout_drive(drive, data)
 
-        {:next_state, {:driving, {:offline, last}, nil}, %{data | last_used: DateTime.utc_now()},
+        {:next_state, {:driving, {:offline, last}, nil},
+         %{data | last_used: DateTime.utc_now(), current_drive: nil},
          [broadcast_summary(), schedule_fetch(30, data)]}
 
       _min ->
@@ -1267,7 +1284,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
       not is_nil(drv) ->
         data = maybe_reconnect_stream(data)
 
-        {:next_state, {:driving, :available, drv}, %{data | last_used: DateTime.utc_now()},
+        {:next_state, {:driving, :available, drv},
+         %{data | last_used: DateTime.utc_now(), driving_status: :available},
          {:next_event, :internal, {:update, {:online, now}}}}
     end
   end
@@ -1291,7 +1309,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
     data = maybe_reconnect_stream(data)
 
-    {:next_state, {:driving, :available, drv}, %{data | last_used: DateTime.utc_now()},
+    {:next_state, {:driving, :available, drv},
+     %{data | last_used: DateTime.utc_now(), driving_status: :available},
      {:next_event, :internal, {:update, e}}}
   end
 

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -41,8 +41,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
               current_drive: nil,
               current_charging_process: nil,
               current_update: nil,
-              # Sub-state for driving: :available | {:unavailable, n} | {:offline, last_vehicle}
-              driving_status: :available
+              # Sub-state for driving: nil | :available | {:unavailable, n} | {:offline, last_vehicle}
+              driving_status: nil
   end
 
   @asleep_interval 30
@@ -479,8 +479,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
               car_id: data.car.id
             )
 
-            {:next_state, :start,
-             %Data{data | last_used: DateTime.utc_now(), driving_status: nil, current_drive: nil},
+            {:next_state, :start, reset_activity(%Data{data | last_used: DateTime.utc_now()}),
              [
                broadcast_fetch(false),
                broadcast_summary(),
@@ -497,7 +496,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         :ok = fuse_name(:api_error, data.car.id) |> :fuse.circuit_disable()
 
         # Stop polling
-        {:next_state, :start, data, [broadcast_fetch(false), broadcast_summary()]}
+        {:next_state, :start, reset_activity(data), [broadcast_fetch(false), broadcast_summary()]}
 
       {:error, :vehicle_not_found} ->
         Logger.error("Error / :vehicle_not_found", car_id: data.car.id)
@@ -755,7 +754,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   def handle_event(:info, {_ref, {state, %Vehicle{}} = event}, {:suspended, _}, data)
       when state in [:asleep, :offline] do
-    {:next_state, :start, data, {:next_event, :internal, {:update, event}}}
+    {:next_state, :start, reset_activity(data), {:next_event, :internal, {:update, event}}}
   end
 
   def handle_event(:info, {_ref, {:online, %Vehicle{}}}, {:suspended, _}, _data) do
@@ -1017,7 +1016,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   def handle_event(:internal, {:update, {event, _vehicle}}, :online, data)
       when event in [:offline, :asleep] do
-    {:next_state, :start, data, schedule_fetch(data)}
+    {:next_state, :start, reset_activity(data), schedule_fetch(data)}
   end
 
   def handle_event(:internal, {:update, {:online, vehicle}}, state, %Data{} = data)
@@ -1110,7 +1109,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   def handle_event(:internal, {:update, {state, _}} = event, {:suspended, _}, data)
       when state in [:asleep, :offline] do
-    {:next_state, :start, data, {:next_event, :internal, event}}
+    {:next_state, :start, reset_activity(data), {:next_event, :internal, event}}
   end
 
   #### :charging
@@ -1132,8 +1131,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
     {:ok, _} = call(data.deps.log, :complete_charging_process, [cproc])
     Logger.info("Charging / Aborted", car_id: data.car.id)
 
-    {:next_state, :start, %{data | current_charging_process: nil},
-     {:next_event, :internal, event}}
+    {:next_state, :start, reset_activity(data), {:next_event, :internal, event}}
   end
 
   def handle_event(
@@ -1154,8 +1152,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
           |> Map.get(:charger_power)
           |> determince_interval()
 
-        {:next_state, :charging, %{data | current_charging_process: cproc},
-         [broadcast_summary(), schedule_fetch(interval, data)]}
+        {:next_state, :charging, data, [broadcast_summary(), schedule_fetch(interval, data)]}
 
       %Vehicle{charge_state: %Charge{charging_state: state}} ->
         Repo.transaction(fn ->
@@ -1170,7 +1167,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
           Logger.info("Charging / #{state} / #{added} kWh – #{duration} min", car_id: data.car.id)
         end)
 
-        {:next_state, :start, data, {:next_event, :internal, {:update, {:online, vehicle}}}}
+        {:next_state, :start, reset_activity(data),
+         {:next_event, :internal, {:update, {:online, vehicle}}}}
     end
   end
 
@@ -1220,7 +1218,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         :driving,
         %Data{driving_status: {:offline, _}, current_drive: nil} = data
       ) do
-    {:next_state, :start, %Data{data | last_used: DateTime.utc_now(), driving_status: nil},
+    {:next_state, :start, reset_activity(%Data{data | last_used: DateTime.utc_now()}),
      schedule_fetch(data)}
   end
 
@@ -1283,13 +1281,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         Logger.info("Vehicle was charged while being offline: #{added} kWh", car_id: data.car.id)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now(), driving_status: nil},
+        {:next_state, :start, reset_activity(%{data | last_used: DateTime.utc_now()}),
          {:next_event, :internal, {:update, {:online, now}}}}
 
       not has_gained_range? and offline_min >= @drive_timeout_min ->
         unless is_nil(drv), do: timeout_drive(drv, data)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now(), driving_status: nil},
+        {:next_state, :start, reset_activity(%{data | last_used: DateTime.utc_now()}),
          {:next_event, :internal, {:update, {:online, now}}}}
 
       not is_nil(drv) ->
@@ -1310,7 +1308,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         %Data{current_drive: drv} = data
       ) do
     unless is_nil(drv), do: timeout_drive(drv, data)
-    {:next_state, :start, %{data | driving_status: nil}, schedule_fetch(data)}
+    {:next_state, :start, reset_activity(data), schedule_fetch(data)}
   end
 
   #### msg: :online
@@ -1368,7 +1366,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         Logger.info("Driving / Ended / #{km && round(km)} km – #{min} min", car_id: data.car.id)
 
         {:next_state, :start,
-         %{data | last_used: DateTime.utc_now(), driving_status: nil, geofence: geofence},
+         reset_activity(%{data | last_used: DateTime.utc_now(), geofence: geofence}),
          {:next_event, :internal, {:update, {:online, vehicle}}}}
 
       %Vehicle{drive_state: nil} ->
@@ -1415,7 +1413,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
           car_id: data.car.id
         )
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now()},
+        {:next_state, :start, reset_activity(%{data | last_used: DateTime.utc_now()}),
          {:next_event, :internal, {:update, {:online, vehicle}}}}
 
       %VehicleState{timestamp: ts, car_version: vsn, software_update: %SW{} = software_update} ->
@@ -1436,7 +1434,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
         Logger.info("Update / Installed #{vsn}", car_id: data.car.id)
 
-        {:next_state, :start, %{data | last_used: DateTime.utc_now()},
+        {:next_state, :start, reset_activity(%{data | last_used: DateTime.utc_now()}),
          {:next_event, :internal, {:update, {:online, vehicle}}}}
     end
   end
@@ -1455,20 +1453,30 @@ defmodule TeslaMate.Vehicles.Vehicle do
   end
 
   def handle_event(:internal, {:update, {:offline, _}}, {:asleep, _interval}, data) do
-    {:next_state, :start, data, schedule_fetch(data)}
+    {:next_state, :start, reset_activity(data), schedule_fetch(data)}
   end
 
   def handle_event(:internal, {:update, {:asleep, _}}, {:offline, _interval}, data) do
-    {:next_state, :start, data, schedule_fetch(data)}
+    {:next_state, :start, reset_activity(data), schedule_fetch(data)}
   end
 
   def handle_event(:internal, {:update, {:online, _}} = event, {state, _interval}, %Data{} = data)
       when state in [:asleep, :offline] do
-    {:next_state, :start, %{data | last_used: DateTime.utc_now()},
+    {:next_state, :start, reset_activity(%{data | last_used: DateTime.utc_now()}),
      {:next_event, :internal, event}}
   end
 
   # Private
+
+  defp reset_activity(%Data{} = data) do
+    %Data{
+      data
+      | current_drive: nil,
+        current_charging_process: nil,
+        current_update: nil,
+        driving_status: nil
+    }
+  end
 
   defp restore_last_known_values(%Vehicle{} = vehicle, data) do
     with %{drive_state: nil, charge_state: nil, climate_state: nil} <- vehicle,

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -42,12 +42,13 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       healthy?: healthy?,
       car: car,
       elevation: elevation,
-      geofence: gf
+      geofence: gf,
+      driving_status: driving_status
     } = attrs
 
     %__MODULE__{
       format_vehicle(vehicle)
-      | state: format_state(state),
+      | state: format_state(state, driving_status),
         since: since,
         healthy: healthy?,
         elevation: elevation,
@@ -61,11 +62,9 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     }
   end
 
-  defp format_state({:driving, {:offline, _}, _id}), do: :offline
-  defp format_state({:driving, _state, _id}), do: :driving
-  defp format_state({state, _, _}) when is_atom(state), do: state
-  defp format_state({state, _}) when is_atom(state), do: state
-  defp format_state(state) when is_atom(state), do: state
+  defp format_state(:driving, {:offline, _}), do: :offline
+  defp format_state({state, _}, _driving_status) when is_atom(state), do: state
+  defp format_state(state, _driving_status) when is_atom(state), do: state
 
   defp get_car_attr(%Car{exterior_color: v}, :exterior_color), do: v
   defp get_car_attr(%Car{spoiler_type: v}, :spoiler_type), do: v

--- a/test/support/vehicle_case.ex
+++ b/test/support/vehicle_case.ex
@@ -85,6 +85,17 @@ defmodule TeslaMate.VehicleCase do
     :ok
   end
 
+  def activity_data(name) do
+    {_state, %Vehicle.Data{} = data} = :sys.get_state(name)
+
+    Map.take(data, [
+      :current_drive,
+      :current_charging_process,
+      :current_update,
+      :driving_status
+    ])
+  end
+
   def online_event(ts, opts \\ []) do
     assert is_integer(ts)
     now = ts

--- a/test/teslamate/vehicles/vehicle/charging_test.exs
+++ b/test/teslamate/vehicles/vehicle/charging_test.exs
@@ -96,6 +96,14 @@ defmodule TeslaMate.Vehicles.Vehicle.ChargingTest do
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online, since: ^s2}}}
 
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
+
+    assert %{
+             current_drive: nil,
+             current_charging_process: nil,
+             current_update: nil,
+             driving_status: nil
+           } = activity_data(name)
+
     refute_receive _
   end
 

--- a/test/teslamate/vehicles/vehicle/driving_test.exs
+++ b/test/teslamate/vehicles/vehicle/driving_test.exs
@@ -45,6 +45,13 @@ defmodule TeslaMate.Vehicles.Vehicle.DrivingTest do
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online, since: s2}}}
     assert DateTime.diff(s1, s2, :nanosecond) < 0
 
+    assert %{
+             current_drive: nil,
+             current_charging_process: nil,
+             current_update: nil,
+             driving_status: nil
+           } = activity_data(name)
+
     refute_receive _
   end
 

--- a/test/teslamate/vehicles/vehicle/summary_test.exs
+++ b/test/teslamate/vehicles/vehicle/summary_test.exs
@@ -8,12 +8,13 @@ defmodule TeslaMate.Vehicles.Vehicle.SummaryTest do
 
   defp attrs do
     %{
-      state: {:online, nil},
+      state: :online,
       since: DateTime.utc_now(),
       healthy?: true,
       car: nil,
       elevation: nil,
-      geofence: nil
+      geofence: nil,
+      driving_status: nil
     }
   end
 
@@ -60,6 +61,23 @@ defmodule TeslaMate.Vehicles.Vehicle.SummaryTest do
       vehicle = %Vehicle{vehicle_state: %VehicleState{software_update: nil}}
       summary = Summary.into(vehicle, attrs())
       assert summary.update_available == nil
+    end
+  end
+
+  describe "state" do
+    test "formats an active drive" do
+      attrs = %{attrs() | state: :driving, driving_status: :available}
+      assert %Summary{state: :driving} = Summary.into(%Vehicle{}, attrs)
+    end
+
+    test "formats an offline drive as offline" do
+      attrs = %{attrs() | state: :driving, driving_status: {:offline, %Vehicle{}}}
+      assert %Summary{state: :offline} = Summary.into(%Vehicle{}, attrs)
+    end
+
+    test "formats a suspended state" do
+      attrs = %{attrs() | state: {:suspended, :online}}
+      assert %Summary{state: :suspended} = Summary.into(%Vehicle{}, attrs)
     end
   end
 

--- a/test/teslamate/vehicles/vehicle/updating_test.exs
+++ b/test/teslamate/vehicles/vehicle/updating_test.exs
@@ -59,6 +59,13 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
 
     assert DateTime.diff(s1, s2, :nanosecond) < 0
 
+    assert %{
+             current_drive: nil,
+             current_charging_process: nil,
+             current_update: nil,
+             driving_status: nil
+           } = activity_data(name)
+
     refute_receive _
   end
 


### PR DESCRIPTION
## Summary

This refreshes #5259 onto current `main`. Brian's six original commits and authorship are preserved, followed by one focused commit that addresses the remaining review feedback.

The refactor keeps `:driving`, `:charging`, and `:updating` as simple state atoms, with their records and driving sub-state in `Vehicle.Data`. The follow-up makes the new invariant explicit:

- Every transition back to `:start` clears drive, charging, update, and driving-status data through one helper.
- `driving_status` consistently uses `nil` outside `:driving`.
- The redundant charging self-assignment is removed.
- Drive, charge, and update tests verify that all activity fields are cleared after completion.
- Summary tests cover active driving, offline driving, and suspended state formatting with the new state shape.

This intentionally stays separate from #5515. If that approved change lands first, this branch only needs a small rebase in `vehicle.ex`.

## Checks

- `mix ci`: 389 tests, 0 failures
- `mix compile --warnings-as-errors`
- Combined integration with the other current fixes: 405 tests, 0 failures