### PR TITLE
test: stop the app in test_helper instead of relying on --no-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - build(deps): bump tzdata from 1.1.3 to 1.1.4 (#5614 - @mews-se)
 - ci: purge orphaned GHCR attestation referrers (#5622 - @swiffer)
+- test: stop the app in test_helper instead of relying on --no-start (#5615 - @swiffer)
 
 #### Dashboards
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,12 @@
-# FIXME Workaround to apply the logger config when running the tests with
-# "--no-start". This looks like a bug in Elixir v1.11.0
+# ElixirLS Test Explorer starts the full app (it cannot pass --no-start).
+# Tear it down so tests get the same Repo + PubSub tree as `mix test`.
+case Application.stop(:teslamate) do
+  :ok -> :ok
+  {:error, {:not_started, :teslamate}} -> :ok
+end
+
+# `mix test --no-start` only loads config; Mix restarts Logger when it starts
+# the app. Bounce it here so config/test.exs (level: :warning) takes effect.
 Application.stop(:logger)
 Application.start(:logger)
 
@@ -9,8 +16,8 @@ for app <- Application.spec(:teslamate, :applications) do
   {:ok, _} = Application.ensure_all_started(app)
 end
 
-TeslaMate.Repo.start_link()
-Phoenix.PubSub.Supervisor.start_link(name: TeslaMate.PubSub)
+{:ok, _} = TeslaMate.Repo.start_link()
+{:ok, _} = Phoenix.PubSub.Supervisor.start_link(name: TeslaMate.PubSub)
 
 assert_timeout = String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT") || "300")
 ExUnit.start(assert_receive_timeout: assert_timeout)


### PR DESCRIPTION
`mix test` is green here, but the same suite fails in VS Code via ElixirLS Test Explorer.

ElixirLS starts the full TeslaMate app and cannot pass `--no-start` (our mix alias). Tests that `start_supervised` Endpoint / Repair / MQTT / Terrain then hit already-started processes.

Stop the app in `test_helper.exs` so both runners get the same Repo + PubSub tree. `mix test` is unchanged (476 passed).