### PR TITLE
fix(charging): fall back to charger_power when phase detection fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - fix(geocoder): resolve state for Australian territories (#3868 - mattew124)
 - refactor(vehicles): make the geofence name lookup in the charging log total (#5599 - @JakobLichterfeld)
 - feat: use Grafana 13.1.3 (#5587 - @swiffer)
+- fix(charging): fall back to charger_power when phase detection fails (#5590 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - refactor(vehicles): make the geofence name lookup in the charging log total (#5599 - @JakobLichterfeld)
 - feat: use Grafana 13.1.3 (#5587 - @swiffer)
 - fix(charging): fall back to charger_power when phase detection fails (#5590 - @JakobLichterfeld)
+- fix(charges): enforce positive charger phases at the database (#5590 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+Existing charging processes are recomputed once during the upgrade migration: previously empty or zero `charge_energy_used` values (short or mixed AC sessions) gain values, the first start after the upgrade can take a few minutes longer on databases with years of history and slow HW, and charge costs are deliberately not changed retroactively.
+
 ### New features
 
 - feat: add service mode to webview and reduce log when car is Unlocked at service mode (#5289 - @NirKli)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@
 - fix(geocoder): resolve state for Australian territories (#3868 - mattew124)
 - refactor(vehicles): make the geofence name lookup in the charging log total (#5599 - @JakobLichterfeld)
 - feat: use Grafana 13.1.3 (#5587 - @swiffer)
-- fix(charging): fall back to charger_power when phase detection fails (#5590 - @JakobLichterfeld)
-- fix(charges): enforce positive charger phases at the database (#5590 - @JakobLichterfeld)
+- fix(charging): fall back to charger_power when phase detection fails (#5592 - @JakobLichterfeld)
+- fix(charges): enforce positive charger phases at the database (#5592 - @JakobLichterfeld)
 
 #### Build, CI, internal
 
@@ -110,6 +110,7 @@
 - fix(dashboards): filter latest-value position panels on complete rows so they use the partial index (#5438 - @swiffer)
 - fix(grafana): Battery Health latest SOC/kWh panels pick the newest UNION row and use `usable_battery_level` on charges (#5438 - @swiffer)
 - fix(grafana): use local calendar for Statistics period end boundaries (#5562 - @wjsall)
+- fix(charge-details): keep power panel in sync with the energy integration (#5592 - @JakobLichterfeld)
 
 #### Translations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - feat: use Grafana 13.1.3 (#5587 - @swiffer)
 - fix(charging): fall back to charger_power when phase detection fails (#5592 - @JakobLichterfeld)
 - fix(charges): enforce positive charger phases at the database (#5592 - @JakobLichterfeld)
+- fix(charging): recalculate charge_energy_used for existing processes (#5592 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/grafana/dashboards/internal/charge-details.json
+++ b/grafana/dashboards/internal/charge-details.json
@@ -1239,7 +1239,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT $__timeGroupAlias(date,$__interval),\r\navg(\r\n    case when charger_phases >= 1 then\r\n    cast(nullif(${determine_phases:sqlstring}, '') as numeric) * charger_actual_current * charger_voltage / 1000.0 else charger_power end) as \"Power\" \r\nFROM charges WHERE charging_process_id = $charging_process_id\r\nGROUP BY 1 ORDER BY 1",
+          "rawSql": "SELECT $__timeGroupAlias(date,$__interval),\r\navg(\r\n    case when charger_phases >= 1 then\r\n    coalesce(cast(nullif(${determine_phases:sqlstring}, '') as numeric) * charger_actual_current * charger_voltage / 1000.0, charger_power) else charger_power end) as \"Power\" \r\nFROM charges WHERE charging_process_id = $charging_process_id\r\nGROUP BY 1 ORDER BY 1",
           "refId": "Current",
           "sql": {
             "columns": [
@@ -1891,12 +1891,12 @@
           "text": "2",
           "value": "2"
         },
-        "definition": "with data as (\n\n    select\n        avg(c.charger_power * 1000.0 / nullif(c.charger_actual_current * c.charger_voltage, 0)) p,\n        avg(c.charger_phases) r,\n        avg(c.charger_voltage) v,\n        count(*) as n\n    from charges c\n    where c.charging_process_id = ${charging_process_id}\n\n)\n\nselect\n    case\n        when p is not null and p > 0 and n > 15 then case\n            when r = round(p) then r\n            when r = 3 and abs(p / sqrt(r) - 1) <= 0.1 then sqrt(r)\n            when abs(round(p) - p) <= 0.3 then round(p)\n            else null\n        end\n        else null\n    end as phases\nfrom data",
+        "definition": "with data as (\n\n    select\n        avg(c.charger_power * 1000.0 / nullif(c.charger_actual_current * c.charger_voltage, 0)) p,\n        avg(c.charger_phases) r,\n        avg(c.charger_voltage) v,\n        count(*) as n\n    from charges c\n    where c.charging_process_id = ${charging_process_id}\n\n)\n\nselect\n    case\n        when p is not null and p > 0 and n > 15 then case\n            when r = round(p) then r\n            when r = 3 and abs(p / sqrt(r) - 1) <= 0.1 then sqrt(r)\n            when round(p) > 0 and abs(round(p) - p) <= 0.3 then round(p)\n            else null\n        end\n        else null\n    end as phases\nfrom data",
         "description": "",
         "hide": 2,
         "name": "determine_phases",
         "options": [],
-        "query": "with data as (\n\n    select\n        avg(c.charger_power * 1000.0 / nullif(c.charger_actual_current * c.charger_voltage, 0)) p,\n        avg(c.charger_phases) r,\n        avg(c.charger_voltage) v,\n        count(*) as n\n    from charges c\n    where c.charging_process_id = ${charging_process_id}\n\n)\n\nselect\n    case\n        when p is not null and p > 0 and n > 15 then case\n            when r = round(p) then r\n            when r = 3 and abs(p / sqrt(r) - 1) <= 0.1 then sqrt(r)\n            when abs(round(p) - p) <= 0.3 then round(p)\n            else null\n        end\n        else null\n    end as phases\nfrom data",
+        "query": "with data as (\n\n    select\n        avg(c.charger_power * 1000.0 / nullif(c.charger_actual_current * c.charger_voltage, 0)) p,\n        avg(c.charger_phases) r,\n        avg(c.charger_voltage) v,\n        count(*) as n\n    from charges c\n    where c.charging_process_id = ${charging_process_id}\n\n)\n\nselect\n    case\n        when p is not null and p > 0 and n > 15 then case\n            when r = round(p) then r\n            when r = 3 and abs(p / sqrt(r) - 1) <= 0.1 then sqrt(r)\n            when round(p) > 0 and abs(round(p) - p) <= 0.3 then round(p)\n            else null\n        end\n        else null\n    end as phases\nfrom data",
         "refresh": 1,
         "regex": "",
         "regexApplyTo": "value",

--- a/lib/teslamate/log.ex
+++ b/lib/teslamate/log.ex
@@ -526,7 +526,10 @@ defmodule TeslaMate.Log do
             c_if is_nil(c.charger_phases) do
               c.charger_power
             else
-              c.charger_actual_current * c.charger_voltage * type(^phases, :float) / 1000.0
+              coalesce(
+                c.charger_actual_current * c.charger_voltage * type(^phases, :float) / 1000.0,
+                c.charger_power
+              )
             end *
               fragment(
                 "EXTRACT(epoch FROM (?))",
@@ -568,7 +571,7 @@ defmodule TeslaMate.Log do
 
             :math.sqrt(r)
 
-          abs(round(p) - p) <= 0.3 ->
+          round(p) > 0 and abs(round(p) - p) <= 0.3 ->
             Logger.info("Phase correction: #{r} -> #{round(p)}", car_id: car_id)
             round(p)
 

--- a/lib/teslamate/log/charge.ex
+++ b/lib/teslamate/log/charge.ex
@@ -13,7 +13,7 @@ defmodule TeslaMate.Log.Charge do
     field :usable_battery_level, :integer
     field :charge_energy_added, :decimal, read_after_writes: true
     field :charger_actual_current, :integer
-    field :charger_phases, :integer, default: 1
+    field :charger_phases, :integer
     field :charger_pilot_current, :integer
     field :charger_power, :integer
     field :charger_voltage, :integer

--- a/priv/repo/migrations/20260807090000_enforce_positive_charger_phases.exs
+++ b/priv/repo/migrations/20260807090000_enforce_positive_charger_phases.exs
@@ -1,0 +1,20 @@
+defmodule TeslaMate.Repo.Migrations.EnforcePositiveChargerPhases do
+  use Ecto.Migration
+
+  def up do
+    # A phase count of 0 (or less) was never meaningful; NULL routes those rows
+    # through the charger_power branch of the energy integration.
+    execute("""
+    UPDATE charges
+    SET charger_phases = NULL
+    WHERE charger_phases <= 0
+    """)
+
+    create(constraint(:charges, :positive_charger_phases, check: "charger_phases > 0"))
+  end
+
+  def down do
+    # The 0 -> NULL correction is not reversible.
+    drop(constraint(:charges, :positive_charger_phases))
+  end
+end

--- a/priv/repo/migrations/20260808090000_recalc_charge_energy_used.exs
+++ b/priv/repo/migrations/20260808090000_recalc_charge_energy_used.exs
@@ -1,0 +1,56 @@
+defmodule TeslaMate.Repo.Migrations.RecalcChargeEnergyUsed do
+  use Ecto.Migration
+
+  # charge_energy_used is a stored aggregate; processes completed before the
+  # phase-detection fallback no longer match what the current formula
+  # computes. Recompute the stored values so every installation converges on
+  # the current formula via the upgrade path. Only rows whose value actually
+  # changes are written, an existing value is never overwritten with NULL,
+  # and cost is left untouched since it may have been edited manually.
+  def up do
+    execute("""
+    WITH detection AS (
+      SELECT c.charging_process_id AS cp_id,
+             avg(c.charger_power * 1000.0 / nullif(c.charger_actual_current * c.charger_voltage, 0)) AS p,
+             avg(c.charger_phases)::int AS r,
+             count(*) AS n
+      FROM charges c
+      GROUP BY 1
+    ), phases AS (
+      SELECT cp_id,
+             CASE WHEN p IS NOT NULL AND p > 0 AND n > 15 THEN
+               CASE WHEN r = round(p) THEN r::float
+                    WHEN r = 3 AND abs(p / sqrt(3.0) - 1) <= 0.1 THEN sqrt(3.0)
+                    WHEN round(p) > 0 AND abs(round(p) - p) <= 0.3 THEN round(p)::float
+               END
+             END AS ph
+      FROM detection
+    ), integrated AS (
+      SELECT c.charging_process_id AS cp_id,
+             CASE WHEN c.charger_phases IS NULL THEN c.charger_power::float
+                  ELSE coalesce(c.charger_actual_current * c.charger_voltage * ph.ph / 1000.0, c.charger_power)
+             END *
+             EXTRACT(epoch FROM (c.date - lag(c.date) OVER (PARTITION BY c.charging_process_id ORDER BY c.date))) / 3600 AS energy
+      FROM charges c
+      JOIN phases ph ON ph.cp_id = c.charging_process_id
+    ), recomputed AS (
+      SELECT cp_id,
+             round(sum(energy) FILTER (WHERE energy >= 0)::numeric, 2) AS used
+      FROM integrated
+      GROUP BY 1
+    )
+    UPDATE charging_processes cp
+    SET charge_energy_used = r.used
+    FROM recomputed r
+    WHERE cp.id = r.cp_id
+      AND r.used IS NOT NULL
+      AND cp.charge_energy_used IS DISTINCT FROM r.used
+    """)
+  end
+
+  def down do
+    # The pre-migration values are not preserved; recomputing with the
+    # previous formula would reintroduce the dropped rows.
+    :ok
+  end
+end

--- a/test/teslamate/grafana/dashboard_queries_test.exs
+++ b/test/teslamate/grafana/dashboard_queries_test.exs
@@ -9,14 +9,18 @@ defmodule TeslaMate.Grafana.DashboardQueriesTest do
   # cannot hide an unindexed lookup.
   @latest_position_block ~r/from positions\b(?:(?!\bfrom\b).)*?order by date desc(?:(?!\bfrom\b).)*?limit 1\b/
 
-  test "latest position queries use complete position rows" do
-    dashboards = Path.wildcard(Path.join(@dashboard_directory, "**/*.json"))
+  # The energy integration falls back to charger_power when phase detection
+  # fails (#5558). Power expressions built on the determine_phases variable
+  # replicate that integration and must carry the same fallback.
+  @phases_power_without_fallback ~r/(?<!coalesce\()cast\(nullif\(\$\{determine_phases:sqlstring\}, ''\) as numeric\) \* charger_actual_current/
 
-    assert dashboards != []
+  test "latest position queries use complete position rows" do
+    queries = dashboard_directory_queries()
+
+    assert queries != []
 
     offenders =
-      dashboards
-      |> Enum.flat_map(&dashboard_queries/1)
+      queries
       |> Enum.flat_map(fn {path, query} ->
         query
         |> unfiltered_latest_position_blocks()
@@ -61,6 +65,56 @@ defmodule TeslaMate.Grafana.DashboardQueriesTest do
     assert unfiltered_latest_position_blocks(query) == []
   end
 
+  test "phases-based power expressions fall back to charger_power" do
+    offenders =
+      dashboard_directory_queries()
+      |> Enum.filter(fn {_path, query} -> normalize(query) =~ @phases_power_without_fallback end)
+      |> Enum.map(fn {path, _query} -> path end)
+
+    assert offenders == []
+  end
+
+  test "detector flags a phases power expression without the fallback" do
+    unfixed =
+      "avg(case when charger_phases >= 1 then " <>
+        "cast(nullif(${determine_phases:sqlstring}, '') as numeric) * charger_actual_current" <>
+        " * charger_voltage / 1000.0 else charger_power end)"
+
+    assert normalize(unfixed) =~ @phases_power_without_fallback
+
+    fixed =
+      "avg(case when charger_phases >= 1 then " <>
+        "coalesce(cast(nullif(${determine_phases:sqlstring}, '') as numeric) * charger_actual_current" <>
+        " * charger_voltage / 1000.0, charger_power) else charger_power end)"
+
+    refute normalize(fixed) =~ @phases_power_without_fallback
+  end
+
+  test "phase detection queries never yield a phase count of zero" do
+    tolerance_queries =
+      dashboard_directory_queries()
+      |> Enum.map(fn {path, query} -> {path, normalize(query)} end)
+      |> Enum.filter(fn {_path, query} -> String.contains?(query, "abs(round(p) - p) <= 0.3") end)
+
+    assert tolerance_queries != []
+
+    offenders =
+      tolerance_queries
+      |> Enum.reject(fn {_path, query} ->
+        String.contains?(query, "round(p) > 0 and abs(round(p) - p) <= 0.3")
+      end)
+      |> Enum.map(fn {path, _query} -> path end)
+
+    assert offenders == []
+  end
+
+  defp dashboard_directory_queries do
+    @dashboard_directory
+    |> Path.join("**/*.json")
+    |> Path.wildcard()
+    |> Enum.flat_map(&dashboard_queries/1)
+  end
+
   defp dashboard_queries(path) do
     path
     |> File.read!()
@@ -87,11 +141,16 @@ defmodule TeslaMate.Grafana.DashboardQueriesTest do
   defp collect_queries(values) when is_list(values), do: Enum.flat_map(values, &collect_queries/1)
   defp collect_queries(_value), do: []
 
+  defp normalize(query) do
+    query
+    |> String.downcase()
+    |> String.replace(~r/\s+/, " ")
+  end
+
   defp unfiltered_latest_position_blocks(query) do
     normalized =
       query
-      |> String.downcase()
-      |> String.replace(~r/\s+/, " ")
+      |> normalize()
       |> String.replace(~r/\bextract\s*\(\s*epoch\s+from\b/, "extract(epoch_from")
 
     @latest_position_block

--- a/test/teslamate/log/log_charging_test.exs
+++ b/test/teslamate/log/log_charging_test.exs
@@ -143,6 +143,17 @@ defmodule TeslaMate.LogChargingTest do
       assert charge.ideal_battery_range_km == Decimal.new("250.00")
     end
 
+    test "does not invent a phase count when charger_phases is missing" do
+      car = car_fixture()
+
+      assert {:ok, cproc} = Log.start_charging_process(car, @valid_pos_attrs)
+
+      assert {:ok, %Charge{} = charge} =
+               Log.insert_charge(cproc, Map.delete(@valid_attrs, :charger_phases))
+
+      assert charge.charger_phases == nil
+    end
+
     test "with invalid data returns error changeset" do
       car = car_fixture()
 

--- a/test/teslamate/log/log_charging_test.exs
+++ b/test/teslamate/log/log_charging_test.exs
@@ -894,6 +894,62 @@ defmodule TeslaMate.LogChargingTest do
       assert cproc.duration_min == 21
     end
 
+    test "calculates the energy used for short charging sessions" do
+      # with n <= 15 charges determine_phases returns nil; rows carrying
+      # charger_phases must fall back to charger_power instead of being dropped
+      charges =
+        for i <- 0..11 do
+          date = DateTime.add(~U[2023-05-01 10:00:00Z], i * 60) |> DateTime.to_iso8601()
+          {date, i / 10, 7, 250.0, 2, 16, 229, nil}
+        end
+
+      assert {:ok, cproc} = log_charging_process(charges)
+      assert cproc.charge_energy_used == Decimal.new("1.28")
+    end
+
+    test "calculates the energy used when rows are mixed and phase detection fails" do
+      # rows alternate between charger_phases present and absent; every row must
+      # contribute to the integral even though determine_phases returns nil
+      charges =
+        for i <- 0..11 do
+          date = DateTime.add(~U[2023-05-01 10:00:00Z], i * 60) |> DateTime.to_iso8601()
+          phases = if rem(i, 2) == 0, do: nil, else: 2
+          {date, i / 10, 7, 250.0, phases, 16, 229, nil}
+        end
+
+      assert {:ok, cproc} = log_charging_process(charges)
+      assert cproc.charge_energy_used == Decimal.new("1.28")
+    end
+
+    test "does not use a phase count of zero" do
+      # charger_power (1 kW) is tiny compared to charger_actual_current *
+      # charger_voltage, so the average power ratio rounds to zero phases;
+      # integrating with 0 would report 0.00 kWh instead of the power-based value
+      charges =
+        for i <- 0..19 do
+          date = DateTime.add(~U[2023-05-01 10:00:00Z], i * 60) |> DateTime.to_iso8601()
+          {date, i / 10, 1, 250.0, 3, 16, 229, nil}
+        end
+
+      assert {:ok, cproc} = log_charging_process(charges)
+      assert cproc.charge_energy_used == Decimal.new("0.32")
+    end
+
+    test "does not null the energy used when a single outlier prevents phase detection" do
+      # one terminal row with collapsed current pushes the unweighted mean of the
+      # power ratio between phase counts; the process must fall back to
+      # charger_power instead of returning NULL
+      charges =
+        for i <- 0..19 do
+          date = DateTime.add(~U[2023-05-01 10:00:00Z], i * 60) |> DateTime.to_iso8601()
+          current = if i == 19, do: 1, else: 32
+          {date, i / 10, 7, 250.0, 1, current, 229, nil}
+        end
+
+      assert {:ok, cproc} = log_charging_process(charges)
+      assert cproc.charge_energy_used == Decimal.new("2.22")
+    end
+
     defp charges_fixture(fixture, fast_charger_type \\ "<invalid>")
 
     defp charges_fixture(:phases_nil, fast_charger_type) do


### PR DESCRIPTION
Fall back to `charger_power` when phase detection fails, and never accept a phase count of 0. Full analysis and measurements in the linked issue.

Fixes #5586
Fixes #4206

🤖drafted with [Claude Code](https://claude.com/claude-code) (Fable 5 max) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)