### PR TITLE
feat(mqtt): enrich Home Assistant device metadata and republish on change

### DIFF
--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -119,7 +119,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
   defp device(%Summary{} = summary, car_id, base_url, namespace) do
     name = summary.display_name || car_name(summary) || "Tesla ##{car_id}"
-    model = summary.model || "Tesla"
+    model = model_name(summary) || "Tesla"
 
     %{
       identifiers: [device_identifier(car_id, namespace)],
@@ -128,7 +128,66 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       model: model
     }
     |> maybe_put(:configuration_url, base_url)
+    |> maybe_put(:sw_version, non_empty(summary.version))
   end
+
+  defp model_name(%Summary{} = summary) do
+    model =
+      [summary.model, summary.trim_badging]
+      |> Enum.map(&non_empty/1)
+      |> Enum.reject(&is_nil/1)
+      |> case do
+        [] -> nil
+        parts -> "Model #{Enum.join(parts, " ")}"
+      end
+
+    details =
+      []
+      |> maybe_add_wheels(summary.wheel_type)
+      |> maybe_add_spoiler(summary.spoiler_type)
+
+    case {model, details} do
+      {nil, _details} -> nil
+      {model, []} -> model
+      {model, details} -> "#{model} (#{Enum.join(details, ", ")})"
+    end
+  end
+
+  defp maybe_add_wheels(details, wheel_type) do
+    case non_empty(wheel_type) do
+      nil -> details
+      wheel_type -> details ++ ["#{format_wheel_type(wheel_type)} Wheels"]
+    end
+  end
+
+  defp maybe_add_spoiler(details, spoiler_type) do
+    case format_spoiler_type(spoiler_type) do
+      nil -> details
+      spoiler_type -> details ++ ["#{spoiler_type} Spoiler"]
+    end
+  end
+
+  defp format_wheel_type(wheel_type) do
+    case Regex.named_captures(~r/^(?<name>[A-Za-z]+)(?<size>\d+)$/, wheel_type) do
+      %{"name" => name, "size" => size} -> "#{split_camel_case(name)} #{size}\""
+      nil -> split_camel_case(wheel_type)
+    end
+  end
+
+  defp format_spoiler_type(spoiler_type) do
+    case non_empty(spoiler_type) do
+      nil ->
+        nil
+
+      spoiler_type ->
+        if String.downcase(spoiler_type) == "none", do: nil, else: split_camel_case(spoiler_type)
+    end
+  end
+
+  defp split_camel_case(value), do: Regex.replace(~r/(?<=[a-z])(?=[A-Z])/, value, " ")
+
+  defp non_empty(value) when is_binary(value) and value != "", do: value
+  defp non_empty(_value), do: nil
 
   defp device_identifier(car_id, namespace) do
     [@node, namespace, "car", car_id] |> Enum.reject(&is_nil/1) |> Enum.join("_")

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -185,9 +185,17 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   defp format_model(model), do: model
 
   defp format_wheel_type(wheel_type) do
-    case Regex.named_captures(~r/^(?<name>[A-Za-z]+)(?<size>\d+)$/, wheel_type) do
-      %{"name" => name, "size" => size} -> "#{split_camel_case(name)} #{size}\""
-      nil -> split_camel_case(wheel_type)
+    case Regex.named_captures(
+           ~r/^(?<name>[A-Za-z]+)(?<size>\d+)(?<suffix>[A-Za-z]*)$/,
+           wheel_type
+         ) do
+      %{"name" => name, "size" => size, "suffix" => suffix} ->
+        [split_camel_case(name), "#{size}\"", split_camel_case(suffix)]
+        |> Enum.reject(&(&1 == ""))
+        |> Enum.join(" ")
+
+      nil ->
+        split_camel_case(wheel_type)
     end
   end
 

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -139,7 +139,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
           nil
 
         model ->
-          [format_model(model), non_empty(summary.trim_badging)]
+          [format_model(model), marketing_name(summary) || non_empty(summary.trim_badging)]
           |> Enum.reject(&is_nil/1)
           |> Enum.join(" ")
       end
