### PR TITLE
feat(mqtt): migrate Home Assistant discovery to device-based configuration

### DIFF
--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -14,6 +14,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   alias TeslaMate.Log.Car
 
   @discovery_prefix "homeassistant"
+  @migration_delay :timer.seconds(1)
   @migration_payload Jason.encode!(%{migrate_discovery: true})
   @node "teslamate"
   @version Mix.Project.config()[:version]
@@ -46,15 +47,16 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   discovery config and then clears the old retained configs.
 
   Publishing stops at the first error. Every legacy migration marker must be
-  published successfully before the device config is published, and legacy
-  cleanup starts only after the device config succeeds. Retrying safely
-  restarts the sequence.
+  published successfully before waiting one second for Home Assistant to
+  process the markers and publishing the device config. Legacy cleanup starts
+  only after the device config succeeds. Retrying safely restarts the sequence.
   """
   @spec migrate(term(), publish_opts(), term()) :: :ok | {:error, term()}
   def migrate(%Summary{} = summary, opts, publisher) do
     {prefix, node, device_payload} = discovery_config(summary, opts)
 
     with :ok <- publish_legacy_configs(prefix, node, @migration_payload, publisher),
+         :ok <- Process.sleep(@migration_delay),
          :ok <- publish_device_config(prefix, node, device_payload, publisher) do
       publish_legacy_configs(prefix, node, "", publisher)
     end

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -23,7 +23,8 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
           car_id: pos_integer(),
           namespace: String.t() | nil,
           base_url: String.t() | nil,
-          discovery_prefix: String.t()
+          discovery_prefix: String.t(),
+          migration_delay: non_neg_integer()
         ]
 
   @doc """
@@ -54,9 +55,10 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   @spec migrate(term(), publish_opts(), term()) :: :ok | {:error, term()}
   def migrate(%Summary{} = summary, opts, publisher) do
     {prefix, node, device_payload} = discovery_config(summary, opts)
+    migration_delay = Keyword.get(opts, :migration_delay, @migration_delay)
 
     with :ok <- publish_legacy_configs(prefix, node, @migration_payload, publisher),
-         :ok <- Process.sleep(@migration_delay),
+         :ok <- Process.sleep(migration_delay),
          :ok <- publish_device_config(prefix, node, device_payload, publisher) do
       publish_legacy_configs(prefix, node, "", publisher)
     end

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -26,22 +26,41 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
         ]
 
   @doc """
-  Migrates any existing single-component discovery configs, publishes a device
-  discovery configuration payload containing every entity derived from the
-  given vehicle summary, and then clears the old retained configs.
+  Publishes a device discovery configuration payload containing every entity
+  derived from the given vehicle summary.
 
   The payload is published retained (QoS 1) to
   `<discovery_prefix>/device/<node>/config` where `node` is
   `#{@node}_<car_id>` (with the `MQTT_NAMESPACE` inserted after `#{@node}` when
   set). Returns `:ok` on success.
+  """
+  @spec publish(term(), publish_opts(), term()) :: :ok | {:error, term()}
+  def publish(%Summary{} = summary, opts, publisher) do
+    {prefix, node, device_payload} = discovery_config(summary, opts)
+
+    publish_device_config(prefix, node, device_payload, publisher)
+  end
+
+  @doc """
+  Migrates any existing single-component discovery configs to a device
+  discovery config and then clears the old retained configs.
 
   Publishing stops at the first error. Every legacy migration marker must be
   published successfully before the device config is published, and legacy
   cleanup starts only after the device config succeeds. Retrying safely
   restarts the sequence.
   """
-  @spec publish(term(), publish_opts(), term()) :: :ok | {:error, term()}
-  def publish(%Summary{} = summary, opts, publisher) do
+  @spec migrate(term(), publish_opts(), term()) :: :ok | {:error, term()}
+  def migrate(%Summary{} = summary, opts, publisher) do
+    {prefix, node, device_payload} = discovery_config(summary, opts)
+
+    with :ok <- publish_legacy_configs(prefix, node, @migration_payload, publisher),
+         :ok <- publish_device_config(prefix, node, device_payload, publisher) do
+      publish_legacy_configs(prefix, node, "", publisher)
+    end
+  end
+
+  defp discovery_config(%Summary{} = summary, opts) do
     car_id = Keyword.fetch!(opts, :car_id)
     namespace = Keyword.get(opts, :namespace)
     prefix = Keyword.get(opts, :discovery_prefix, @discovery_prefix)
@@ -65,15 +84,15 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       }
       |> Jason.encode!()
 
-    with :ok <- publish_legacy_configs(prefix, node, @migration_payload, publisher),
-         :ok <-
-           call(publisher, :publish, [
-             device_discovery_topic(prefix, node),
-             device_payload,
-             [retain: true, qos: 1]
-           ]) do
-      publish_legacy_configs(prefix, node, "", publisher)
-    end
+    {prefix, node, device_payload}
+  end
+
+  defp publish_device_config(prefix, node, payload, publisher) do
+    call(publisher, :publish, [
+      device_discovery_topic(prefix, node),
+      payload,
+      [retain: true, qos: 1]
+    ])
   end
 
   @doc """

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -34,6 +34,11 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   `<discovery_prefix>/device/<node>/config` where `node` is
   `#{@node}_<car_id>` (with the `MQTT_NAMESPACE` inserted after `#{@node}` when
   set). Returns `:ok` on success.
+
+  Publishing stops at the first error. Every legacy migration marker must be
+  published successfully before the device config is published, and legacy
+  cleanup starts only after the device config succeeds. Retrying safely
+  restarts the sequence.
   """
   @spec publish(term(), publish_opts(), term()) :: :ok | {:error, term()}
   def publish(%Summary{} = summary, opts, publisher) do

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -14,6 +14,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   alias TeslaMate.Log.Car
 
   @discovery_prefix "homeassistant"
+  @migration_payload Jason.encode!(%{migrate_discovery: true})
   @node "teslamate"
   @version Mix.Project.config()[:version]
 
@@ -25,8 +26,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
         ]
 
   @doc """
-  Publishes a device discovery configuration payload containing every entity
-  derived from the given vehicle summary.
+  Migrates any existing single-component discovery configs, publishes a device
+  discovery configuration payload containing every entity derived from the
+  given vehicle summary, and then clears the old retained configs.
 
   The payload is published retained (QoS 1) to
   `<discovery_prefix>/device/<node>/config` where `node` is
@@ -50,7 +52,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
         |> then(&{object_id, &1})
       end)
 
-    payload =
+    device_payload =
       %{
         components: components,
         device: device(summary, opts),
@@ -58,7 +60,15 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       }
       |> Jason.encode!()
 
-    call(publisher, :publish, [discovery_topic(prefix, node), payload, [retain: true, qos: 1]])
+    with :ok <- publish_legacy_configs(prefix, node, @migration_payload, publisher),
+         :ok <-
+           call(publisher, :publish, [
+             device_discovery_topic(prefix, node),
+             device_payload,
+             [retain: true, qos: 1]
+           ]) do
+      publish_legacy_configs(prefix, node, "", publisher)
+    end
   end
 
   @doc """
