### PR TITLE
feat: use Grafana 13.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - fix(performance): use existing indexes for last-inserted / latest complete position lookups (#5438 - @swiffer)
 - fix(geocoder): resolve state for Australian territories (#3868 - mattew124)
 - refactor(vehicles): make the geofence name lookup in the charging log total (#5599 - @JakobLichterfeld)
+- feat: use Grafana 13.1.3 (#5587 - @swiffer)
 
 #### Build, CI, internal
 

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,6 +1,6 @@
 # Ensure selecting a tag that is available for arm64 and amd64
 # https://hub.docker.com/r/grafana/grafana/tags
-FROM grafana/grafana:13.1.1
+FROM grafana/grafana:13.1.3
 
 ENV GF_ANALYTICS_REPORTING_ENABLED=false \
     GF_ANALYTICS_CHECK_FOR_UPDATES=false \

--- a/website/docs/development.mdx
+++ b/website/docs/development.mdx
@@ -11,7 +11,7 @@ When contributing, please use the versions listed below, which match those used 
 
 - **Elixir** >= 1.20.2-otp-29
 - **Postgres** >= 18.0
-- **Grafana** = 13.1.1
+- **Grafana** = 13.1.3
 - An **MQTT broker** e.g. mosquitto (_optional_)
 - **NodeJS** >= 22.22.0
 

--- a/website/docs/installation/unsupported/debian.md
+++ b/website/docs/installation/unsupported/debian.md
@@ -55,12 +55,12 @@ sudo apt install erlang erlang-dev erlang-syntax-tools elixir
 </details>
 
 <details>
-  <summary>Grafana (v13.1.1+)</summary>
+  <summary>Grafana (v13.1.3+)</summary>
 
 ```bash
 sudo apt-get install -y apt-transport-https software-properties-common
-sudo add-apt-repository "deb https://packages.grafana.com/oss/deb stable main"
-wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
+sudo add-apt-repository "deb https://apt.grafana.com stable main"
+wget -q -O - https://apt.grafana.com/gpg-full.key | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install -y grafana
 sudo systemctl start grafana-server


### PR DESCRIPTION
## Summary
- Bump Grafana Docker image from 13.1.1 to 13.1.3
- Update version pins in development and unsupported Debian install docs
- Point the Debian install snippet at the current Grafana APT repository (`https://apt.grafana.com`)

Dashboard JSON left unchanged (patch-only bump). FreeBSD docs left on 13.1.1 because that package is not available there yet.

Debian APT repository docs: https://grafana.com/docs/grafana/latest/setup-grafana/installation/debian/#install-from-apt-repository

## Test plan
- [x] Confirm `grafana/grafana:13.1.3` pulls successfully for amd64/arm64
- [x] Spot-check that provisioned dashboards load under Grafana 13.1.3