@@ -205,6 +205,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
   defp car_name(%Summary{car: %Car{name: name}}) when is_binary(name) and name != "", do: name
   defp car_name(_), do: nil
+
+  defp marketing_name(%Summary{car: %Car{marketing_name: name}}), do: non_empty(name)
+  defp marketing_name(_), do: nil
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -145,6 +145,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       []
       |> maybe_add_wheels(summary.wheel_type)
       |> maybe_add_spoiler(summary.spoiler_type)
+      |> maybe_add_sunroof(summary.sun_roof_installed)
 
     case {model, details} do
       {nil, _details} -> nil
@@ -166,6 +167,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       spoiler_type -> details ++ ["#{spoiler_type} Spoiler"]
     end
   end
+
+  defp maybe_add_sunroof(details, true), do: details ++ ["Sunroof"]
+  defp maybe_add_sunroof(details, _sun_roof_installed), do: details
 
   defp format_wheel_type(wheel_type) do
     case Regex.named_captures(~r/^(?<name>[A-Za-z]+)(?<size>\d+)$/, wheel_type) do

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -36,11 +36,10 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   def publish(%Summary{} = summary, opts, publisher) do
     car_id = Keyword.fetch!(opts, :car_id)
     namespace = Keyword.get(opts, :namespace)
-    base_url = Keyword.get(opts, :base_url)
     prefix = Keyword.get(opts, :discovery_prefix, @discovery_prefix)
     node = node(car_id, namespace)
 
-    device = device(summary, car_id, base_url, namespace)
+    device = device(summary, opts)
 
     Enum.reduce_while(entities(), :ok, fn {component, object_id, config}, _acc ->
       topic = discovery_topic(prefix, component, node, object_id)
@@ -58,6 +57,28 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
         {:error, _} = error -> {:halt, error}
       end
     end)
