### PR TITLE
build(nix): reduce the manually pinned hashes to one and automate it

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -1,7 +1,6 @@
 name: Publish Docker images
 
 on:
-  workflow_dispatch:
   workflow_call:
   schedule:
     - cron: "0 3 * * *"
@@ -13,6 +12,12 @@ on:
       - "!.github/**" # Important: Exclude PRs related to .github from auto-run
       - "!.github/workflows/**" # Important: Exclude PRs related to .github/workflows from auto-run
       - "!.github/actions/**" # Important: Exclude PRs related to .github/actions from auto-run
+  # Pull requests touching .github are excluded from the automatic runs above,
+  # since the workflow definition that would run is the one from the pull
+  # request. This is the deliberate way to build them anyway, by someone with
+  # write access. The job conditions below allow for it. Note that this
+  # publishes: a run from a branch overwrites the edge tag.
+  workflow_dispatch:
 env:
   REGISTRY_IMAGE: teslamate/teslamate
 
@@ -29,7 +34,7 @@ jobs:
 
   teslamate_build:
     needs: check_paths
-    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'schedule'
+    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -62,7 +67,7 @@ jobs:
     needs:
       - check_paths
       - teslamate_build
-    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'schedule'
+    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -83,7 +88,7 @@ jobs:
             type=edge
   grafana:
     needs: check_paths
-    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'schedule'
+    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -1,7 +1,6 @@
 name: DevOps
 
 on:
-  workflow_dispatch:
   push:
     branches: ["main"]
     paths:
@@ -16,6 +15,11 @@ on:
       - "!.github/**" # Important: Exclude PRs related to .github from auto-run
       - "!.github/workflows/**" # Important: Exclude PRs related to .github/workflows from auto-run
       - "!.github/actions/**" # Important: Exclude PRs related to .github/actions from auto-run
+  # Pull requests touching .github are excluded from the automatic runs above,
+  # since the workflow definition that would run is the one from the pull
+  # request. This is the deliberate way to run the chain for them anyway, by
+  # someone with write access. The job conditions below allow for it.
+  workflow_dispatch:
 
 # Cancel any in-progress runs when a new commit is pushed
 concurrency:
@@ -32,26 +36,26 @@ jobs:
 
   spell_check:
     needs: check_paths
-    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'schedule'
+    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/spell_check.yml
 
   ensure_linting:
     needs:
       - check_paths
       - spell_check
-    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'schedule'
+    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/ensure_linting.yml
 
   elixir_dep_verification_and_static_analysis:
     needs:
       - check_paths
       - ensure_linting
-    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'schedule'
+    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/elixir_dep_verification_and_static_analysis.yml
 
   elixir_test:
     needs:
       - check_paths
       - ensure_linting
-    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'schedule'
+    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/elixir_test.yml

--- a/.github/workflows/ensure_linting.yml
+++ b/.github/workflows/ensure_linting.yml
@@ -19,7 +19,7 @@ jobs:
         uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
         with:
           # restore and save a cache using this key
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock', 'mix.lock') }}
           # if there's no cache hit, restore a cache by this prefix
           restore-prefixes-first-match: nix-${{ runner.os }}-
           # collect garbage until Nix store size (in bytes) is at most this number

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -19,6 +19,11 @@ on:
       - "!.github/actions/**" # Important: Exclude PRs related to .github/actions from auto-run
   merge_group:
     branches: ["main"]
+  # Pull requests touching .github are excluded from the automatic runs above,
+  # since the workflow definition that would run is the one from the pull
+  # request. This is the deliberate way to scan them anyway, by someone with
+  # write access. The job conditions below allow for it.
+  workflow_dispatch:
 
 permissions:
   actions: read
@@ -31,12 +36,12 @@ jobs:
 
   scan-scheduled:
     needs: check_paths
