### PR TITLE
fix(mqtt): don't require the namespace option in VehicleSubscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## [unreleased]
 
+same as 4.1.0 with bug fix
+
 ### New features
 
 ### Improvements and bug fixes
+
+- fix(mqtt): don't require the namespace option in VehicleSubscriber (#5611 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -58,7 +58,9 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
   @impl true
   def init(opts) do
     car_id = Keyword.fetch!(opts, :car_id)
-    namespace = Keyword.fetch!(opts, :namespace)
+    # :namespace is absent (not nil) when MQTT_NAMESPACE is unset, since
+    # Mqtt.init drops nil options before starting PubSub.
+    namespace = Keyword.get(opts, :namespace)
 
     deps = %{
       vehicles: Keyword.get(opts, :deps_vehicles, Vehicles),

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -481,4 +481,30 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     # No discovery config should be published when discovery is disabled
     refute_receive {MqttPublisherMock, {:publish, "homeassistant/" <> _, _, _}}
   end
+
+  test "starts when the namespace option is absent (MQTT_NAMESPACE unset)", %{test: name} do
+    publisher_name = :"mqtt_publisher_#{name}"
+    vehicles_name = :"vehicles_#{name}"
+
+    {:ok, _pid} =
+      start_supervised({MqttPublisherMock, name: publisher_name, pid: self(), responses: %{}})
+
+    {:ok, _pid} = start_supervised({VehiclesMock, name: vehicles_name, pid: self()})
+
+    # Mqtt.init drops nil options before starting PubSub, so subscribers must
+    # start without a :namespace key (regression: KeyError boot crash in 4.1.0)
+    {:ok, _pid} =
+      start_supervised(
+        {VehicleSubscriber,
+         [
+           name: name,
+           car_id: 0,
+           discovery: false,
+           deps_publisher: {MqttPublisherMock, publisher_name},
+           deps_vehicles: {VehiclesMock, vehicles_name}
+         ]}
+      )
+
+    assert_receive {VehiclesMock, {:subscribe_to_summary, 0}}
+  end
 end


### PR DESCRIPTION
## Summary

4.1.0 regression from #5543: every instance with MQTT enabled and no `MQTT_NAMESPACE` set crashes at boot in a restart loop.

`Mqtt.init` drops nil options before starting `PubSub`, so the `:namespace` key is absent (not nil) when `MQTT_NAMESPACE` is unset. `VehicleSubscriber.init` still required it via `Keyword.fetch!(opts, :namespace)`, raising a `KeyError` that cascades through the supervision tree and takes down the BEAM:

```
** (KeyError) key :namespace not found in:
    [discovery: false, car_id: 1]
```

## Fix

- Use `Keyword.get/2` for `:namespace` in `VehicleSubscriber.init` — the namespace is genuinely optional and `nil` is handled correctly everywhere downstream. A code comment documents why the key can be absent.
- The nil-rejection in `Mqtt.init` stays: it is load-bearing for the `discovery_prefix` default.

## Tests

- New regression test starting a subscriber without a `:namespace` key — exactly the 4.1.0 crash; the existing tests never caught it because they always pass the key explicitly (even when nil).
- All MQTT pubsub tests plus `vehicle_sync_test` pass locally (24 tests, 0 failures), `mix format` clean.

Fixes #5608

---

🤖 Review drafted with [Claude Code](https://claude.com/claude-code) (Fable 5 high) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)