@@ -84,9 +94,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   end
 
   @doc """
-  Publishes an empty retained payload to clear a vehicle's device discovery
-  topic, so its entities are removed from Home Assistant when discovery is
-  disabled or the vehicle is removed.
+  Publishes empty retained payloads to clear a vehicle's device discovery topic
+  and any legacy single-component topics, so its entities are removed from Home
+  Assistant when discovery is disabled or the vehicle is removed.
   """
   @spec clear(pos_integer(), publish_opts(), term()) :: :ok | {:error, term()}
   def clear(car_id, opts, publisher) do
@@ -94,11 +104,33 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
     prefix = Keyword.get(opts, :discovery_prefix, @discovery_prefix)
     node = node(car_id, namespace)
 
-    call(publisher, :publish, [discovery_topic(prefix, node), "", [retain: true, qos: 1]])
+    with :ok <-
+           call(publisher, :publish, [
+             device_discovery_topic(prefix, node),
+             "",
+             [retain: true, qos: 1]
+           ]) do
+      publish_legacy_configs(prefix, node, "", publisher)
+    end
   end
 
-  defp discovery_topic(prefix, node) do
+  defp publish_legacy_configs(prefix, node, payload, publisher) do
+    Enum.reduce_while(entities(), :ok, fn {component, object_id, _config}, _acc ->
+      topic = component_discovery_topic(prefix, component, node, object_id)
+
+      case call(publisher, :publish, [topic, payload, [retain: true, qos: 1]]) do
+        :ok -> {:cont, :ok}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp device_discovery_topic(prefix, node) do
     Enum.join([prefix, "device", node, "config"], "/")
+  end
+
+  defp component_discovery_topic(prefix, component, node, object_id) do
+    Enum.join([prefix, component, node, object_id, "config"], "/")
   end
 
   defp origin do

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -1,8 +1,8 @@
 defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   @moduledoc """
-  Publishes Home Assistant MQTT discovery configuration payloads, one per
-  vehicle entity, so users can opt out of manually configuring the MQTT
-  sensors in `configuration.yaml`.
+  Publishes Home Assistant MQTT device discovery configuration payloads, one
+  per vehicle, so users can opt out of manually configuring the MQTT sensors
+  in `configuration.yaml`.
 
   See: https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
   """
@@ -15,6 +15,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
   @discovery_prefix "homeassistant"
   @node "teslamate"
+  @version Mix.Project.config()[:version]
 
   @type publish_opts :: [
           car_id: pos_integer(),
@@ -24,13 +25,13 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
         ]
 
   @doc """
-  Publishes discovery configuration payloads for every entity derived from
-  the given vehicle summary.
+  Publishes a device discovery configuration payload containing every entity
+  derived from the given vehicle summary.
 
-  Each payload is published retained (QoS 1) to
-  `<discovery_prefix>/<component>/<node>/<object_id>/config` where `node` is
-  `#{@node}_<car_id>` (with the `MQTT_NAMESPACE` inserted after `#{@node}`
-  when set). Returns `:ok` on success.
+  The payload is published retained (QoS 1) to
+  `<discovery_prefix>/device/<node>/config` where `node` is
+  `#{@node}_<car_id>` (with the `MQTT_NAMESPACE` inserted after `#{@node}` when
+  set). Returns `:ok` on success.
   """
   @spec publish(term(), publish_opts(), term()) :: :ok | {:error, term()}
   def publish(%Summary{} = summary, opts, publisher) do
@@ -39,28 +40,29 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
     prefix = Keyword.get(opts, :discovery_prefix, @discovery_prefix)
     node = node(car_id, namespace)
 
-    device = device(summary, opts)
-
-    Enum.reduce_while(entities(), :ok, fn {component, object_id, config}, _acc ->
-      topic = discovery_topic(prefix, component, node, object_id)
-
-      payload =
+    components =
+      Map.new(entities(), fn {component, object_id, config} ->
         config
         |> resolve_topics(car_id, namespace)
+        |> Map.put(:platform, component)
         |> Map.put(:unique_id, "#{node}_#{object_id}")
         |> Map.put(:object_id, "tesla_#{object_id}")
-        |> Map.put(:device, device)
-        |> Jason.encode!()
+        |> then(&{object_id, &1})
+      end)
 
-      case call(publisher, :publish, [topic, payload, [retain: true, qos: 1]]) do
-        :ok -> {:cont, :ok}
-        {:error, _} = error -> {:halt, error}
-      end
-    end)
+    payload =
+      %{
+        components: components,
+        device: device(summary, opts),
+        origin: origin()
+      }
+      |> Jason.encode!()
+
+    call(publisher, :publish, [discovery_topic(prefix, node), payload, [retain: true, qos: 1]])
   end
 
   @doc """
-  Builds the Home Assistant device metadata rendered into each discovery
+  Builds the Home Assistant device metadata rendered into the discovery
   configuration payload.
   """
   @spec device(Summary.t(), publish_opts()) :: map()
@@ -82,9 +84,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   end
 
   @doc """
-  Publishes an empty retained payload to clear a discovery topic, so entities
-  are removed from Home Assistant when discovery is disabled or a vehicle is
-  removed.
+  Publishes an empty retained payload to clear a vehicle's device discovery
+  topic, so its entities are removed from Home Assistant when discovery is
+  disabled or the vehicle is removed.
   """
   @spec clear(pos_integer(), publish_opts(), term()) :: :ok | {:error, term()}
   def clear(car_id, opts, publisher) do
@@ -92,18 +94,19 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
     prefix = Keyword.get(opts, :discovery_prefix, @discovery_prefix)
     node = node(car_id, namespace)
 
-    Enum.reduce_while(entities(), :ok, fn {component, object_id, _config}, _acc ->
-      topic = discovery_topic(prefix, component, node, object_id)
-
-      case call(publisher, :publish, [topic, "", [retain: true, qos: 1]]) do
-        :ok -> {:cont, :ok}
-        {:error, _} = error -> {:halt, error}
-      end
-    end)
+    call(publisher, :publish, [discovery_topic(prefix, node), "", [retain: true, qos: 1]])
   end
 
-  defp discovery_topic(prefix, component, node, object_id) do
-    Enum.join([prefix, component, node, object_id, "config"], "/")
+  defp discovery_topic(prefix, node) do
+    Enum.join([prefix, "device", node, "config"], "/")
+  end
+
+  defp origin do
+    %{
+      name: "TeslaMate",
+      sw_version: @version,
+      support_url: "https://docs.teslamate.org/"
+    }
   end
 
   defp resolve_topics(config, car_id, namespace) do

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -190,6 +190,14 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
     end
   end
 
+  defp publish_discovery(
+         %Summary{} = summary,
+         opts,
+         %State{discovery_device: nil, deps: deps}
+       ) do
+    HomeAssistant.migrate(summary, opts, deps.publisher)
+  end
+
   defp publish_discovery(%Summary{} = summary, opts, %State{deps: deps}) do
     HomeAssistant.publish(summary, opts, deps.publisher)
   end

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -20,6 +20,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
     :discovery,
     :discovery_base_url,
     :discovery_prefix,
+    :migration_delay,
     :discovery_device,
     :discovery_pending_summary,
     :discovery_pending_device,
@@ -78,6 +79,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
     discovery = Keyword.get(opts, :discovery, false)
     discovery_base_url = Keyword.get(opts, :discovery_base_url)
     discovery_prefix = Keyword.get(opts, :discovery_prefix)
+    migration_delay = Keyword.get(opts, :migration_delay)
 
     :ok = call(deps.vehicles, :subscribe_to_summary, [car_id])
 
@@ -88,7 +90,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
        deps: deps,
        discovery: discovery,
        discovery_base_url: discovery_base_url,
-       discovery_prefix: discovery_prefix
+       discovery_prefix: discovery_prefix,
+       migration_delay: migration_delay
      }, {:continue, :clear_retained}}
   end
 