-    if: ( github.event_name == 'push' && needs.check_paths.outputs.githubfolder == 'false' ) || github.event_name == 'schedule'
+    if: ( github.event_name == 'push' && needs.check_paths.outputs.githubfolder == 'false' ) || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9fd1bcce27f67e3bd819a0a7620e332803dc43bc" # v2.3.8
     with:
-      # Don't fail on push to main / scheduled runs: vulnerabilities are still
-      # reported via the SARIF upload, but the CI run stays green so it doesn't
-      # look like a build failure on main.
+      # Don't fail on push to main, scheduled or manual runs: vulnerabilities
+      # are still reported via the SARIF upload, but the CI run stays green so
+      # it doesn't look like a build failure on main.
       fail-on-vuln: false
       scan-args: |-
         -r

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -24,7 +24,7 @@ jobs:
         uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
         with:
           # restore and save a cache using this key
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock', 'mix.lock') }}
           # if there's no cache hit, restore a cache by this prefix
           restore-prefixes-first-match: nix-${{ runner.os }}-
           # collect garbage until Nix store size (in bytes) is at most this number

--- a/.github/workflows/update-nix-hashes.yml
+++ b/.github/workflows/update-nix-hashes.yml
@@ -21,25 +21,15 @@ env:
   PATCH_NAME: nix-hashes.patch
 
 jobs:
-  # Refreshing the hashes means building the dependencies the pull request
-  # updates, which means running their code. That is why this is split in two:
-  # this job has no credentials and hands its result on as a patch, and the job
-  # below never runs repository code but is the only one that can push. Keeping
-  # both in one job would put the pushing step in a workspace that the build
-  # just had write access to, where a git hook or a core.fsmonitor entry planted
-  # during the build would run while the token is in the environment.
+  # Runs for every pull request that touches the dependencies, so a stale hash
+  # becomes visible wherever it appears, not just where it is repaired
+  # automatically. Refreshing the hashes means building those dependencies and
+  # therefore running their code, which is why this job receives no secrets or
+  # repository write credentials:
+  # it only reports what would have to change and publishes it as a patch.
+  # Pushing that change back is left to the commit job below.
   compute:
     name: Compute updated hashes
-    # Dependabot's own pull requests, from branches in this repository only.
-    # The actor check additionally keeps the updater from running on the commit
-    # it pushes itself: that push uses a token of its own, so the resulting
-    # synchronize event no longer has Dependabot as its actor. The regular CI
-    # workflows are not actor-gated and do verify that commit.
-    if: >-
-      github.actor == 'dependabot[bot]' &&
-      github.event.pull_request.user.login == 'dependabot[bot]' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-
     runs-on: ubuntu-24.04
     timeout-minutes: 45
 
@@ -50,7 +40,7 @@ jobs:
       changed: ${{ steps.diff.outputs.changed }}
 
     steps:
-      - name: Checkout the Dependabot commit
+      - name: Checkout the pull request commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -99,6 +89,8 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Uploaded for every pull request, not only the ones repaired below: on a
+      # human pull request it is what the author has to apply.
       - name: Upload the patch
         if: steps.diff.outputs.changed == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -108,10 +100,50 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # Deliberately separate from the commit job: this one fails whenever the
+  # hashes are stale, on every pull request including Dependabot's, so the
+  # state is never reported as good while it is not. The commit job depends on
+  # `compute` alone, so it still runs and repairs them, and its push produces a
+  # new run in which there is nothing left to change and this job is green.
+  verify:
+    name: Verify the pinned hashes
+    needs: compute
+
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Report stale hashes
+        shell: bash
+        env:
+          CHANGED: ${{ needs.compute.outputs.changed }}
+        run: |
+          set -euo pipefail
+
+          if [ "$CHANGED" = "true" ]; then
+            echo "::error::the pinned Nix hashes are out of date. Run 'nix run .#update-nix-hashes' and commit the result, or download the nix-hashes-patch artifact of this run." >&2
+            exit 1
+          fi
+
+          echo "the pinned Nix hashes are up to date"
+
   commit:
     name: Commit updated hashes
     needs: compute
