### PR TITLE
build(deps): bump assets npm packages (geocoder 4.0, sass 1.102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@
 - build: use Elixir 1.20.2 OTP 29 (#5579 - @swiffer)
 - ci: derive Elixir cache keys from the toolchain and MIX_ENV (#5595 - @JakobLichterfeld)
 - fix(test): override meck to 1.2 for OTP 29 compatibility (#5598 - @swiffer)
+- build(deps): bump leaflet-control-geocoder from 3.3.1 to 4.0.0 in /assets (#5602 - @swiffer)
+- build(deps-dev): bump sass from 1.101.0 to 1.102.0 in /assets (#5602 - @swiffer)
 
 #### Dashboards
 

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -13,7 +13,7 @@
         "@mdi/font": "^7.4.47",
         "bulma-switch": "^2.0.4",
         "leaflet": "^1.9.4",
-        "leaflet-control-geocoder": "^3.3.1",
+        "leaflet-control-geocoder": "^4.0.0",
         "phoenix": "file:../deps/phoenix",
         "phoenix_html": "file:../deps/phoenix_html",
         "phoenix_live_view": "file:../deps/phoenix_live_view"
@@ -22,22 +22,47 @@
         "bulma": "^1.0.4",
         "esbuild": "^0.28.1",
         "esbuild-sass-plugin": "^3.7.0",
-        "sass": "^1.101.0"
+        "sass": "^1.102.0"
       }
     },
     "../deps/phoenix": {
-      "version": "1.7.21",
+      "version": "1.7.24",
       "license": "MIT"
     },
     "../deps/phoenix_html": {
       "version": "4.3.0"
     },
     "../deps/phoenix_live_view": {
-      "version": "0.20.17",
+      "version": "1.2.8",
       "license": "MIT",
+      "dependencies": {
+        "morphdom": "github:SteffenDE/morphdom#sd-keyed-root"
+      },
       "devDependencies": {
-        "@playwright/test": "^1.43.1",
-        "monocart-reporter": "^2.3.1"
+        "@babel/cli": "7.27.2",
+        "@babel/core": "7.29.6",
+        "@babel/preset-env": "7.27.2",
+        "@babel/preset-typescript": "^7.27.1",
+        "@eslint/js": "^9.29.0",
+        "@playwright/test": "^1.60.0",
+        "@types/jest": "^30.0.0",
+        "@types/phoenix": "^1.6.6",
+        "css.escape": "^1.5.1",
+        "eslint": "9.29.0",
+        "eslint-plugin-jest": "28.14.0",
+        "eslint-plugin-playwright": "^2.2.0",
+        "globals": "^16.2.0",
+        "jest": "^30.0.0",
+        "jest-environment-jsdom": "^30.0.0",
+        "jest-monocart-coverage": "^1.1.1",
+        "monocart-reporter": "^2.9.21",
+        "phoenix": "1.7.21",
+        "prettier": "3.5.3",
+        "ts-jest": "^29.4.0",
+        "typedoc": "^0.28.19",
+        "typedoc-plugin-missing-exports": "^4.1.3",
+        "typescript": "^5.8.3",
+        "typescript-eslint": "^8.34.0"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -1294,15 +1319,15 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/leaflet-control-geocoder": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/leaflet-control-geocoder/-/leaflet-control-geocoder-3.3.1.tgz",
-      "integrity": "sha512-DOLZLAbTq5mKzbvXt6O4HOWeJ03QofwYBbEjcp4Upg1JyWcrVSkfOKWIwbB4bOSPb40cdFoe59DOxGa1Sj10yQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/leaflet-control-geocoder/-/leaflet-control-geocoder-4.0.0.tgz",
+      "integrity": "sha512-VInJiG9GKbUtZ/m425MxLZfnEDFQfjGXUHK/96sfMYRYsDuVCRgT3jszhqY114tDlkpAssRIex08i6UArDN3rA==",
       "license": "BSD-2-Clause",
       "optionalDependencies": {
         "open-location-code": "^1.0.3"
       },
       "peerDependencies": {
-        "leaflet": "^1.6.0 || ^2.0.0"
+        "leaflet": "^1.6.0"
       }
     },
     "node_modules/lodash": {
@@ -1447,9 +1472,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.101.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
-      "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
+      "version": "1.102.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.102.0.tgz",
+      "integrity": "sha512-NSOyTnaQF7rTAEOtI2fwb386vL+akyiQLBZu8Na7hXCb+umJy0GAqlcMIaqACZ6Z1VgTBS4K9PG6B3IdjHGJsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -12,7 +12,7 @@
     "@mdi/font": "^7.4.47",
     "bulma-switch": "^2.0.4",
     "leaflet": "^1.9.4",
-    "leaflet-control-geocoder": "^3.3.1",
+    "leaflet-control-geocoder": "^4.0.0",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
     "phoenix_live_view": "file:../deps/phoenix_live_view"
@@ -21,7 +21,7 @@
     "bulma": "^1.0.4",
     "esbuild": "^0.28.1",
     "esbuild-sass-plugin": "^3.7.0",
-    "sass": "^1.101.0"
+    "sass": "^1.102.0"
   },
   "name": "assets"
 }


### PR DESCRIPTION
## Summary

Bump outdated Node packages under `/assets`:

| Package | From | To |
|---------|------|-----|
| `leaflet-control-geocoder` | 3.3.1 | **4.0.0** |
| `sass` (dev) | 1.101.0 | **1.102.0** |

### Notes
- Geocoder 4.0 keeps the `Control.geocoder` API we use; adds Nominatim response caching and public-service rate limiting.
- `esbuild` 0.28.2 exists but is not installable yet due to `assets/.npmrc` `min-release-age=7` (published 2026-08-08).
- Supercedes open Dependabot PRs #5565 and #5566 for the same packages.

## Test plan
- [x] `npm run deploy` in `/assets` succeeds locally
- [ ] CI green