@@ -245,7 +248,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
       car_id: state.car_id,
       namespace: state.namespace,
       base_url: state.discovery_base_url,
-      discovery_prefix: state.discovery_prefix
+      discovery_prefix: state.discovery_prefix,
+      migration_delay: state.migration_delay
     ]
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
   end

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -5,6 +5,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
   alias TeslaMate.Vehicles.Vehicle.Summary
   alias TeslaMate.Log.Car
 
+  @migration_delay :timer.seconds(1)
   @migration_payload Jason.encode!(%{migrate_discovery: true})
 
   defp start_publisher(name, responses \\ %{}) do
@@ -32,7 +33,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     publisher_name = start_publisher(name)
 
     opts = [car_id: 0, namespace: nil, base_url: "https://teslamate.example.com/"]
+    started_at = System.monotonic_time(:millisecond)
     :ok = HomeAssistant.migrate(@summary, opts, {MqttPublisherMock, publisher_name})
+    assert System.monotonic_time(:millisecond) - started_at >= @migration_delay
 
     messages = receive_configs()
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -5,8 +5,10 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
   alias TeslaMate.Vehicles.Vehicle.Summary
   alias TeslaMate.Log.Car
 
-  @migration_delay :timer.seconds(1)
+  @migration_delay 10
   @migration_payload Jason.encode!(%{migrate_discovery: true})
+
+  defp migration_opts(opts), do: Keyword.put(opts, :migration_delay, @migration_delay)
 
   defp start_publisher(name, responses \\ %{}) do
     publisher_name = :"mqtt_publisher_#{name}"
@@ -32,7 +34,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
   test "migrates legacy configs around one device config containing every entity", %{test: name} do
     publisher_name = start_publisher(name)
 
-    opts = [car_id: 0, namespace: nil, base_url: "https://teslamate.example.com/"]
+    opts =
+      migration_opts(car_id: 0, namespace: nil, base_url: "https://teslamate.example.com/")
+
     started_at = System.monotonic_time(:millisecond)
     :ok = HomeAssistant.migrate(@summary, opts, {MqttPublisherMock, publisher_name})
     assert System.monotonic_time(:millisecond) - started_at >= @migration_delay
@@ -224,7 +228,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     :ok =
       HomeAssistant.migrate(
         @summary,
-        [car_id: 0, namespace: "ns1"],
+        migration_opts(car_id: 0, namespace: "ns1"),
         {MqttPublisherMock, publisher_name}
       )
 
@@ -333,7 +337,11 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     publisher_name = start_publisher(name, %{legacy_topic => [{:error, :disconnected}]})
 
     assert {:error, :disconnected} =
-             HomeAssistant.migrate(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+             HomeAssistant.migrate(
+               @summary,
+               migration_opts(car_id: 0),
+               {MqttPublisherMock, publisher_name}
+             )
 
     assert [{^legacy_topic, @migration_payload, [retain: true, qos: 1]}] = receive_configs()
   end
@@ -343,7 +351,11 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     publisher_name = start_publisher(name, %{device_topic => [{:error, :disconnected}]})
 
     assert {:error, :disconnected} =
-             HomeAssistant.migrate(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+             HomeAssistant.migrate(
+               @summary,
+               migration_opts(car_id: 0),
+               {MqttPublisherMock, publisher_name}
+             )
 
     messages = receive_configs()
     assert {^device_topic, _payload, [retain: true, qos: 1]} = List.last(messages)
@@ -360,7 +372,11 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       start_publisher(name, %{legacy_topic => [:ok, {:error, :disconnected}]})
 
     assert {:error, :disconnected} =
-             HomeAssistant.migrate(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+             HomeAssistant.migrate(
+               @summary,
+               migration_opts(car_id: 0),
+               {MqttPublisherMock, publisher_name}
+             )
 
     messages = receive_configs()
     assert {^legacy_topic, "", [retain: true, qos: 1]} = List.last(messages)

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -24,40 +24,36 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     car: %Car{id: 0, name: "Tesla Model 3", model: "3"}
   }
 
-  test "publishes a discovery config per entity", %{test: name} do
+  test "publishes one device discovery config containing every entity", %{test: name} do
     publisher_name = start_publisher(name)
 
     opts = [car_id: 0, namespace: nil, base_url: "https://teslamate.example.com/"]
     :ok = HomeAssistant.publish(@summary, opts, {MqttPublisherMock, publisher_name})
 
-    # Collect every config topic published within a short window
-    {topics, payloads} =
-      for _ <- 1..200,
-          reduce: {MapSet.new(), []} do
-        {topics, payloads} ->
-          receive do
-            {MqttPublisherMock,
-             {:publish, "homeassistant/" <> _ = topic, payload, [retain: true, qos: 1]}} ->
-              {MapSet.put(topics, topic), [Jason.decode!(payload) | payloads]}
-          after
-            0 -> {topics, payloads}
-          end
-      end
+    {topic, decoded} = receive_device_config()
+    assert topic == "homeassistant/device/teslamate_0/config"
 
-    topics_count = MapSet.size(topics)
-    assert topics_count > 0
-    assert topics_count == length(payloads)
+    components = decoded["components"]
+    assert map_size(components) > 1
 
-    for decoded <- payloads do
-      assert Map.has_key?(decoded, "unique_id")
-      assert Map.has_key?(decoded, "object_id")
-      device = decoded["device"]
-      assert device["identifiers"] == ["teslamate_car_0"]
-      assert device["manufacturer"] == "Tesla"
-      assert device["configuration_url"] == "https://teslamate.example.com/"
-      assert device["model"] == "Model 3"
-      refute Map.has_key?(device, "sw_version")
+    for config <- Map.values(components) do
+      assert Map.has_key?(config, "platform")
+      assert Map.has_key?(config, "unique_id")
+      assert Map.has_key?(config, "object_id")
     end
+
+    device = decoded["device"]
+    assert device["identifiers"] == ["teslamate_car_0"]
+    assert device["manufacturer"] == "Tesla"
+    assert device["configuration_url"] == "https://teslamate.example.com/"
+    assert device["model"] == "Model 3"
+    refute Map.has_key?(device, "sw_version")
+
+    assert decoded["origin"]["name"] == "TeslaMate"
+    assert is_binary(decoded["origin"]["sw_version"])
+    assert decoded["origin"]["support_url"] == "https://docs.teslamate.org/"
+
+    refute_receive {MqttPublisherMock, {:publish, "homeassistant/" <> _, _, _}}
   end
 
   test "publishes rich model and firmware metadata", %{test: name} do
@@ -77,7 +73,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
-    {_topic, decoded} = receive_one_config()
+    {_topic, decoded} = receive_device_config()
 
     assert decoded["device"]["model"] ==
              ~s|Model S LR AWD (Aero Turbine 19" Wheels, Carbon Fiber Spoiler, Sunroof)|
@@ -92,7 +88,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
-    {_topic, decoded} = receive_one_config()
+    {_topic, decoded} = receive_device_config()
     assert decoded["device"]["model"] == "Model 3 74D"
   end
 
@@ -103,7 +99,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
-    {_topic, decoded} = receive_one_config()
+    {_topic, decoded} = receive_device_config()
     assert decoded["device"]["model"] == "Tesla"
   end
 
@@ -114,7 +110,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
-    {_topic, decoded} = receive_one_config()
+    {_topic, decoded} = receive_device_config()
     assert decoded["device"]["model"] == "Cybertruck FOUNDATION"
   end
 
@@ -131,7 +127,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
-    {_topic, decoded} = receive_one_config()
+    {_topic, decoded} = receive_device_config()
     assert decoded["device"]["model"] == "Model 3 Long Range (Induction Wheels)"
   end
 
@@ -155,7 +151,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
-    {_topic, decoded} = receive_one_config()
+    {_topic, decoded} = receive_device_config()
     assert decoded["device"]["name"] == "Tesla Model 3"
   end
 
@@ -167,7 +163,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
-    {_topic, decoded} = receive_one_config()
+    {_topic, decoded} = receive_device_config()
     assert decoded["device"]["name"] == "Tesla #0"
   end
 
@@ -182,12 +178,11 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       )
 
     assert_receive {MqttPublisherMock,
-                    {:publish, "custom_prefix/" <> _ = topic, _payload, [retain: true, qos: 1]}}
-
-    assert String.starts_with?(topic, "custom_prefix/")
+                    {:publish, "custom_prefix/device/teslamate_0/config", _payload,
+                     [retain: true, qos: 1]}}
   end
 
-  test "scopes node, unique_id and device by namespace", %{test: name} do
+  test "scopes device topic, unique_id and device by namespace", %{test: name} do
     publisher_name = start_publisher(name)
 
     :ok =
@@ -197,16 +192,17 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
         {MqttPublisherMock, publisher_name}
       )
 
