### PR TITLE
ci: purge orphaned GHCR attestation referrers

### DIFF
--- a/.github/workflows/ghcr_purge.yml
+++ b/.github/workflows/ghcr_purge.yml
@@ -58,6 +58,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           delete-tags: "buildcache-arm64-${{ steps.normalize_version.outputs.normalized_version }},buildcache-amd64-${{ steps.normalize_version.outputs.normalized_version }}"
 
+      # Untagged delete also cascades to attached sha256-* referrers (children).
+      # delete-orphaned-images only catches leftovers whose parent is already gone.
       - uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         name: Delete untagged images from ghcr.io
         with:
@@ -65,4 +67,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           delete-untagged: "true"
           delete-ghost-images: "true"
+          delete-orphaned-images: "true"
           older-than: "1 day"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Build, CI, internal
 
+- ci: purge orphaned GHCR attestation referrers (#5622 - @swiffer)
 - build(deps): bump tzdata from 1.1.3 to 1.1.4 (#5614 - @mews-se)
 
 #### Dashboards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 #### Build, CI, internal
 
-- ci: purge orphaned GHCR attestation referrers (#5622 - @swiffer)
 - build(deps): bump tzdata from 1.1.3 to 1.1.4 (#5614 - @mews-se)
+- ci: purge orphaned GHCR attestation referrers (#5622 - @swiffer)
 
 #### Dashboards
 


### PR DESCRIPTION
## Motivation

The `teslamate` GHCR package has far more tagged versions than `teslamate/grafana` (currently ~223 vs ~16). Most of the extra teslamate tags are not product versions.

Since #5380, published images get signed SLSA provenance and SPDX SBOMs with `push-to-registry: true`. That writes OCI referrers onto the same package as `sha256-*` tags. Teslamate is built per-platform and then merged, so each `main` push can add several of those tags (provenance + SBOM per arch, plus manifest-list provenance). Grafana is one multi-arch image and only attests the list, so it stays small.

`:main` is a moving tag. After it moves, the old image becomes untagged and is already eligible for the existing 1-day untagged cleanup. The leftover `sha256-*` referrers stay tagged, so they never get purged. They describe images nobody is told to pull anymore.

The GitHub attestation store (`gh attestation verify --repo teslamate-org/teslamate`) is separate. This PR only cleans GHCR package versions. It does not delete repo attestations.

#5380 intentionally attests merged-to-main (PRs are skipped so unreviewed code cannot look official). This change does not undo that. Current `:main` / `:pr-*` referrers stay because their parent image still exists.

## What this does

Enable `delete-orphaned-images: true` on the existing untagged-cleanup step in `ghcr_purge.yml`. Same action, same packages, same `older-than: 1 day` window.

`dataaxiom/ghcr-cleanup-action` already treats attestation/cosign referrers as children:

1. Load versions and manifests
2. Drop children (platform images, `sha256-*` referrers) from the working set
3. Apply exclude / age filters
4. Stage tagged / ghost / **orphaned** matches
5. Stage **untagged** matches
6. Delete staged versions **including their children**

So one step is enough:

- an untagged parent older than 1 day is deleted, and its attached `sha256-*` referrers cascade with it
- `delete-orphaned-images` only catches referrers whose parent is **already gone** (leftovers from an earlier incomplete cleanup)

No new workflow, no extra action call, no change to how attestations are generated.

## Note

This workflow still only runs when a same-repo PR is closed, and `.github`-only PRs are excluded. Closing this PR will not run the purge. The next qualifying PR close will.