### PR TITLE
ci: derive Elixir cache keys from the toolchain and MIX_ENV

### DIFF
--- a/.github/actions/setup-elixir-and-cache-deps/action.yml
+++ b/.github/actions/setup-elixir-and-cache-deps/action.yml
@@ -9,12 +9,6 @@ inputs:
     description: "OTP version"
     required: false
     default: "29"
-  cache-name-deps:
-    description: "Cache name for dependencies"
-    required: true
-  cache-name-compiled:
-    description: "Cache name for compiled build"
-    required: true
   mix-env:
     description: "Mix environment"
     required: false
@@ -45,9 +39,9 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: deps
-        key: ${{ runner.os }}-mix-${{ inputs.cache-name-deps }}-${{ hashFiles('**/mix.lock') }}
+        key: ${{ runner.os }}-mix-deps-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          ${{ runner.os }}-mix-${{ inputs.cache-name-deps }}-
+          ${{ runner.os }}-mix-deps-
 
     - name: Cache compiled build
       id: cache-build
@@ -56,10 +50,9 @@ runs:
         path: |
           _build
           priv/cldr/locales
-        key: ${{ runner.os }}-mix-${{ inputs.cache-name-compiled }}-${{ hashFiles('**/mix.lock') }}
+        key: ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-mix-build-${{ inputs.mix-env }}-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          ${{ runner.os }}-mix-${{ inputs.cache-name-compiled }}-
-          ${{ runner.os }}-mix-
+          ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-mix-build-${{ inputs.mix-env }}-
 
     - name: Clean to rule out incremental build as a source of flakiness
       if: github.run_attempt > 3

--- a/.github/workflows/elixir_dep_verification_and_static_analysis.yml
+++ b/.github/workflows/elixir_dep_verification_and_static_analysis.yml
@@ -4,9 +4,6 @@ on:
   workflow_call:
 
 env:
-  CACHE_NAME_DEPS: cache-elixir-deps
-  CACHE_NAME_COMPILED_DEV: cache-compiled-dev-build
-  CACHE_NAME_COMPILED_TEST: cache-compiled-test-build
   ELIXIR_ASSERT_TIMEOUT: 1000
 
 permissions:
@@ -27,8 +24,6 @@ jobs:
         id: setup-elixir-and-cache-deps
         uses: ./.github/actions/setup-elixir-and-cache-deps
         with:
-          cache-name-deps: ${{ env.CACHE_NAME_DEPS }}
-          cache-name-compiled: ${{ env.CACHE_NAME_COMPILED_DEV }}
           mix-env: dev
 
       - name: Compile without warnings

--- a/.github/workflows/elixir_test.yml
+++ b/.github/workflows/elixir_test.yml
@@ -4,8 +4,6 @@ on:
   workflow_call:
 
 env:
-  CACHE_NAME_DEPS: cache-elixir-deps
-  CACHE_NAME_COMPILED_TEST: cache-compiled-test-build
   ELIXIR_ASSERT_TIMEOUT: 1000
 
 permissions:
@@ -35,8 +33,6 @@ jobs:
         id: setup-elixir-and-cache-deps
         uses: ./.github/actions/setup-elixir-and-cache-deps
         with:
-          cache-name-deps: ${{ env.CACHE_NAME_DEPS }}
-          cache-name-compiled: ${{ env.CACHE_NAME_COMPILED_TEST }}
           mix-env: test
           ELIXIR_ASSERT_TIMEOUT: ${{ env.ELIXIR_ASSERT_TIMEOUT }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - build(deps): bump the actions-deps group across 4 directories with 11 updates (#5576)
 - test(grafana): guard latest-position dashboard queries against missing partial-index predicate (#5581 - @magrathean-uk)
 - build: use Elixir 1.20.2 OTP 29 (#5579 - @swiffer)
+- ci: derive Elixir cache keys from the toolchain and MIX_ENV (#5595 - @JakobLichterfeld)
 
 #### Dashboards
 


### PR DESCRIPTION
## Summary

Found while reviewing #5579 (Elixir 1.20.2 / OTP 29): the compiled build cache is keyed on `mix.lock` alone, so the toolchain bump did not invalidate it. The restored `_build` still holds artifacts compiled by the previous Elixir/OTP — including NIFs such as `lazy_html`'s, which Mix does not necessarily rebuild.
The PLT cache already keys on the versions `setup-beam` resolves; the build cache now does the same.

Second part: the `cache-name-*` inputs are gone. `cache-name-deps` was the same constant in every caller, and `cache-name-compiled` duplicated the dev/test distinction that `mix-env` already carries — two sources for one fact, free to
drift. The unversioned `restore-keys` fallback goes with them, since it would have restored exactly the stale artifacts the new key separates.

The deps cache keeps its `mix.lock`-only key: it holds sources, which the lockfile already identifies.