-    find_config("homeassistant/sensor/teslamate_ns1_0/speed/config", fn decoded ->
-      assert decoded["object_id"] == "tesla_speed"
-      assert decoded["unique_id"] == "teslamate_ns1_0_speed"
-      assert decoded["state_topic"] == "teslamate/ns1/cars/0/speed"
-      assert decoded["device"]["identifiers"] == ["teslamate_ns1_car_0"]
-    end)
+    {topic, decoded} = receive_device_config()
+    assert topic == "homeassistant/device/teslamate_ns1_0/config"
 
-    find_config("homeassistant/sensor/teslamate_ns1_0/display_name/config", fn decoded ->
-      assert decoded["unique_id"] == "teslamate_ns1_0_display_name"
-    end)
+    speed = decoded["components"]["speed"]
+    assert speed["object_id"] == "tesla_speed"
+    assert speed["unique_id"] == "teslamate_ns1_0_speed"
+    assert speed["state_topic"] == "teslamate/ns1/cars/0/speed"
+    assert decoded["device"]["identifiers"] == ["teslamate_ns1_car_0"]
+
+    assert decoded["components"]["display_name"]["unique_id"] ==
+             "teslamate_ns1_0_display_name"
   end
 
   test "locked binary sensor is inverted", %{test: name} do
@@ -214,12 +210,13 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
-    find_config("homeassistant/binary_sensor/teslamate_0/locked/config", fn decoded ->
-      assert decoded["payload_on"] == "false"
-      assert decoded["payload_off"] == "true"
-      assert decoded["device_class"] == "lock"
-      assert decoded["state_topic"] == "teslamate/cars/0/locked"
-    end)
+    {_topic, decoded} = receive_device_config()
+    config = decoded["components"]["locked"]
+    assert config["platform"] == "binary_sensor"
+    assert config["payload_on"] == "false"
+    assert config["payload_off"] == "true"
+    assert config["device_class"] == "lock"
+    assert config["state_topic"] == "teslamate/cars/0/locked"
   end
 
   test "active route sensors include availability and template", %{test: name} do
@@ -227,11 +224,11 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
-    find_config("homeassistant/sensor/teslamate_0/active_route_destination/config", fn decoded ->
-      assert decoded["state_topic"] == "teslamate/cars/0/active_route"
-      assert String.contains?(decoded["value_template"], "value_json.destination")
-      assert %{"topic" => "teslamate/cars/0/active_route"} = decoded["availability"]
-    end)
+    {_topic, decoded} = receive_device_config()
+    config = decoded["components"]["active_route_destination"]
+    assert config["state_topic"] == "teslamate/cars/0/active_route"
+    assert String.contains?(config["value_template"], "value_json.destination")
+    assert %{"topic" => "teslamate/cars/0/active_route"} = config["availability"]
   end
 
   test "psi sensor derives value from the bar topic", %{test: name} do
@@ -239,11 +236,11 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
-    find_config("homeassistant/sensor/teslamate_0/tpms_pressure_fl_psi/config", fn decoded ->
-      assert decoded["state_topic"] == "teslamate/cars/0/tpms_pressure_fl"
-      assert decoded["unit_of_measurement"] == "psi"
-      assert String.contains?(decoded["value_template"], "14.50377")
-    end)
+    {_topic, decoded} = receive_device_config()
+    config = decoded["components"]["tpms_pressure_fl_psi"]
+    assert config["state_topic"] == "teslamate/cars/0/tpms_pressure_fl"
+    assert config["unit_of_measurement"] == "psi"
+    assert String.contains?(config["value_template"], "14.50377")
   end
 
   test "entity ids match the manual mqtt_sensors.yaml naming", %{test: name} do
@@ -251,52 +248,39 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
-    find_config("homeassistant/sensor/teslamate_0/speed/config", fn decoded ->
-      assert decoded["object_id"] == "tesla_speed"
-      assert decoded["unique_id"] == "teslamate_0_speed"
-    end)
+    {_topic, decoded} = receive_device_config()
 
-    find_config("homeassistant/sensor/teslamate_0/est_battery_range/config", fn decoded ->
-      assert decoded["object_id"] == "tesla_est_battery_range"
-      assert decoded["unique_id"] == "teslamate_0_est_battery_range"
-    end)
+    assert decoded["components"]["speed"]["object_id"] == "tesla_speed"
+    assert decoded["components"]["speed"]["unique_id"] == "teslamate_0_speed"
 
-    find_config("homeassistant/binary_sensor/teslamate_0/healthy/config", fn decoded ->
-      assert decoded["object_id"] == "tesla_healthy"
-      assert decoded["unique_id"] == "teslamate_0_healthy"
-    end)
+    assert decoded["components"]["est_battery_range"]["object_id"] ==
+             "tesla_est_battery_range"
+
+    assert decoded["components"]["est_battery_range"]["unique_id"] ==
+             "teslamate_0_est_battery_range"
+
+    assert decoded["components"]["healthy"]["object_id"] == "tesla_healthy"
+    assert decoded["components"]["healthy"]["unique_id"] == "teslamate_0_healthy"
   end
 