-    if: needs.compute.outputs.changed == 'true'
+    # Repairing automatically means pushing into the pull request's branch, so
+    # it stays limited to Dependabot's own pull requests from branches in this
+    # repository, where nobody else can steer that branch. The actor check also
+    # keeps the updater from running on the commit it pushes itself: that push
+    # uses a token of its own, so the resulting synchronize event no longer has
+    # Dependabot as its actor.
+    if: >-
+      needs.compute.outputs.changed == 'true' &&
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/update-nix-hashes.yml
+++ b/.github/workflows/update-nix-hashes.yml
@@ -9,18 +9,27 @@ on:
     paths:
       - mix.exs
       - mix.lock
+      - "!.github/**" # Important: Exclude PRs related to .github from auto-run
+      - "!.github/workflows/**" # Important: Exclude PRs related to .github/workflows from auto-run
+      - "!.github/actions/**" # Important: Exclude PRs related to .github/actions from auto-run
+  # For pull requests that the gate holds back, so the hashes can still be
+  # verified deliberately, by someone who can trigger a workflow run.
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: update-nix-hashes-${{ github.event.pull_request.number }}
+  group: update-nix-hashes-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
   PATCH_NAME: nix-hashes.patch
 
 jobs:
+  check_paths:
+    uses: ./.github/workflows/check_paths.yml
+
   # Runs for every pull request that touches the dependencies, so a stale hash
   # becomes visible wherever it appears, not just where it is repaired
   # automatically. Refreshing the hashes means building those dependencies and
@@ -30,6 +39,10 @@ jobs:
   # Pushing that change back is left to the commit job below.
   compute:
     name: Compute updated hashes
+    needs: check_paths
+    # Pull requests that touch .github are not run automatically anywhere in
+    # this repository. Those are what the manual trigger is for.
+    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
 

