### PR TITLE
fix(vehicle): shorten the streaming suspend probe interval from 30 to 10 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improvements and bug fixes
 
+- fix(vehicle): shorten the streaming suspend probe interval from 30 to 10 minutes (#5600 - @onevcat)
+
 #### Build, CI, internal
 
 #### Dashboards

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -342,7 +342,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
 
       suspend_min =
         case {data.car.settings, streaming?(data)} do
-          {%CarSettings{use_streaming_api: true}, true} -> 30
+          {%CarSettings{use_streaming_api: true}, true} -> 10
           {%CarSettings{suspend_min: s}, _} -> s
         end
 
@@ -1736,7 +1736,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
   defp try_to_suspend(vehicle, current_state, %Data{car: car} = data) do
     {suspend_after_idle_min, suspend_min, i} =
       case {car.settings, streaming?(data)} do
-        {%CarSettings{use_streaming_api: true}, true} -> {3, 30, 2}
+        {%CarSettings{use_streaming_api: true}, true} -> {3, 10, 2}
         {%CarSettings{suspend_after_idle_min: i, suspend_min: s}, _} -> {i, s, 1}
       end
 


### PR DESCRIPTION
## Problem

With `use_streaming_api` enabled, both suspend paths hard-code a **30-minute** probe interval (`{3, 30, 2}` in `try_to_suspend`, and the manual `suspend_logging` path), ignoring the stored `suspend_min`. That value was a precaution from the polling-only era, where the suspended-state probe could escalate to a billed `vehicle_data` call that also reset the car's own idle timer.

Under streaming neither concern applies: the suspended-state fetch takes the `allow_vehicle_data? = false` path and issues only `GET /api/1/vehicles/<id>` — free, served from Tesla's cache, and incapable of keeping the car awake. The stream stays subscribed throughout, so drive and charge starts are detected instantly regardless of this timer. The fixed 30 minutes therefore only delays *recording* the sleep transition: a car that falls asleep early in the window is reported `online` for up to ~20 extra minutes, systematically inflating online time in the statistics.

## Change

As suggested in review, simply lower the hard-coded streaming probe interval from 30 to 10 minutes — no new configuration. Both the automatic (`try_to_suspend`) and the manual (`suspend_logging`) paths change; the non-streaming path is untouched and continues to honor the stored `suspend_after_idle_min` / `suspend_min`.

*(An earlier revision of this PR added a `POLLING_SUSPENDED_INTERVAL` environment variable instead; reworked per review feedback — the env var, its docs table entry and its parsing test are gone.)*

## Field results

Before this rework we ran the earlier env-var revision on our own instance (self-hosted Fleet Telemetry + streaming API) with the probe interval set to 5 minutes, continuously since 2026-08-10:

- Sleep transitions are recorded within ~5 minutes of the car actually falling asleep.
- No additional billed traffic appeared on the Fleet API usage/billing page — the probe stays on the free vehicle-list endpoint, as analyzed.
- No effect on the car's ability to reach deep sleep.

10 minutes is the conservative choice suggested in review (144 instead of 48 probes/day/car) and is strictly better than the current 30 minutes for everyone, with no knob to explain.

## Notes

Existing suspend/streaming tests assert state transitions rather than the timer value, so no test changes are needed. CHANGELOG entry included.