-  test "clear publishes empty payloads per entity", %{test: name} do
+  test "clear publishes an empty device discovery payload", %{test: name} do
     publisher_name = start_publisher(name)
 
     :ok = HomeAssistant.clear(0, [car_id: 0], {MqttPublisherMock, publisher_name})
 
     assert_receive {MqttPublisherMock,
-                    {:publish, "homeassistant/sensor/teslamate_0/display_name/config", "",
+                    {:publish, "homeassistant/device/teslamate_0/config", "",
                      [retain: true, qos: 1]}}
 
-    assert_receive {MqttPublisherMock,
-                    {:publish, "homeassistant/binary_sensor/teslamate_0/locked/config", "",
-                     [retain: true, qos: 1]}}
+    refute_receive {MqttPublisherMock, {:publish, "homeassistant/" <> _, _, _}}
   end
 
-  defp receive_one_config(timeout \\ 200) do
+  defp receive_device_config(timeout \\ 200) do
     assert_receive {MqttPublisherMock,
-                    {:publish, "homeassistant/" <> _ = topic, payload, [retain: true, qos: 1]}},
+                    {:publish, "homeassistant/device/" <> _ = topic, payload,
+                     [retain: true, qos: 1]}},
                    timeout
 
     {topic, Jason.decode!(payload)}
-  end
-
-  # Drains the mailbox looking for a specific config topic, invoking `fun`
-  # with the decoded payload once found.
-  defp find_config(target, fun, timeout \\ 500) do
-    receive do
-      {MqttPublisherMock, {:publish, ^target, payload, [retain: true, qos: 1]}} ->
-        fun.(Jason.decode!(payload))
-    after
-      timeout -> flunk("Did not receive #{target}")
-    end
   end
 end

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -28,11 +28,11 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     car: %Car{id: 0, name: "Tesla Model 3", model: "3"}
   }
 
-  test "publishes one device discovery config containing every entity", %{test: name} do
+  test "migrates legacy configs around one device config containing every entity", %{test: name} do
     publisher_name = start_publisher(name)
 
     opts = [car_id: 0, namespace: nil, base_url: "https://teslamate.example.com/"]
-    :ok = HomeAssistant.publish(@summary, opts, {MqttPublisherMock, publisher_name})
+    :ok = HomeAssistant.migrate(@summary, opts, {MqttPublisherMock, publisher_name})
 
     messages = receive_configs()
 
@@ -75,6 +75,18 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert decoded["origin"]["name"] == "TeslaMate"
     assert is_binary(decoded["origin"]["sw_version"])
     assert decoded["origin"]["support_url"] == "https://docs.teslamate.org/"
+  end
+
+  test "publishes a device config without touching legacy topics", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok =
+      HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    assert [{topic, payload, publish_opts}] = receive_configs()
+    assert topic == "homeassistant/device/teslamate_0/config"
+    assert publish_opts == [retain: true, qos: 1]
+    assert is_map(Jason.decode!(payload)["components"])
   end
 
   test "publishes rich model and firmware metadata", %{test: name} do
@@ -207,7 +219,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     publisher_name = start_publisher(name)
 
     :ok =
