### PR TITLE
refactor(vehicles): make the geofence name lookup in the charging log total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - feat: use Grafana 13.1.1 (#5559 - @swiffer)
 - fix(performance): use existing indexes for last-inserted / latest complete position lookups (#5438 - @swiffer)
 - fix(geocoder): resolve state for Australian territories (#3868 - mattew124)
+- refactor(vehicles): make the geofence name lookup in the charging log total (#5599 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1127,7 +1127,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
             cproc
           end)
 
-        ["Charging", "SOC: #{lvl}%", with(%GeoFence{name: name} <- cproc.geofence, do: name)]
+        ["Charging", "SOC: #{lvl}%", geofence_name(cproc.geofence)]
         |> Enum.reject(&is_nil/1)
         |> Enum.join(" / ")
         |> Logger.info(car_id: data.car.id)
@@ -2058,6 +2058,9 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
   defp fuse_name(:vehicle_not_found, car_id), do: :"#{__MODULE__}_#{car_id}_not_found"
   defp fuse_name(:api_error, car_id), do: :"#{__MODULE__}_#{car_id}_api_error"
+
+  defp geofence_name(%GeoFence{name: name}), do: name
+  defp geofence_name(_), do: nil
 
   defp broadcast_summary, do: {:next_event, :internal, :broadcast_summary}
   defp broadcast_fetch(status), do: {:next_event, :internal, {:broadcast_fetch, status}}


### PR DESCRIPTION
## Summary

Noticed while reviewing #5579. The charging log line does

```elixir
with(%GeoFence{name: name} <- cproc.geofence, do: name)
```

and `with` without `else` returns the non-matching value itself, which then flows into `Enum.join` as part of the message. `Log.start_charging_process/3` preloads `:geofence`, so the value is `nil` or a `%GeoFence{}` and the
expression is total today — nothing in the expression says so, though, and a value that is neither would raise `Protocol.UndefinedError` inside the vehicle `:gen_statem`.

Two clauses of a private `geofence_name/1` state the intent instead. No behaviour change, no new test: the existing charging tests cover the line, and the preload contract is already upheld by `LogMock` since #5579.