--- a/.github/workflows/update-nix-hashes.yml
+++ b/.github/workflows/update-nix-hashes.yml
@@ -1,0 +1,233 @@
+name: Update Nix hashes
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - mix.exs
+      - mix.lock
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-nix-hashes-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  PATCH_NAME: nix-hashes.patch
+
+jobs:
+  # Refreshing the hashes means building the dependencies the pull request
+  # updates, which means running their code. That is why this is split in two:
+  # this job has no credentials and hands its result on as a patch, and the job
+  # below never runs repository code but is the only one that can push. Keeping
+  # both in one job would put the pushing step in a workspace that the build
+  # just had write access to, where a git hook or a core.fsmonitor entry planted
+  # during the build would run while the token is in the environment.
+  compute:
+    name: Compute updated hashes
+    # Dependabot's own pull requests, from branches in this repository only.
+    # The actor check additionally keeps the updater from running on the commit
+    # it pushes itself: that push uses a token of its own, so the resulting
+    # synchronize event no longer has Dependabot as its actor. The regular CI
+    # workflows are not actor-gated and do verify that commit.
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    permissions:
+      contents: read
+
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
+
+    steps:
+      - name: Checkout the Dependabot commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+
+      - name: Nix binary cache
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+        with:
+          # restore and save a cache using this key
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock', 'mix.lock') }}
+          # if there's no cache hit, restore a cache by this prefix
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          # collect garbage until Nix store size (in bytes) is at most this number
+          # before trying to save a new cache
+          # 1G = 1073741824, 2G = 2147483648
+          gc-max-store-size-linux: 2147483648
+          # do purge caches
+          purge: true
+          # purge all versions of the cache
+          purge-prefixes: nix-${{ runner.os }}-
+          # created more than this number of seconds ago
+          # relative to the start of the `Post Restore and save Nix store` phase
+          purge-created: 0
+          # except any version with the key that is the same as the `primary-key`
+          purge-primary-key: never
+
+      # The helper invalidates every pinned hash before building, so a stale
+      # fixed-output path restored from the cache cannot hide a change.
+      - name: Refresh and verify the Nix hashes
+        run: nix run .#update-nix-hashes
+
+      - name: Collect the hash changes
+        id: diff
+        shell: bash
+        run: |
+          git diff --output="$PATCH_NAME" -- nix
+
+          if [ -s "$PATCH_NAME" ]; then
+            cat "$PATCH_NAME"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no hash needed an update"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload the patch
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nix-hashes-patch
+          path: ${{ env.PATCH_NAME }}
+          if-no-files-found: error
+          retention-days: 1
+
+  commit:
+    name: Commit updated hashes
+    needs: compute
+    if: needs.compute.outputs.changed == 'true'
+
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    # The push uses its own token, so the workflow token stays read-only.
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout the Dependabot commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Download the patch
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nix-hashes-patch
+
+      # The patch comes out of a job that ran third-party build code, so it is
+      # untrusted input. Rather than parsing its syntax, it is applied to the
+      # index without a token and the staged result is validated: that is what
+      # a commit would contain, and unlike a patch it cannot be misread. A
+      # binary hunk, or ---/+++ paths disagreeing with the diff --git line,
+      # change nothing about the check below.
+      - name: Apply the patch to the index
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ ! -s "$PATCH_NAME" ]; then
+            echo "::error::the patch is empty" >&2
+            exit 1
+          fi
+
+          git apply --cached -- "$PATCH_NAME"
+
+      - name: Validate the staged result
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          staged=0
+
+          # Each record is ":<src mode> <dst mode> <src sha> <dst sha> <status>"
+          # followed by the path, both NUL terminated.
+          while IFS= read -r -d '' entry && IFS= read -r -d '' path; do
+            read -r src_mode dst_mode _ _ status <<<"${entry#:}"
+
+            if [ "$status" != "M" ]; then
+              echo "::error::$path is staged as '$status', but only modifications are allowed" >&2
+              exit 1
+            fi
+
+            if [ "$src_mode" != "100644" ] || [ "$dst_mode" != "100644" ]; then
+              echo "::error::$path changes its mode from $src_mode to $dst_mode" >&2
+              exit 1
+            fi
+
+            case "$path" in
+              nix/*.nix) ;;
+              *)
+                echo "::error::$path is not a .nix file below nix/" >&2
+                exit 1
+                ;;
+            esac
+
+            before="$(mktemp)"
+            after="$(mktemp)"
+
+            # Masking only well formed SRI literals folds the format check into
+            # the comparison: a malformed replacement is left in place and the
+            # two versions stop matching.
+            git show "HEAD:$path" | sed -E 's|sha256-[A-Za-z0-9+/]{43}=|<hash>|g' > "$before"
+            git show ":$path" | sed -E 's|sha256-[A-Za-z0-9+/]{43}=|<hash>|g' > "$after"
+
+            if ! cmp -s "$before" "$after"; then
+              echo "::error::$path changes more than sha256 literals" >&2
+              diff -u "$before" "$after" >&2 || true
+              exit 1
+            fi
+
+            echo "$path: only sha256 literals changed"
+            staged=$((staged + 1))
+          done < <(git diff --cached --raw -z HEAD)
+
+          if [ "$staged" -eq 0 ]; then
+            echo "::error::the patch staged no change" >&2
+            exit 1
+          fi
+
+      - name: Commit the staged hashes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git \
+            -c user.name="teslamate-actions" \
+            -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            commit -m "build(deps): update Nix hashes"
+      # The only step that sees a write token, in a workspace that never ran
+      # repository code.
+      - name: Push to the Dependabot branch
+        shell: bash
+        env:
+          PUSH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          : "${PUSH_TOKEN:?is empty. Runs triggered by Dependabot cannot read Actions secrets, so this has to be stored as a Dependabot secret}"
+
+          # No force: if Dependabot rebased the branch in the meantime, the
+          # patch was computed against a commit that is no longer there and the
+          # push has to fail rather than overwrite it.
+          git push \
+            "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/${HEAD_REF}"

--- a/.github/workflows/update-nix-hashes.yml
+++ b/.github/workflows/update-nix-hashes.yml
@@ -273,6 +273,11 @@ jobs:
           # No force: if Dependabot rebased the branch in the meantime, the
           # patch was computed against a commit that is no longer there and the
           # push has to fail rather than overwrite it.
-          git push \
-            "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+          # The single quotes are load-bearing: git expands ${PUSH_TOKEN} from
+          # the environment only inside the helper subprocess, so the token
+          # never appears on a command line or on disk.
+          git \
+            -c credential.helper='!f() { echo "username=x-access-token"; echo "password=${PUSH_TOKEN}"; }; f' \
+            push \
+            "https://github.com/${GITHUB_REPOSITORY}.git" \
             "HEAD:refs/heads/${HEAD_REF}"

--- a/.github/workflows/update-nix-hashes.yml
+++ b/.github/workflows/update-nix-hashes.yml
@@ -111,7 +111,7 @@ jobs:
           name: nix-hashes-patch
           path: ${{ env.PATCH_NAME }}
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
   # Deliberately separate from the commit job: this one fails whenever the
   # hashes are stale, on every pull request including Dependabot's, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,8 @@
 - ci: derive Elixir cache keys from the toolchain and MIX_ENV (#5595 - @JakobLichterfeld)
 - fix(test): override meck to 1.2 for OTP 29 compatibility (#5598 - @swiffer)
 - build(nix): reduce the manually pinned hashes to one and automate it (#5593 - @JakobLichterfeld)
-- ci: let Dependabot pull requests refresh the Nix hashes
+- ci: let Dependabot pull requests refresh the Nix hashes (#5593 - @JakobLichterfeld)
+- ci: verify Nix hashes on all dependency pull requests (#5593 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 - build: use Elixir 1.20.2 OTP 29 (#5579 - @swiffer)
 - ci: derive Elixir cache keys from the toolchain and MIX_ENV (#5595 - @JakobLichterfeld)
 - fix(test): override meck to 1.2 for OTP 29 compatibility (#5598 - @swiffer)
+- build(nix): reduce the manually pinned hashes to one and automate it (#5593 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 - ci: derive Elixir cache keys from the toolchain and MIX_ENV (#5595 - @JakobLichterfeld)
 - fix(test): override meck to 1.2 for OTP 29 compatibility (#5598 - @swiffer)
 - build(nix): reduce the manually pinned hashes to one and automate it (#5593 - @JakobLichterfeld)
+- ci: let Dependabot pull requests refresh the Nix hashes
 
 #### Dashboards
 
@@ -113,7 +114,7 @@
 - docs: update star history links in README with to include the now needed sealed token (#5489 - @JakobLichterfeld)
 - docs: link directly to restore section in upgrading PostgreSQL guide (#5501 - @JakobLichterfeld)
 - docs: split the backup and restore guides into two separate guides and highlight that you should transfer your backup of the host (#5502 - @JakobLichterfeld)
-- - docs: point Tesla Auth users to fixed releases (#5509 - @magrathean-uk)
+- docs: point Tesla Auth users to fixed releases (#5509 - @magrathean-uk)
 
 ## [4.0.1] - 2026-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 - build(nix): reduce the manually pinned hashes to one and automate it (#5593 - @JakobLichterfeld)
 - ci: let Dependabot pull requests refresh the Nix hashes (#5593 - @JakobLichterfeld)
 - ci: verify Nix hashes on all dependency pull requests (#5593 - @JakobLichterfeld)
+- ci: let maintainers run CI on pull requests touching .github (#5593 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
         ./nix/flake-modules/devenv.nix
         ./nix/flake-modules/formatter.nix
         ./nix/flake-modules/package.nix
+        ./nix/flake-modules/update-hashes.nix
       ];
     };
 }

--- a/nix/flake-modules/package.nix
+++ b/nix/flake-modules/package.nix
@@ -25,35 +25,60 @@
       };
 
       nodejs = pkgs.nodejs;
-      nodePackages = pkgs.buildNpmPackage {
-        name = "${pname}-assets";
-        src = "${src}/assets";
-        npmDepsHash = "sha256-x0/2/j1nsWhJHo1f+7KDdI2ks4rB3th1Ty/ad76cRts="; # if you change the npm deps, you need to update this hash
-        # npmDepsHash = pkgs.lib.fakeHash;
-        dontNpmBuild = true;
-        inherit nodejs;
+      assetsRoot = src + "/assets";
 
-        installPhase = ''
-          mkdir $out
-          cp -r node_modules $out
-          ln -s $out/node_modules/.bin $out/bin
-
-          rm $out/node_modules/phoenix
-          ln -s ${mixFodDeps}/phoenix $out/node_modules
-
-          rm $out/node_modules/phoenix_html
-          ln -s ${mixFodDeps}/phoenix_html $out/node_modules
-
-          rm $out/node_modules/phoenix_live_view
-          ln -s ${mixFodDeps}/phoenix_live_view $out/node_modules
-        '';
+      # assets/package-lock.json links phoenix, phoenix_html and
+      # phoenix_live_view as `file:../deps/*`. That directory only exists in a
+      # working tree after `mix deps.get`, so the already fetched mix deps are
+      # substituted for them here. Every other dependency is fetched from the
+      # integrity hashes in package-lock.json, which is why this needs no
+      # aggregate hash of its own.
+      npmSources = pkgs.importNpmLock {
+        npmRoot = assetsRoot;
+        packageSourceOverrides = {
+          "node_modules/phoenix" = "${mixFodDeps}/phoenix";
+          "node_modules/phoenix_html" = "${mixFodDeps}/phoenix_html";
+          "node_modules/phoenix_live_view" = "${mixFodDeps}/phoenix_live_view";
+        };
       };
+
+      nodePackages = pkgs.importNpmLock.buildNodeModules {
+        npmRoot = assetsRoot;
+        inherit nodejs;
+        derivationArgs = {
+          pname = "${pname}-assets";
+          inherit version;
+          # Overrides the sources buildNodeModules would derive itself, so that
+          # the phoenix packages resolve to mixFodDeps (see npmSources above).
+          npmDeps = npmSources;
+          postInstall = ''
+            ln -s $out/node_modules/.bin $out/bin
+          '';
+        };
+      };
+
+      # The locale data must come from the same release as the ex_cldr version
+      # resolved in mix.lock. Reading the version from the lockfile keeps the
+      # two from drifting apart; a stale rev otherwise builds green and just
+      # ships the wrong locales.
+      cldrVersion =
+        let
+          matches = lib.filter (match: match != null) (
+            map (builtins.match ''^ *"ex_cldr": \{:hex, :ex_cldr, "([^"]+)".*'') (
+              lib.splitString "\n" (builtins.readFile "${src}/mix.lock")
+            )
+          );
+        in
+        if matches == [ ] then
+          throw "could not determine the ex_cldr version from mix.lock"
+        else
+          lib.head (lib.head matches);
 
       cldr = pkgs.fetchFromGitHub {
         owner = "elixir-cldr";
         repo = "cldr";
-        rev = "v2.47.4"; # this must match the version in the mix file
-        sha256 = "sha256-LIQK6pZRAW1T3Ej2XAjnuPo82hPJ2KiMPWYmHWgx008="; # if you change the cldr version in the mix file, you need to update this hash
+        rev = "v${cldrVersion}";
+        sha256 = "sha256-nGVuv8jyGCMZS63ga2iObjl+ldIZmM/xDfpQbB/ZRjE="; # if the ex_cldr version in mix.lock changes, you need to update this hash
         # sha256 = pkgs.lib.fakeHash;
       };
 

--- a/nix/flake-modules/update-hashes.nix
+++ b/nix/flake-modules/update-hashes.nix
@@ -1,0 +1,150 @@
+{ ... }:
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      # Refreshes the fixed-output hashes pinned in the flake modules.
+      #
+      # A fixed-output derivation is addressed by its hash alone, so a stale
+      # hash resolves to the store path that was fetched for it earlier: the
+      # build succeeds, the fetcher never runs and nothing reports a mismatch,
+      # while the old content is silently used. Building and waiting for an
+      # error therefore finds nothing. Each pinned hash is instead invalidated
+      # on purpose, one at a time, and the hash the fetcher then reports is
+      # written back. Every run consequently re-fetches, which is the price of
+      # an answer that does not depend on what happens to sit in the store.
+      #
+      # The files to patch are looked up by their pinned hashes rather than
+      # named here, so neither renaming a module nor pinning a further
+      # fixed-output derivation elsewhere needs a change to this script.
+      packages.update-nix-hashes = pkgs.writeShellApplication {
+        name = "update-nix-hashes";
+        runtimeInputs = [
+          pkgs.nix
+          pkgs.coreutils
+          pkgs.gawk
+          pkgs.gnugrep
+          pkgs.gnused
+        ];
+        text = ''
+          # lib.fakeHash. Its output can never be a valid store path, so a
+          # derivation pinned to it always runs and always reports what it got.
+          # Assembled at run time rather than written out, so that the search
+          # for pinned hashes below does not find this file's own placeholder.
+          fake="sha256-$(printf 'A%.0s' {1..43})="
+
+          # Anchored on the flake, because that is what the build resolves
+          # against.
+          if [ ! -f flake.nix ]; then
+            echo "run this from the project root (no flake.nix here)" >&2
+            exit 1
+          fi
+
+          log="$(mktemp)"
+          patched="$(mktemp)"
+          restore=1
+          saved_files=()
+          saved_copies=()
+
+          save() {
+            local file="$1" copy known
+            for known in ''${saved_files[@]+"''${saved_files[@]}"}; do
+              if [ "$known" = "$file" ]; then
+                return 0
+              fi
+            done
+            copy="$(mktemp)"
+            cp "$file" "$copy"
+            saved_files+=("$file")
+            saved_copies+=("$copy")
+          }
+
+          cleanup() {
+            local i
+            if [ "$restore" -eq 1 ] && [ ''${#saved_files[@]} -gt 0 ]; then
+              echo "restoring the hashes this run had replaced" >&2
+              for i in "''${!saved_files[@]}"; do
+                cat "''${saved_copies[$i]}" > "''${saved_files[$i]}"
+              done
+            fi
+            rm -f "$log" "$patched" ''${saved_copies[@]+"''${saved_copies[@]}"}
+          }
+          trap cleanup EXIT
+
+          # Writes through a temporary file rather than with sed -i, which is
+          # not portable, and copies it back so the source file keeps its mode
+          # instead of the one mktemp created.
+          replace() {
+            sed "s|$2|$3|" "$1" > "$patched"
+            cat "$patched" > "$1"
+          }
+
+          mapfile -t pins < <(grep -rEo 'sha256-[A-Za-z0-9+/]{43}=' nix --include='*.nix' | sort -u)
+          if [ ''${#pins[@]} -eq 0 ]; then
+            echo "no pinned hashes found below nix/" >&2
+            exit 1
+          fi
+
+          for pin in "''${pins[@]}"; do
+            file="''${pin%%:*}"
+            hash="''${pin#*:}"
+
+            # Two pins sharing one file and hash cannot be told apart once both
+            # carry the placeholder, so refuse instead of updating them wrongly.
+            occurrences="$(grep -cF "$hash" "$file")"
+            if [ "$occurrences" -ne 1 ]; then
+              echo "$file pins $hash on $occurrences lines, which cannot be updated independently" >&2
+              exit 1
+            fi
+
+            save "$file"
+            replace "$file" "$hash" "$fake"
+
+            # --keep-going so that this fetch still finishes and reports its
+            # hash when another fixed-output derivation mismatches first. That
+            # happens whenever a second pinned hash is stale as well and its
+            # output is not in the store, which is the normal state on a fresh
+            # machine after an ex_cldr bump.
+            if nix build .#default --no-link --keep-going > "$log" 2>&1; then
+              echo "expected $file to report a hash mismatch, but the build succeeded" >&2
+              exit 1
+            fi
+
+            # Nix reports the pair as "specified: <hash>" followed by
+            # "got: <hash>". With several mismatches in one log, taking the
+            # first "got:" can pick another derivation's hash, so read the one
+            # that follows the placeholder this iteration put in place.
+            got="$(awk -v fake="$fake" '
+              index($0, "specified:") && index($0, fake) { pending = 1; next }
+              pending && index($0, "got:") { print $NF; exit }
+            ' "$log" || true)"
+
+            if ! printf '%s' "$got" | grep -qE '^sha256-[A-Za-z0-9+/]{43}=$'; then
+              cat "$log" >&2
+              echo "the build reported no hash for the placeholder in $file" >&2
+              exit 1
+            fi
+
+            replace "$file" "$fake" "$got"
+            if [ "$got" = "$hash" ]; then
+              echo "$file: $hash is unchanged"
+            else
+              echo "$file: $hash -> $got"
+            fi
+          done
+
+          # Past this point every hash was produced by a fetch that just ran, so
+          # a later failure is not one this script should undo.
+          restore=0
+
+          if ! nix build .#default --no-link > "$log" 2>&1; then
+            cat "$log" >&2
+            echo "the hashes are up to date, but the build fails for another reason" >&2
+            exit 1
+          fi
+
+          echo "all hashes are up to date"
+        '';
+      };
+    };
+}

--- a/website/docs/development.mdx
+++ b/website/docs/development.mdx
@@ -244,8 +244,16 @@ nix run .#lint
 devenv up
 ```
 
-It is most likely you need to change the hash in `./nix/flake-modules/package.nix`. This could be `mixFodDeps`, `npmDepsHash`, or the `sha256` for `cldr`.
+After a dependency update, refresh the hashes pinned in the flake modules:
+
+```bash
+nix run .#update-nix-hashes
+```
+
+Do not rely on the build to tell you that a hash went stale. A fixed-output derivation is addressed by its hash alone, so a stale hash resolves to the store path that was fetched for it earlier: the build succeeds, the fetcher never runs and the old content is used. The command therefore invalidates each pinned hash on purpose, lets the fetcher run and writes back the hash it reports, then builds the package once more — so a green run also means the package still builds. Expect it to take a few minutes, since it re-fetches every time by design, and if it fails it restores the hashes it had replaced.
+
+The hashes it maintains are `mixFodDeps` and the `sha256` for `cldr`; npm dependencies need no hash, they are fetched from the integrity hashes in `assets/package-lock.json`.
 
 :::note
-A `cldr` version update is particularly critical. The old hashes will still appear to work if you previously built using the old hash. But will silently get the old file not the new file.
+The `cldr` revision is derived from the `ex_cldr` version in `mix.lock`, so a dependency bump moves it automatically and only its `sha256` needs refreshing. Never pin the revision by hand.
 :::


### PR DESCRIPTION
Every mix or npm dependency bump invalidated one or more hashes in nix/flake-modules/package.nix, and each one had to be looked up from a failing build and pasted back by hand. Three changes shrink that to a single hash and take the pasting out of it.

- [x] Fetch the npm dependencies with pkgs.importNpmLock instead of buildNpmPackage and drop the now unneeded hash.
- [x] Derive the cldr revision from the ex_cldr version in mix.lock, this makes the two impossible to drift apart, and a lockfile without ex_cldr now aborts the evaluation instead of falling back to something plausible. 
- [x] Add nix run .#update-nix-hashes for what is left. It builds, reads the hash mismatch Nix reports, writes it back and repeats until the build succeeds.
- [x] CI: Auto update hashes in nix