-      HomeAssistant.publish(
+      HomeAssistant.migrate(
         @summary,
         [car_id: 0, namespace: "ns1"],
         {MqttPublisherMock, publisher_name}
@@ -318,7 +330,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     publisher_name = start_publisher(name, %{legacy_topic => [{:error, :disconnected}]})
 
     assert {:error, :disconnected} =
-             HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+             HomeAssistant.migrate(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
     assert [{^legacy_topic, @migration_payload, [retain: true, qos: 1]}] = receive_configs()
   end
@@ -328,7 +340,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     publisher_name = start_publisher(name, %{device_topic => [{:error, :disconnected}]})
 
     assert {:error, :disconnected} =
-             HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+             HomeAssistant.migrate(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
     messages = receive_configs()
     assert {^device_topic, _payload, [retain: true, qos: 1]} = List.last(messages)
@@ -345,7 +357,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       start_publisher(name, %{legacy_topic => [:ok, {:error, :disconnected}]})
 
     assert {:error, :disconnected} =
-             HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+             HomeAssistant.migrate(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
     messages = receive_configs()
     assert {^legacy_topic, "", [retain: true, qos: 1]} = List.last(messages)

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -5,11 +5,15 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
   alias TeslaMate.Vehicles.Vehicle.Summary
   alias TeslaMate.Log.Car
 
-  defp start_publisher(name) do
+  @migration_payload Jason.encode!(%{migrate_discovery: true})
+
+  defp start_publisher(name, responses \\ %{}) do
     publisher_name = :"mqtt_publisher_#{name}"
 
     {:ok, _pid} =
-      start_supervised({MqttPublisherMock, name: publisher_name, pid: self(), responses: %{}})
+      start_supervised(
+        {MqttPublisherMock, name: publisher_name, pid: self(), responses: responses}
+      )
 
     publisher_name
   end
@@ -30,11 +34,30 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     opts = [car_id: 0, namespace: nil, base_url: "https://teslamate.example.com/"]
     :ok = HomeAssistant.publish(@summary, opts, {MqttPublisherMock, publisher_name})
 
-    {topic, decoded} = receive_device_config()
+    messages = receive_configs()
+
+    {migrations, [{topic, payload, publish_opts} | cleanup]} =
+      Enum.split_while(messages, fn {topic, _payload, _opts} ->
+        topic != "homeassistant/device/teslamate_0/config"
+      end)
+
+    assert migrations != []
+
+    assert Enum.all?(
+             migrations,
+             &match?({_topic, @migration_payload, [retain: true, qos: 1]}, &1)
+           )
+
     assert topic == "homeassistant/device/teslamate_0/config"
+    assert publish_opts == [retain: true, qos: 1]
+
+    assert Enum.map(migrations, &elem(&1, 0)) == Enum.map(cleanup, &elem(&1, 0))
+    assert Enum.all?(cleanup, &match?({_topic, "", [retain: true, qos: 1]}, &1))
+
+    decoded = Jason.decode!(payload)
 
     components = decoded["components"]
-    assert map_size(components) > 1
+    assert map_size(components) == length(migrations)
 
     for config <- Map.values(components) do
       assert Map.has_key?(config, "platform")
@@ -52,8 +75,6 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert decoded["origin"]["name"] == "TeslaMate"
     assert is_binary(decoded["origin"]["sw_version"])
     assert decoded["origin"]["support_url"] == "https://docs.teslamate.org/"
-
-    refute_receive {MqttPublisherMock, {:publish, "homeassistant/" <> _, _, _}}
   end
 
   test "publishes rich model and firmware metadata", %{test: name} do
@@ -192,6 +213,10 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
         {MqttPublisherMock, publisher_name}
       )
 
+    assert_receive {MqttPublisherMock,
+                    {:publish, "homeassistant/sensor/teslamate_ns1_0/speed/config",
+                     @migration_payload, [retain: true, qos: 1]}}
+
     {topic, decoded} = receive_device_config()
     assert topic == "homeassistant/device/teslamate_ns1_0/config"
 
@@ -203,6 +228,10 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     assert decoded["components"]["display_name"]["unique_id"] ==
              "teslamate_ns1_0_display_name"
+
+    assert_receive {MqttPublisherMock,
+                    {:publish, "homeassistant/sensor/teslamate_ns1_0/speed/config", "",
+                     [retain: true, qos: 1]}}
   end
 
   test "locked binary sensor is inverted", %{test: name} do
@@ -263,16 +292,67 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert decoded["components"]["healthy"]["unique_id"] == "teslamate_0_healthy"
   end
 
-  test "clear publishes an empty device discovery payload", %{test: name} do
+  test "clear removes device and legacy discovery payloads", %{test: name} do
     publisher_name = start_publisher(name)
 
     :ok = HomeAssistant.clear(0, [car_id: 0], {MqttPublisherMock, publisher_name})
 
-    assert_receive {MqttPublisherMock,
-                    {:publish, "homeassistant/device/teslamate_0/config", "",
-                     [retain: true, qos: 1]}}
+    [{device_topic, "", publish_opts} | legacy_cleanup] = receive_configs()
 
-    refute_receive {MqttPublisherMock, {:publish, "homeassistant/" <> _, _, _}}
+    assert device_topic == "homeassistant/device/teslamate_0/config"
+    assert publish_opts == [retain: true, qos: 1]
+    assert legacy_cleanup != []
+    assert Enum.all?(legacy_cleanup, &match?({_topic, "", [retain: true, qos: 1]}, &1))
+
+    assert Enum.any?(legacy_cleanup, fn {topic, _, _} ->
+             topic == "homeassistant/sensor/teslamate_0/display_name/config"
+           end)
+
+    assert Enum.any?(legacy_cleanup, fn {topic, _, _} ->
+             topic == "homeassistant/binary_sensor/teslamate_0/locked/config"
+           end)
+  end
+
+  test "stops before device discovery when a migration marker fails", %{test: name} do
+    legacy_topic = "homeassistant/sensor/teslamate_0/display_name/config"
+    publisher_name = start_publisher(name, %{legacy_topic => [{:error, :disconnected}]})
+
+    assert {:error, :disconnected} =
+             HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    assert [{^legacy_topic, @migration_payload, [retain: true, qos: 1]}] = receive_configs()
+  end
+
+  test "does not clear legacy topics when device discovery publishing fails", %{test: name} do
+    device_topic = "homeassistant/device/teslamate_0/config"
+    publisher_name = start_publisher(name, %{device_topic => [{:error, :disconnected}]})
+
+    assert {:error, :disconnected} =
+             HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    messages = receive_configs()
+    assert {^device_topic, _payload, [retain: true, qos: 1]} = List.last(messages)
+
+    assert messages
+           |> Enum.drop(-1)
+           |> Enum.all?(&match?({_topic, @migration_payload, [retain: true, qos: 1]}, &1))
+  end
+
+  test "stops legacy cleanup on the first failure", %{test: name} do
+    legacy_topic = "homeassistant/sensor/teslamate_0/display_name/config"
+
+    publisher_name =
+      start_publisher(name, %{legacy_topic => [:ok, {:error, :disconnected}]})
+
+    assert {:error, :disconnected} =
+             HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    messages = receive_configs()
+    assert {^legacy_topic, "", [retain: true, qos: 1]} = List.last(messages)
+
+    assert Enum.count(messages, fn {topic, payload, _opts} ->
+             topic == legacy_topic and payload == @migration_payload
+           end) == 1
   end
 
   defp receive_device_config(timeout \\ 200) do
@@ -282,5 +362,14 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
                    timeout
 
     {topic, Jason.decode!(payload)}
+  end
+
+  defp receive_configs(messages \\ []) do
+    receive do
+      {MqttPublisherMock, {:publish, topic, payload, opts}} ->
+        receive_configs([{topic, payload, opts} | messages])
+    after
+      0 -> Enum.reverse(messages)
+    end
   end
 end

--- a/test/teslamate/mqtt/pubsub/pubsub_test.exs
+++ b/test/teslamate/mqtt/pubsub/pubsub_test.exs
@@ -16,6 +16,9 @@ defmodule TeslaMate.Mqtt.PubSubTest do
     active_topic = "homeassistant/device/teslamate_#{active_car.id}/config"
     removed_topic = "homeassistant/device/teslamate_#{removed_car.id}/config"
 
+    removed_legacy_topic =
+      "homeassistant/sensor/teslamate_#{removed_car.id}/display_name/config"
+
     :ok =
       PubSub.clear_removed_vehicles(vehicles,
         deps_publisher: {MqttPublisherMock, publisher_name}
@@ -26,6 +29,9 @@ defmodule TeslaMate.Mqtt.PubSubTest do
 
     # Removed vehicle's discovery configs are cleared
     assert_receive {MqttPublisherMock, {:publish, ^removed_topic, "", [retain: true, qos: 1]}}
+
+    assert_receive {MqttPublisherMock,
+                    {:publish, ^removed_legacy_topic, "", [retain: true, qos: 1]}}
   end
 
   test "clears discovery configs under the namespace-scoped node", %{test: name} do
@@ -40,6 +46,9 @@ defmodule TeslaMate.Mqtt.PubSubTest do
     removed_topic = "homeassistant/device/teslamate_ns1_#{removed_car.id}/config"
     unscoped_topic = "homeassistant/device/teslamate_#{removed_car.id}/config"
 
+    removed_legacy_topic =
+      "homeassistant/sensor/teslamate_ns1_#{removed_car.id}/display_name/config"
+
     :ok =
       PubSub.clear_removed_vehicles(vehicles,
         namespace: "ns1",
@@ -48,6 +57,10 @@ defmodule TeslaMate.Mqtt.PubSubTest do
 
     # Cleared under the namespace-scoped node only
     assert_receive {MqttPublisherMock, {:publish, ^removed_topic, "", [retain: true, qos: 1]}}
+
+    assert_receive {MqttPublisherMock,
+                    {:publish, ^removed_legacy_topic, "", [retain: true, qos: 1]}}
+
     refute_receive {MqttPublisherMock, {:publish, ^unscoped_topic, _, _}}
   end
 

--- a/test/teslamate/mqtt/pubsub/pubsub_test.exs
+++ b/test/teslamate/mqtt/pubsub/pubsub_test.exs
@@ -13,9 +13,8 @@ defmodule TeslaMate.Mqtt.PubSubTest do
     {:ok, _pid} = start_supervised({MqttPublisherMock, name: publisher_name, pid: self()})
 
     vehicles = [%Summary{car: active_car}]
-    active_topic = "homeassistant/sensor/teslamate_#{active_car.id}/display_name/config"
-    removed_topic = "homeassistant/sensor/teslamate_#{removed_car.id}/display_name/config"
-    removed_locked_topic = "homeassistant/binary_sensor/teslamate_#{removed_car.id}/locked/config"
+    active_topic = "homeassistant/device/teslamate_#{active_car.id}/config"
+    removed_topic = "homeassistant/device/teslamate_#{removed_car.id}/config"
 
     :ok =
       PubSub.clear_removed_vehicles(vehicles,
@@ -27,9 +26,6 @@ defmodule TeslaMate.Mqtt.PubSubTest do
 
     # Removed vehicle's discovery configs are cleared
     assert_receive {MqttPublisherMock, {:publish, ^removed_topic, "", [retain: true, qos: 1]}}
-
-    assert_receive {MqttPublisherMock,
-                    {:publish, ^removed_locked_topic, "", [retain: true, qos: 1]}}
   end
 
   test "clears discovery configs under the namespace-scoped node", %{test: name} do
@@ -41,8 +37,8 @@ defmodule TeslaMate.Mqtt.PubSubTest do
 
     vehicles = [%Summary{car: active_car}]
 
-    removed_topic = "homeassistant/sensor/teslamate_ns1_#{removed_car.id}/display_name/config"
-    unscoped_topic = "homeassistant/sensor/teslamate_#{removed_car.id}/display_name/config"
+    removed_topic = "homeassistant/device/teslamate_ns1_#{removed_car.id}/config"
+    unscoped_topic = "homeassistant/device/teslamate_#{removed_car.id}/config"
 
     :ok =
       PubSub.clear_removed_vehicles(vehicles,

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -513,7 +513,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     assert Jason.decode!(payload)["device"]["model"] ==
              ~s|Model 3 Performance (Aero Turbine 19" Wheels)|
 
-    drain_discovery_configs()
+    refute_receive {MqttPublisherMock, {:publish, "homeassistant/" <> _, _, _}}
 
     send(pid, %Summary{summary | sun_roof_installed: true})
 
@@ -525,7 +525,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     assert Jason.decode!(payload)["device"]["model"] ==
              ~s|Model 3 LR AWD (Aero Turbine 19" Wheels, Sunroof)|
 
-    drain_discovery_configs()
+    refute_receive {MqttPublisherMock, {:publish, "homeassistant/" <> _, _, _}}
 
     send(pid, %Summary{summary | sun_roof_installed: true, version: "2026.26.1"})
 
@@ -535,6 +535,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
                    500
 
     assert Jason.decode!(payload)["device"]["sw_version"] == "2026.26.1"
+    refute_receive {MqttPublisherMock, {:publish, "homeassistant/" <> _, _, _}}
   end
 
   @tag :capture_log
@@ -595,6 +596,16 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
         send(pid, %Summary{latest | version: "2026.3"})
         assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
         assert_discovery_retry(pid, :timer.seconds(5))
+        refute_receive {MqttPublisherMock, {:publish, "homeassistant/" <> _, _, _}}
+
+        fire_discovery_retry(pid)
+        assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
+        refute_receive {MqttPublisherMock, {:publish, "homeassistant/" <> _, _, _}}
+
+        state = :sys.get_state(pid)
+        assert state.discovery_device.sw_version == "2026.3"
+        assert state.discovery_retry_delay == nil
+        assert state.discovery_retry_timer == nil
       end)
 
     assert length(Regex.scan(~r/MQTT HA discovery publishing failed/, log)) == 8

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -474,18 +474,18 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
 
     send(pid, summary)
 
-    # The discovery config messages are emitted synchronously on the first
-    # summary. Wait for and drain them all so they don't carry over to the
-    # refute on the next summary.
+    # The discovery config message is emitted synchronously on the first
+    # summary.
     assert_receive {MqttPublisherMock,
-                    {:publish, "homeassistant/" <> _ = _topic, payload, [retain: true, qos: 1]}},
+                    {:publish, "homeassistant/device/teslamate_0/config", payload,
+                     [retain: true, qos: 1]}},
                    500
 
     decoded = Jason.decode!(payload)
-    assert Map.has_key?(decoded, "unique_id")
+    assert Map.has_key?(decoded, "device")
+    assert Map.has_key?(decoded, "components")
+    assert Map.has_key?(decoded, "origin")
     assert decoded["device"]["model"] == ~s|Model 3 LR AWD (Aero Turbine 19" Wheels)|
-
-    drain_discovery_configs()
 
     send(pid, %Summary{summary | speed: 42})
 
@@ -534,7 +534,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
 
   @tag :capture_log
   test "backs off failed discovery publishes and retries the latest metadata", %{test: name} do
-    topic = "homeassistant/sensor/teslamate_0/display_name/config"
+    topic = "homeassistant/device/teslamate_0/config"
     error = {:error, :disconnected}
     responses = %{topic => List.duplicate(error, 7) ++ [:ok, error]}
 
@@ -605,10 +605,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     # Retained discovery configs are cleared on init so entities are removed
     # from Home Assistant when discovery is disabled.
     assert_receive {MqttPublisherMock,
-                    {:publish, "homeassistant/sensor/teslamate_0/display_name/config", "",
+                    {:publish, "homeassistant/device/teslamate_0/config", "",
                      [retain: true, qos: 1]}}
-
-    drain_discovery_configs()
 
     send(pid, %Summary{healthy: true, display_name: "Foo", state: :online})
 

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -8,6 +8,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
   alias TeslaMate.Locations.GeoFence
   alias TeslaMate.Log.Car
 
+  @migration_publish_timeout :timer.seconds(2)
+
   defmodule BlockingPublisher do
     def publish(test_pid, topic, message, opts) do
       send(test_pid, {__MODULE__, {:publish, topic, message, opts}, self()})
@@ -479,7 +481,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     assert_receive {MqttPublisherMock,
                     {:publish, "homeassistant/device/teslamate_0/config", payload,
                      [retain: true, qos: 1]}},
-                   500
+                   @migration_publish_timeout
 
     decoded = Jason.decode!(payload)
     assert Map.has_key?(decoded, "device")
@@ -553,7 +555,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
         summary = %Summary{healthy: true, display_name: "Foo", model: "3", state: :online}
         send(pid, summary)
 
-        assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
+        assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}},
+                       @migration_publish_timeout
 
         state = assert_discovery_retry(pid, :timer.seconds(5))
         assert state.discovery_pending_summary == summary
@@ -572,12 +575,17 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
 
         for expected_delay <- [10, 20, 40, 80, 160, 300] do
           fire_discovery_retry(pid)
-          assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
+
+          assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}},
+                         @migration_publish_timeout
+
           assert_discovery_retry(pid, :timer.seconds(expected_delay))
         end
 
         fire_discovery_retry(pid)
-        assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
+
+        assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}},
+                       @migration_publish_timeout
 
         state = :sys.get_state(pid)
         assert state.discovery_device.sw_version == "2026.2"
@@ -638,7 +646,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     assert_receive {MqttPublisherMock,
                     {:publish, "homeassistant/device/teslamate_0/config", _payload,
                      [retain: true, qos: 1]}},
-                   500
+                   @migration_publish_timeout
 
     drain_discovery_configs()
   end

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -487,9 +487,11 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     assert Map.has_key?(decoded, "origin")
     assert decoded["device"]["model"] == ~s|Model 3 LR AWD (Aero Turbine 19" Wheels)|
 
+    drain_discovery_configs()
+
     send(pid, %Summary{summary | speed: 42})
 
-    # Changes unrelated to device metadata do not republish every discovery entity.
+    # Changes unrelated to device metadata do not republish discovery.
     refute_receive {MqttPublisherMock,
                     {:publish, "homeassistant/" <> _, _, [retain: true, qos: 1]}}
 
@@ -504,7 +506,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     send(pid, %Summary{summary | car: car})
 
     assert_receive {MqttPublisherMock,
-                    {:publish, "homeassistant/" <> _, payload, [retain: true, qos: 1]}},
+                    {:publish, "homeassistant/device/teslamate_0/config", payload,
+                     [retain: true, qos: 1]}},
                    500
 
     assert Jason.decode!(payload)["device"]["model"] ==
@@ -515,7 +518,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     send(pid, %Summary{summary | sun_roof_installed: true})
 
     assert_receive {MqttPublisherMock,
-                    {:publish, "homeassistant/" <> _, payload, [retain: true, qos: 1]}},
+                    {:publish, "homeassistant/device/teslamate_0/config", payload,
+                     [retain: true, qos: 1]}},
                    500
 
     assert Jason.decode!(payload)["device"]["model"] ==
@@ -526,7 +530,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     send(pid, %Summary{summary | sun_roof_installed: true, version: "2026.26.1"})
 
     assert_receive {MqttPublisherMock,
-                    {:publish, "homeassistant/" <> _, payload, [retain: true, qos: 1]}},
+                    {:publish, "homeassistant/device/teslamate_0/config", payload,
+                     [retain: true, qos: 1]}},
                    500
 
     assert Jason.decode!(payload)["device"]["sw_version"] == "2026.26.1"
@@ -597,6 +602,36 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     assert log =~ "retrying in 300s"
   end
 
+  test "retries Home Assistant discovery after a publishing failure", %{test: name} do
+    legacy_topic = "homeassistant/sensor/teslamate_0/display_name/config"
+
+    {:ok, pid} =
+      start_subscriber(name, 0, nil, %{legacy_topic => [{:error, :disconnected}]},
+        discovery: true
+      )
+
+    assert_receive {VehiclesMock, {:subscribe_to_summary, 0}}
+
+    summary = %Summary{healthy: true, display_name: "Foo", model: "3", state: :online}
+    send(pid, summary)
+
+    assert_receive {MqttPublisherMock,
+                    {:publish, ^legacy_topic, _migration_payload, [retain: true, qos: 1]}}
+
+    refute_receive {MqttPublisherMock,
+                    {:publish, "homeassistant/device/teslamate_0/config", _, _}}
+
+    assert_discovery_retry(pid, :timer.seconds(5))
+    fire_discovery_retry(pid)
+
+    assert_receive {MqttPublisherMock,
+                    {:publish, "homeassistant/device/teslamate_0/config", _payload,
+                     [retain: true, qos: 1]}},
+                   500
+
+    drain_discovery_configs()
+  end
+
   test "clears discovery configs when discovery is disabled", %{test: name} do
     {:ok, pid} = start_subscriber(name, 0)
 
@@ -607,6 +642,8 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     assert_receive {MqttPublisherMock,
                     {:publish, "homeassistant/device/teslamate_0/config", "",
                      [retain: true, qos: 1]}}
+
+    drain_discovery_configs()
 
     send(pid, %Summary{healthy: true, display_name: "Foo", state: :online})
 

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -8,7 +8,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
   alias TeslaMate.Locations.GeoFence
   alias TeslaMate.Log.Car
 
-  @migration_publish_timeout :timer.seconds(2)
+  @migration_delay 10
 
   defmodule BlockingPublisher do
     def publish(test_pid, topic, message, opts) do
@@ -47,6 +47,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
          name: name,
          car_id: car_id,
          namespace: namespace,
+         migration_delay: @migration_delay,
          deps_publisher: {MqttPublisherMock, publisher_name},
          deps_vehicles: {VehiclesMock, vehicles_name}
        ]
@@ -481,7 +482,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     assert_receive {MqttPublisherMock,
                     {:publish, "homeassistant/device/teslamate_0/config", payload,
                      [retain: true, qos: 1]}},
-                   @migration_publish_timeout
+                   500
 
     decoded = Jason.decode!(payload)
     assert Map.has_key?(decoded, "device")
@@ -555,8 +556,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
         summary = %Summary{healthy: true, display_name: "Foo", model: "3", state: :online}
         send(pid, summary)
 
-        assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}},
-                       @migration_publish_timeout
+        assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
 
         state = assert_discovery_retry(pid, :timer.seconds(5))
         assert state.discovery_pending_summary == summary