+  end
+
+  @doc """
+  Builds the Home Assistant device metadata rendered into each discovery
+  configuration payload.
+  """
+  @spec device(Summary.t(), publish_opts()) :: map()
+  def device(%Summary{} = summary, opts) do
+    car_id = Keyword.fetch!(opts, :car_id)
+    namespace = Keyword.get(opts, :namespace)
+    base_url = Keyword.get(opts, :base_url)
+    name = summary.display_name || car_name(summary) || "Tesla ##{car_id}"
+    model = model_name(summary) || "Tesla"
+
+    %{
+      identifiers: [device_identifier(car_id, namespace)],
+      manufacturer: "Tesla",
+      name: name,
+      model: model
+    }
+    |> maybe_put(:configuration_url, base_url)
+    |> maybe_put(:sw_version, non_empty(summary.version))
   end
 
   @doc """
@@ -116,20 +137,6 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
     [@node, namespace, car_id]
     |> Enum.reject(&is_nil/1)
     |> Enum.join("_")
-  end
-
-  defp device(%Summary{} = summary, car_id, base_url, namespace) do
-    name = summary.display_name || car_name(summary) || "Tesla ##{car_id}"
-    model = model_name(summary) || "Tesla"
-
-    %{
-      identifiers: [device_identifier(car_id, namespace)],
-      manufacturer: "Tesla",
-      name: name,
-      model: model
-    }
-    |> maybe_put(:configuration_url, base_url)
-    |> maybe_put(:sw_version, non_empty(summary.version))
   end
 
   defp model_name(%Summary{} = summary) do

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -14,6 +14,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
   @discovery_prefix "homeassistant"
   @node "teslamate"
+  @models_with_prefix ~w(S X 3 Y)
 
   @type publish_opts :: [
           car_id: pos_integer(),
@@ -133,12 +134,14 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
   defp model_name(%Summary{} = summary) do
     model =
-      [summary.model, summary.trim_badging]
-      |> Enum.map(&non_empty/1)
-      |> Enum.reject(&is_nil/1)
-      |> case do
-        [] -> nil
-        parts -> "Model #{Enum.join(parts, " ")}"
+      case non_empty(summary.model) do
+        nil ->
+          nil
+
+        model ->
+          [format_model(model), non_empty(summary.trim_badging)]
+          |> Enum.reject(&is_nil/1)
+          |> Enum.join(" ")
       end
 
     details =
@@ -170,6 +173,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
   defp maybe_add_sunroof(details, true), do: details ++ ["Sunroof"]
   defp maybe_add_sunroof(details, _sun_roof_installed), do: details
+
+  defp format_model(model) when model in @models_with_prefix, do: "Model #{model}"
+  defp format_model(model), do: model
 
   defp format_wheel_type(wheel_type) do
     case Regex.named_captures(~r/^(?<name>[A-Za-z]+)(?<size>\d+)$/, wheel_type) do

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -17,7 +17,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
     :discovery,
     :discovery_base_url,
     :discovery_prefix,
-    discovery_published: false
+    :discovery_metadata
   ]
 
   alias __MODULE__, as: State
@@ -121,16 +121,40 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
 
     last_values = publish_values(values, state)
 
-    state =
-      if state.discovery and not state.discovery_published do
-        publish_discovery(summary, state)
-        %{state | discovery_published: true}
-      else
-        state
-      end
+    state = maybe_publish_discovery(summary, state)
 
     {:noreply, %{state | last_values: last_values}}
   end
+
+  defp maybe_publish_discovery(%Summary{} = summary, %State{discovery: true} = state) do
+    metadata = discovery_metadata(summary)
+
+    if metadata == state.discovery_metadata do
+      state
+    else
+      case publish_discovery(summary, state) do
+        :ok -> %{state | discovery_metadata: metadata}
+        {:error, _reason} -> state
+      end
+    end
+  end
+
+  defp maybe_publish_discovery(%Summary{}, %State{} = state), do: state
+
+  defp discovery_metadata(%Summary{} = summary) do
+    {
+      summary.display_name,
+      car_name(summary.car),
+      summary.model,
+      summary.trim_badging,
+      summary.wheel_type,
+      summary.spoiler_type,
+      summary.version
+    }
+  end
+
+  defp car_name(%{name: name}), do: name
+  defp car_name(_car), do: nil
 
   defp publish_discovery(%Summary{} = summary, %State{deps: deps} = state) do
     opts = discovery_opts(state)
@@ -139,8 +163,9 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
       :ok ->
         :ok
 
-      {:error, reason} ->
+      {:error, reason} = error ->
         Logger.warning("MQTT HA discovery publishing failed: #{inspect(reason)}")
+        error
     end
   end
 

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -146,6 +146,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
       summary.display_name,
       car_name(summary.car),
       summary.model,
+      car_marketing_name(summary.car),
       summary.trim_badging,
       summary.wheel_type,
       summary.spoiler_type,
@@ -156,6 +157,9 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
 
   defp car_name(%{name: name}), do: name
   defp car_name(_car), do: nil
+
+  defp car_marketing_name(%{marketing_name: marketing_name}), do: marketing_name
+  defp car_marketing_name(_car), do: nil
 
   defp publish_discovery(%Summary{} = summary, %State{deps: deps} = state) do
     opts = discovery_opts(state)

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -17,7 +17,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
     :discovery,
     :discovery_base_url,
     :discovery_prefix,
-    :discovery_metadata
+    :discovery_device
   ]
 
   alias __MODULE__, as: State
@@ -127,13 +127,14 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
   end
 
   defp maybe_publish_discovery(%Summary{} = summary, %State{discovery: true} = state) do
-    metadata = discovery_metadata(summary)
+    opts = discovery_opts(state)
+    device = HomeAssistant.device(summary, opts)
 
-    if metadata == state.discovery_metadata do
+    if device == state.discovery_device do
       state
     else
-      case publish_discovery(summary, state) do
-        :ok -> %{state | discovery_metadata: metadata}
+      case publish_discovery(summary, opts, state) do
+        :ok -> %{state | discovery_device: device}
         {:error, _reason} -> state
       end
     end
@@ -141,29 +142,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
 
   defp maybe_publish_discovery(%Summary{}, %State{} = state), do: state
 
-  defp discovery_metadata(%Summary{} = summary) do
-    {
-      summary.display_name,
-      car_name(summary.car),
-      summary.model,
-      car_marketing_name(summary.car),
-      summary.trim_badging,
-      summary.wheel_type,
-      summary.spoiler_type,
-      summary.sun_roof_installed,
-      summary.version
-    }
-  end
-
-  defp car_name(%{name: name}), do: name
-  defp car_name(_car), do: nil
-
-  defp car_marketing_name(%{marketing_name: marketing_name}), do: marketing_name
-  defp car_marketing_name(_car), do: nil
-
-  defp publish_discovery(%Summary{} = summary, %State{deps: deps} = state) do
-    opts = discovery_opts(state)
-
+  defp publish_discovery(%Summary{} = summary, opts, %State{deps: deps}) do
     case HomeAssistant.publish(summary, opts, deps.publisher) do
       :ok ->
         :ok

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -9,6 +9,9 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
   alias TeslaMate.Vehicles.Vehicle.Summary
   alias TeslaMate.Vehicles
 
+  @discovery_retry_initial_delay :timer.seconds(5)
+  @discovery_retry_max_delay :timer.minutes(5)
+
   defstruct [
     :car_id,
     :last_values,
@@ -17,7 +20,12 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
     :discovery,
     :discovery_base_url,
     :discovery_prefix,
-    :discovery_device
+    :discovery_device,
+    :discovery_pending_summary,
+    :discovery_pending_device,
+    :discovery_retry_delay,
+    :discovery_retry_timer,
+    :discovery_retry_token
   ]
 
   alias __MODULE__, as: State
@@ -126,31 +134,102 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
     {:noreply, %{state | last_values: last_values}}
   end
 
+  def handle_info(
+        {:retry_discovery, token},
+        %State{
+          discovery: true,
+          discovery_retry_token: token,
+          discovery_pending_summary: %Summary{} = summary,
+          discovery_pending_device: device
+        } = state
+      ) do
+    state = %{
+      state
+      | discovery_pending_summary: nil,
+        discovery_pending_device: nil,
+        discovery_retry_timer: nil,
+        discovery_retry_token: nil
+    }
+
+    {:noreply, publish_or_schedule_discovery(summary, device, state)}
+  end
+
+  def handle_info({:retry_discovery, _stale_token}, %State{} = state), do: {:noreply, state}
+
   defp maybe_publish_discovery(%Summary{} = summary, %State{discovery: true} = state) do
     opts = discovery_opts(state)
     device = HomeAssistant.device(summary, opts)
 
-    if device == state.discovery_device do
-      state
-    else
-      case publish_discovery(summary, opts, state) do
-        :ok -> %{state | discovery_device: device}
-        {:error, _reason} -> state
-      end
+    cond do
+      device == state.discovery_device ->
+        reset_discovery_retry(state)
+
+      is_reference(state.discovery_retry_timer) ->
+        %{
+          state
+          | discovery_pending_summary: summary,
+            discovery_pending_device: device
+        }
+
+      true ->
+        publish_or_schedule_discovery(summary, device, state)
     end
   end
 
   defp maybe_publish_discovery(%Summary{}, %State{} = state), do: state
 
-  defp publish_discovery(%Summary{} = summary, opts, %State{deps: deps}) do
-    case HomeAssistant.publish(summary, opts, deps.publisher) do
+  defp publish_or_schedule_discovery(%Summary{} = summary, device, %State{} = state) do
+    case publish_discovery(summary, discovery_opts(state), state) do
       :ok ->
-        :ok
+        state
+        |> reset_discovery_retry()
+        |> Map.put(:discovery_device, device)
 
-      {:error, reason} = error ->
-        Logger.warning("MQTT HA discovery publishing failed: #{inspect(reason)}")
-        error
+      {:error, reason} ->
+        schedule_discovery_retry(summary, device, reason, state)
     end
+  end
+
+  defp publish_discovery(%Summary{} = summary, opts, %State{deps: deps}) do
+    HomeAssistant.publish(summary, opts, deps.publisher)
+  end
+
+  defp schedule_discovery_retry(%Summary{} = summary, device, reason, %State{} = state) do
+    delay = next_discovery_retry_delay(state.discovery_retry_delay)
+    token = make_ref()
+    timer = Process.send_after(self(), {:retry_discovery, token}, delay)
+
+    Logger.warning(
+      "MQTT HA discovery publishing failed: #{inspect(reason)}; retrying in #{div(delay, 1_000)}s"
+    )
+
+    %{
+      state
+      | discovery_pending_summary: summary,
+        discovery_pending_device: device,
+        discovery_retry_delay: delay,
+        discovery_retry_timer: timer,
+        discovery_retry_token: token
+    }
+  end
+
+  defp next_discovery_retry_delay(nil), do: @discovery_retry_initial_delay
+
+  defp next_discovery_retry_delay(delay) do
+    min(delay * 2, @discovery_retry_max_delay)
+  end
+
+  defp reset_discovery_retry(%State{discovery_retry_timer: timer} = state) do
+    if is_reference(timer), do: Process.cancel_timer(timer)
+
+    %{
+      state
+      | discovery_pending_summary: nil,
+        discovery_pending_device: nil,
+        discovery_retry_delay: nil,
+        discovery_retry_timer: nil,
+        discovery_retry_token: nil
+    }
   end
 
   defp discovery_opts(%State{} = state) do

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -149,6 +149,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
       summary.trim_badging,
       summary.wheel_type,
       summary.spoiler_type,
+      summary.sun_roof_installed,
       summary.version
     }
   end

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -55,7 +55,47 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       assert device["identifiers"] == ["teslamate_car_0"]
       assert device["manufacturer"] == "Tesla"
       assert device["configuration_url"] == "https://teslamate.example.com/"
+      assert device["model"] == "Model 3"
+      refute Map.has_key?(device, "sw_version")
     end
+  end
+
+  test "publishes rich model and firmware metadata", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    summary = %{
+      @summary
+      | model: "S",
+        trim_badging: "P100D",
+        wheel_type: "AeroTurbine19",
+        spoiler_type: "CarbonFiber",
+        version: "2026.26.1"
+    }
+
+    :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_one_config()
+
+    assert decoded["device"]["model"] ==
+             ~s|Model S P100D (Aero Turbine 19" Wheels, Carbon Fiber Spoiler)|
+
+    assert decoded["device"]["sw_version"] == "2026.26.1"
+  end
+
+  test "omits an absent spoiler from the rich model", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    summary = %{
+      @summary
+      | trim_badging: "Long Range",
+        wheel_type: "Induction",
+        spoiler_type: "None"
+    }
+
+    :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_one_config()
+    assert decoded["device"]["model"] == "Model 3 Long Range (Induction Wheels)"
   end
 
   test "device name falls back to car.name when display_name is nil", %{test: name} do

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -62,15 +62,17 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
   test "publishes rich model and firmware metadata", %{test: name} do
     publisher_name = start_publisher(name)
+    car = %{@summary.car | marketing_name: "LR AWD"}
 
     summary = %{
       @summary
       | model: "S",
-        trim_badging: "P100D",
+        trim_badging: "74D",
         wheel_type: "AeroTurbine19",
         spoiler_type: "CarbonFiber",
         sun_roof_installed: true,
-        version: "2026.26.1"
+        version: "2026.26.1",
+        car: car
     }
 
     :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
@@ -78,9 +80,20 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     {_topic, decoded} = receive_one_config()
 
     assert decoded["device"]["model"] ==
-             ~s|Model S P100D (Aero Turbine 19" Wheels, Carbon Fiber Spoiler, Sunroof)|
+             ~s|Model S LR AWD (Aero Turbine 19" Wheels, Carbon Fiber Spoiler, Sunroof)|
 
     assert decoded["device"]["sw_version"] == "2026.26.1"
+  end
+
+  test "falls back to raw trim badging when the marketing name is unavailable", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    summary = %{@summary | trim_badging: "74D"}
+
+    :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_one_config()
+    assert decoded["device"]["model"] == "Model 3 74D"
   end
 
   test "falls back to Tesla when the model is unknown", %{test: name} do

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -135,6 +135,19 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert decoded["device"]["model"] == "Model 3 Long Range (Induction Wheels)"
   end
 
+  test "formats wheel types with optional suffixes" do
+    wheel_types = [
+      {"AeroTurbine19", ~s|Aero Turbine 19" Wheels|},
+      {"Pinwheel18", ~s|Pinwheel 18" Wheels|},
+      {"Slipstream19Carbon", ~s|Slipstream 19" Carbon Wheels|}
+    ]
+
+    for {wheel_type, expected} <- wheel_types do
+      device = HomeAssistant.device(%{@summary | wheel_type: wheel_type}, car_id: 0)
+      assert device.model == "Model 3 (#{expected})"
+    end
+  end
+
   test "device name falls back to car.name when display_name is nil", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -69,6 +69,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
         trim_badging: "P100D",
         wheel_type: "AeroTurbine19",
         spoiler_type: "CarbonFiber",
+        sun_roof_installed: true,
         version: "2026.26.1"
     }
 
@@ -77,7 +78,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     {_topic, decoded} = receive_one_config()
 
     assert decoded["device"]["model"] ==
-             ~s|Model S P100D (Aero Turbine 19" Wheels, Carbon Fiber Spoiler)|
+             ~s|Model S P100D (Aero Turbine 19" Wheels, Carbon Fiber Spoiler, Sunroof)|
 
     assert decoded["device"]["sw_version"] == "2026.26.1"
   end
@@ -89,7 +90,8 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       @summary
       | trim_badging: "Long Range",
         wheel_type: "Induction",
-        spoiler_type: "None"
+        spoiler_type: "None",
+        sun_roof_installed: false
     }
 
     :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -83,6 +83,28 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert decoded["device"]["sw_version"] == "2026.26.1"
   end
 
+  test "falls back to Tesla when the model is unknown", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    summary = %{@summary | model: nil, trim_badging: "FOUNDATION"}
+
+    :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_one_config()
+    assert decoded["device"]["model"] == "Tesla"
+  end
+
+  test "does not prefix Cybertruck with Model", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    summary = %{@summary | model: "Cybertruck", trim_badging: "FOUNDATION"}
+
+    :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_one_config()
+    assert decoded["device"]["model"] == "Cybertruck FOUNDATION"
+  end
+
   test "omits an absent spoiler from the rich model", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -431,7 +431,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     refute_receive _
   end
 
-  test "publishes Home Assistant discovery config on the first summary", %{test: name} do
+  test "publishes Home Assistant discovery config when device metadata changes", %{test: name} do
     {:ok, pid} =
       start_subscriber(name, 0, nil, %{},
         discovery: true,
@@ -440,7 +440,14 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
 
     assert_receive {VehiclesMock, {:subscribe_to_summary, 0}}
 
-    summary = %Summary{healthy: true, display_name: "Foo", model: "3", state: :online}
+    summary = %Summary{
+      healthy: true,
+      display_name: "Foo",
+      model: "3",
+      wheel_type: "AeroTurbine19",
+      state: :online
+    }
+
     send(pid, summary)
 
     # The discovery config messages are emitted synchronously on the first
@@ -452,15 +459,23 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
 
     decoded = Jason.decode!(payload)
     assert Map.has_key?(decoded, "unique_id")
-    assert Map.has_key?(decoded, "device")
+    assert decoded["device"]["model"] == ~s|Model 3 (Aero Turbine 19" Wheels)|
 
     drain_discovery_configs()
 
-    send(pid, %Summary{summary | version: "1"})
+    send(pid, %Summary{summary | speed: 42})
 
-    # No new discovery config should be published on subsequent summaries
+    # Changes unrelated to device metadata do not republish every discovery entity.
     refute_receive {MqttPublisherMock,
                     {:publish, "homeassistant/" <> _, _, [retain: true, qos: 1]}}
+
+    send(pid, %Summary{summary | version: "2026.26.1"})
+
+    assert_receive {MqttPublisherMock,
+                    {:publish, "homeassistant/" <> _, payload, [retain: true, qos: 1]}},
+                   500
+
+    assert Jason.decode!(payload)["device"]["sw_version"] == "2026.26.1"
   end
 
   test "clears discovery configs when discovery is disabled", %{test: name} do

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -445,6 +445,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
       display_name: "Foo",
       model: "3",
       wheel_type: "AeroTurbine19",
+      sun_roof_installed: false,
       state: :online
     }
 
@@ -469,7 +470,18 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     refute_receive {MqttPublisherMock,
                     {:publish, "homeassistant/" <> _, _, [retain: true, qos: 1]}}
 
-    send(pid, %Summary{summary | version: "2026.26.1"})
+    send(pid, %Summary{summary | sun_roof_installed: true})
+
+    assert_receive {MqttPublisherMock,
+                    {:publish, "homeassistant/" <> _, payload, [retain: true, qos: 1]}},
+                   500
+
+    assert Jason.decode!(payload)["device"]["model"] ==
+             ~s|Model 3 (Aero Turbine 19" Wheels, Sunroof)|
+
+    drain_discovery_configs()
+
+    send(pid, %Summary{summary | sun_roof_installed: true, version: "2026.26.1"})
 
     assert_receive {MqttPublisherMock,
                     {:publish, "homeassistant/" <> _, payload, [retain: true, qos: 1]}},

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -447,7 +447,6 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
       model: "3",
       trim_badging: "74D",
       wheel_type: "AeroTurbine19",
-      sun_roof_installed: false,
       state: :online,
       car: %Car{name: "Foo", marketing_name: "LR AWD"}
     }
@@ -470,6 +469,13 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     send(pid, %Summary{summary | speed: 42})
 
     # Changes unrelated to device metadata do not republish every discovery entity.
+    refute_receive {MqttPublisherMock,
+                    {:publish, "homeassistant/" <> _, _, [retain: true, qos: 1]}}
+
+    send(pid, %Summary{summary | sun_roof_installed: false})
+    :sys.get_state(pid)
+
+    # nil and false both omit the sunroof detail, so the rendered device is unchanged.
     refute_receive {MqttPublisherMock,
                     {:publish, "homeassistant/" <> _, _, [retain: true, qos: 1]}}
 

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -52,6 +52,27 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     )
   end
 
+  defp assert_discovery_retry(pid, expected_delay) do
+    state = :sys.get_state(pid)
+
+    assert state.discovery_retry_delay == expected_delay
+    assert is_reference(state.discovery_retry_timer)
+    assert is_reference(state.discovery_retry_token)
+    assert is_integer(Process.read_timer(state.discovery_retry_timer))
+
+    state
+  end
+
+  defp fire_discovery_retry(pid) do
+    state = :sys.get_state(pid)
+
+    assert is_reference(state.discovery_retry_timer)
+    assert is_reference(state.discovery_retry_token)
+    assert is_integer(Process.cancel_timer(state.discovery_retry_timer))
+
+    send(pid, {:retry_discovery, state.discovery_retry_token})
+  end
+
   test "starts before retained topic cleanup completes", %{test: name} do
     vehicles_name = :"vehicles_#{name}"
     {:ok, _pid} = start_supervised({VehiclesMock, name: vehicles_name, pid: self()})
@@ -509,6 +530,71 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
                    500
 
     assert Jason.decode!(payload)["device"]["sw_version"] == "2026.26.1"
+  end
+
+  @tag :capture_log
+  test "backs off failed discovery publishes and retries the latest metadata", %{test: name} do
+    topic = "homeassistant/sensor/teslamate_0/display_name/config"
+    error = {:error, :disconnected}
+    responses = %{topic => List.duplicate(error, 7) ++ [:ok, error]}
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        {:ok, pid} = start_subscriber(name, 0, nil, responses, discovery: true)
+
+        assert_receive {VehiclesMock, {:subscribe_to_summary, 0}}
+
+        summary = %Summary{healthy: true, display_name: "Foo", model: "3", state: :online}
+        send(pid, summary)
+
+        assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
+
+        state = assert_discovery_retry(pid, :timer.seconds(5))
+        assert state.discovery_pending_summary == summary
+        assert state.discovery_pending_device.model == "Model 3"
+
+        send(pid, %Summary{summary | version: "2026.1"})
+        latest = %Summary{summary | version: "2026.2"}
+        send(pid, latest)
+
+        state = :sys.get_state(pid)
+        assert state.discovery_pending_summary == latest
+        assert state.discovery_pending_device.sw_version == "2026.2"
+        assert state.discovery_retry_delay == :timer.seconds(5)
+
+        refute_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
+
+        for expected_delay <- [10, 20, 40, 80, 160, 300] do
+          fire_discovery_retry(pid)
+          assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
+          assert_discovery_retry(pid, :timer.seconds(expected_delay))
+        end
+
+        fire_discovery_retry(pid)
+        assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
+
+        state = :sys.get_state(pid)
+        assert state.discovery_device.sw_version == "2026.2"
+        assert state.discovery_pending_summary == nil
+        assert state.discovery_pending_device == nil
+        assert state.discovery_retry_delay == nil
+        assert state.discovery_retry_timer == nil
+        assert state.discovery_retry_token == nil
+
+        drain_discovery_configs()
+
+        send(pid, %Summary{latest | speed: 42})
+        :sys.get_state(pid)
+        refute_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
+
+        send(pid, %Summary{latest | version: "2026.3"})
+        assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
+        assert_discovery_retry(pid, :timer.seconds(5))
+      end)
+
+    assert length(Regex.scan(~r/MQTT HA discovery publishing failed/, log)) == 8
+    assert log =~ "retrying in 5s"
+    assert log =~ "retrying in 300s"
   end
 
   test "clears discovery configs when discovery is disabled", %{test: name} do

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -6,6 +6,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
   alias TeslaMate.Mqtt.PubSub.VehicleSubscriber
   alias TeslaMate.Vehicles.Vehicle.Summary
   alias TeslaMate.Locations.GeoFence
+  alias TeslaMate.Log.Car
 
   defmodule BlockingPublisher do
     def publish(test_pid, topic, message, opts) do
@@ -444,9 +445,11 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
       healthy: true,
       display_name: "Foo",
       model: "3",
+      trim_badging: "74D",
       wheel_type: "AeroTurbine19",
       sun_roof_installed: false,
-      state: :online
+      state: :online,
+      car: %Car{name: "Foo", marketing_name: "LR AWD"}
     }
 
     send(pid, summary)
@@ -460,7 +463,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
 
     decoded = Jason.decode!(payload)
     assert Map.has_key?(decoded, "unique_id")
-    assert decoded["device"]["model"] == ~s|Model 3 (Aero Turbine 19" Wheels)|
+    assert decoded["device"]["model"] == ~s|Model 3 LR AWD (Aero Turbine 19" Wheels)|
 
     drain_discovery_configs()
 
@@ -470,6 +473,18 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     refute_receive {MqttPublisherMock,
                     {:publish, "homeassistant/" <> _, _, [retain: true, qos: 1]}}
 
+    car = %{summary.car | marketing_name: "Performance"}
+    send(pid, %Summary{summary | car: car})
+
+    assert_receive {MqttPublisherMock,
+                    {:publish, "homeassistant/" <> _, payload, [retain: true, qos: 1]}},
+                   500
+
+    assert Jason.decode!(payload)["device"]["model"] ==
+             ~s|Model 3 Performance (Aero Turbine 19" Wheels)|
+
+    drain_discovery_configs()
+
     send(pid, %Summary{summary | sun_roof_installed: true})
 
     assert_receive {MqttPublisherMock,
@@ -477,7 +492,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
                    500
 
     assert Jason.decode!(payload)["device"]["model"] ==
-             ~s|Model 3 (Aero Turbine 19" Wheels, Sunroof)|
+             ~s|Model 3 LR AWD (Aero Turbine 19" Wheels, Sunroof)|
 
     drain_discovery_configs()
 


### PR DESCRIPTION
## Summary

- Add detailed vehicle model metadata including trim, wheel type, and spoiler information.
- Publish firmware version as the Home Assistant device software version.
- Republish discovery configuration only when device metadata changes.
- Add coverage for formatted metadata, omitted spoiler details, and metadata-triggered discovery updates.

## Testing

- Added and updated Home Assistant and vehicle subscriber tests covering the new behavior.

Resolves #5612 