### PR TITLE
build: use Elixir 1.20.2 OTP 29

### DIFF
--- a/.github/actions/setup-elixir-and-cache-deps/action.yml
+++ b/.github/actions/setup-elixir-and-cache-deps/action.yml
@@ -4,11 +4,11 @@ inputs:
   elixir-version:
     description: "Elixir version"
     required: false
-    default: "1.19.5"
+    default: "1.20.2"
   otp-version:
     description: "OTP version"
     required: false
-    default: "28"
+    default: "29"
   cache-name-deps:
     description: "Cache name for dependencies"
     required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - build(deps): bump postcss from 8.5.15 to 8.5.25 in /website (#5582)
 - build(deps): bump the actions-deps group across 4 directories with 11 updates (#5576)
 - test(grafana): guard latest-position dashboard queries against missing partial-index predicate (#5581 - @magrathean-uk)
+- build: use Elixir 1.20.2 OTP 29
 
 #### Dashboards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@
 - build(deps): bump postcss from 8.5.15 to 8.5.25 in /website (#5582)
 - build(deps): bump the actions-deps group across 4 directories with 11 updates (#5576)
 - test(grafana): guard latest-position dashboard queries against missing partial-index predicate (#5581 - @magrathean-uk)
-- build: use Elixir 1.20.2 OTP 29
+- build: use Elixir 1.20.2 OTP 29 (#5579 - @swiffer)
 
 #### Dashboards
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.19.5-otp-28 AS builder
+FROM elixir:1.20.2-otp-29 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule TeslaMate.MixProject do
     [
       app: :teslamate,
       version: version(),
-      elixir: "~> 1.17",
+      elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,

--- a/nix/flake-modules/package.nix
+++ b/nix/flake-modules/package.nix
@@ -8,8 +8,8 @@
       ...
     }:
     let
-      beamPackages = pkgs.beam.packagesWith pkgs.beam.interpreters.erlang_28;
-      elixir = beamPackages.elixir_1_19;
+      beamPackages = pkgs.beam.packagesWith pkgs.beam.interpreters.erlang_29;
+      elixir = beamPackages.elixir_1_20;
       rebar3 = beamPackages.rebar3;
 
       src = ../..;

--- a/test/support/mocks/log.ex
+++ b/test/support/mocks/log.ex
@@ -99,7 +99,15 @@ defmodule LogMock do
 
   def handle_call({:start_charging_process, _, _, _} = action, _from, %State{pid: pid} = state) do
     send(pid, action)
-    {:reply, {:ok, %ChargingProcess{id: 99, start_date: DateTime.utc_now()}}, state}
+
+    {:reply,
+     {:ok,
+      %ChargingProcess{
+        id: 99,
+        start_date: DateTime.utc_now(),
+        address: nil,
+        geofence: nil
+      }}, state}
   end
 
   def handle_call(

--- a/website/docs/development.mdx
+++ b/website/docs/development.mdx
@@ -6,10 +6,10 @@ sidebar_label: Development and Contributing
 
 ## Requirements
 
-TeslaMate officially supports the versions listed below. In general, TeslaMate aims to stay compatible with the last three major Erlang and Postgres releases and the last three minor Elixir releases. At the moment, OTP 28+ is a hard requirement, so Elixir support is currently limited to versions that support OTP 28 (Elixir 1.18.4+ and 1.19.x).
+TeslaMate officially supports the versions listed below. In general, TeslaMate aims to stay compatible with the last three major Erlang and Postgres releases and the last three minor Elixir releases. At the moment, OTP 28+ is a hard requirement, so Elixir support is currently limited to versions that support OTP 28+ (Elixir v1.19 and v1.20).
 When contributing, please use the versions listed below, which match those used in official TeslaMate distributions.
 
-- **Elixir** >= 1.19.5-otp-28
+- **Elixir** >= 1.20.2-otp-29
 - **Postgres** >= 18.0
 - **Grafana** = 13.1.1
 - An **MQTT broker** e.g. mosquitto (_optional_)


### PR DESCRIPTION
## Summary

Full Elixir **1.20.2 / OTP 29** enablement for official runtime, CI, and Nix, superseding the Dependabot-only Dockerfile bump in #5564.

**Status:** Ready for review — rebased on latest `main`, CI green, local validation done.

### Version bump
- `Dockerfile`: builder image `elixir:1.20.2-otp-29`
- `.github/actions/setup-elixir-and-cache-deps`: defaults `1.20.2` / `29`
- `nix/flake-modules/package.nix`: `erlang_29` + `elixir_1_20`
- `mix.exs`: require `~> 1.19` (allows 1.19.x and 1.20.x; official pin is 1.20.2)
- `website/docs/development.mdx`: contributor pin and supported range
- `CHANGELOG.md`: unreleased build note

### Required test fix (`LogMock`)
While running tests on Elixir 1.20, charging-related tests failed with:

```text
** (Protocol.UndefinedError) protocol String.Chars not implemented for
   Ecto.Association.NotLoaded
   #Ecto.Association.NotLoaded<association :geofence is not loaded>
   lib/teslamate/vehicles/vehicle.ex (Enum.join of geofence name in charging log)
```

**Finding:** production `Log.start_charging_process/3` preloads `:address` and `:geofence` (so they are `nil` or a struct). `LogMock` returned a bare `%ChargingProcess{}`, leaving associations as `NotLoaded`.

Vehicle logging does roughly:

```elixir
with(%GeoFence{name: name} <- cproc.geofence, do: name)
# mismatch on NotLoaded returns the NotLoaded value (not nil)
|> Enum.join(...)  # String.Chars → crash
```

**Fix:** set `address: nil` and `geofence: nil` on the mock charging process so it matches preloaded production data.

Related: #5564 (Dependabot Dockerfile-only bump to 1.20.x / OTP 29).

## Test plan
- [x] CI green on this PR (`elixir_test`, static analysis, image build)
- [x] Charging tests previously failing on 1.20.2-otp-29 pass after the LogMock fix (local)
- [x] End-to-end validation on my deployment/setup
- [ ] Confirm Nix package still evaluates with `elixir_1_20` / `erlang_29` on current flake pin

---

🤖 Assisted by Grok 4.5 (xAI) via Grok Build (Elixir 1.20 bump, LogMock fix, PR description).