@@ -576,16 +576,14 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
         for expected_delay <- [10, 20, 40, 80, 160, 300] do
           fire_discovery_retry(pid)
 
-          assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}},
-                         @migration_publish_timeout
+          assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
 
           assert_discovery_retry(pid, :timer.seconds(expected_delay))
         end
 
         fire_discovery_retry(pid)
 
-        assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}},
-                       @migration_publish_timeout
+        assert_receive {MqttPublisherMock, {:publish, ^topic, _payload, _opts}}
 
         state = :sys.get_state(pid)
         assert state.discovery_device.sw_version == "2026.2"
@@ -646,7 +644,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     assert_receive {MqttPublisherMock,
                     {:publish, "homeassistant/device/teslamate_0/config", _payload,
                      [retain: true, qos: 1]}},
-                   @migration_publish_timeout
+                   500
 
     drain_discovery_configs()
   end

--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -35,9 +35,10 @@ Enable it with the following environment variables (see [Environment variables](
 | `MQTT_HOME_ASSISTANT_DISCOVERY_URL`    | TeslaMate URL surfaced in the discovered device panel (e.g. `https://teslamate.example.com/`). | _none_          |
 | `MQTT_HOME_ASSISTANT_DISCOVERY_PREFIX` | Discovery topic prefix. Must match Home Assistant's `discovery_prefix` setting.                | `homeassistant` |
 
-When enabled, TeslaMate publishes a retained `config` payload per entity to
-`<discovery_prefix>/<component>/<node>/<object_id>/config` on the first
-vehicle summary, where `<node>` is `teslamate_<car_id>`. If
+When enabled, TeslaMate publishes one retained device discovery payload per
+vehicle to `<discovery_prefix>/device/<node>/config` on the first vehicle
+summary. The payload contains all of the vehicle's entities, and `<node>` is
+`teslamate_<car_id>`. If
 `MQTT_NAMESPACE` is set, it is inserted after `teslamate_` (e.g.
 `teslamate_<namespace>_<car_id>`), so multiple TeslaMate instances sharing a
 broker do not collide on the same discovery topics. The device is grouped
@@ -59,8 +60,7 @@ tracked, e.g. because they were removed from the Tesla account or because
 logging was disabled, so their entities are removed from Home Assistant.
 
 The discovered entities cover the same set of `teslamate/cars/<id>/...` topics
-as the manual `mqtt_sensors.yaml` below. The list is easy to extend in the
-future, as configs are published per entity.
+as the manual `mqtt_sensors.yaml` below.
 
 :::note
 

--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -45,6 +45,12 @@ broker do not collide on the same discovery topics. The device is grouped
 under the `teslamate_car_<car_id>` identifier (likewise namespace-scoped), and
 the entity IDs match those produced by the manual `mqtt_sensors.yaml` below.
 
+When upgrading from TeslaMate's former per-entity discovery format, TeslaMate
+uses Home Assistant's discovery migration protocol to preserve entity registry
+settings and customizations. It marks the former single-component topics for
+migration, publishes the device discovery payload, and then clears the old
+retained topics.
+
 :::note
 
 The `unique_id`s of the discovered entities match those of the manual


### PR DESCRIPTION
## Summary

- Publish one Home Assistant device discovery payload containing all vehicle entities.
- Preserve entity registry settings by migrating legacy per-entity discovery topics before cleanup.
- Add discovery origin metadata and retain namespace-aware topic behavior.
- Retry discovery publishing after failures instead of marking discovery complete prematurely.
- Update documentation and coverage for migration, cleanup, and retry behavior.

This is an update to align with Home Assistant's [documented preference for Device Discovery over Single Component Discovery](https://www.home-assistant.io/integrations/mqtt/#discovery-messages).