### PR TITLE
fix(grafana): open the TeslaMate header link in a new tab so it works when Grafana and TeslaMate share an origin

### DIFF
--- a/grafana/dashboards/battery-health.json
+++ b/grafana/dashboards/battery-health.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/charge-level.json
+++ b/grafana/dashboards/charge-level.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/charges.json
+++ b/grafana/dashboards/charges.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/charging-stats.json
+++ b/grafana/dashboards/charging-stats.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/database-info.json
+++ b/grafana/dashboards/database-info.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/drive-stats.json
+++ b/grafana/dashboards/drive-stats.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/drives.json
+++ b/grafana/dashboards/drives.json
@@ -28,6 +28,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/efficiency.json
+++ b/grafana/dashboards/efficiency.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/internal/charge-details.json
+++ b/grafana/dashboards/internal/charge-details.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/internal/drive-details.json
+++ b/grafana/dashboards/internal/drive-details.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/locations.json
+++ b/grafana/dashboards/locations.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/mileage.json
+++ b/grafana/dashboards/mileage.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/overview.json
+++ b/grafana/dashboards/overview.json
@@ -29,6 +29,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/projected-range.json
+++ b/grafana/dashboards/projected-range.json
@@ -37,6 +37,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/reports/dutch-tax.json
+++ b/grafana/dashboards/reports/dutch-tax.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/states.json
+++ b/grafana/dashboards/states.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/statistics.json
+++ b/grafana/dashboards/statistics.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "type": "link",
       "url": "${base_url:raw}"

--- a/grafana/dashboards/timeline.json
+++ b/grafana/dashboards/timeline.json
@@ -25,7 +25,7 @@
       "includeVars": false,
       "keepTime": false,
       "tags": [],
-      "targetBlank": false,
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/trip.json
+++ b/grafana/dashboards/trip.json
@@ -30,6 +30,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/updates.json
+++ b/grafana/dashboards/updates.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/vampire-drain.json
+++ b/grafana/dashboards/vampire-drain.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",

--- a/grafana/dashboards/visited.json
+++ b/grafana/dashboards/visited.json
@@ -22,6 +22,7 @@
     {
       "icon": "dashboard",
       "tags": [],
+      "targetBlank": true,
       "title": "TeslaMate",
       "tooltip": "",
       "type": "link",


### PR DESCRIPTION
Hey there. This PR fixes an issue I ran into with my TeslaMate config. I have Grafana hosted at `/` and the TeslaMate admin panel hosted on the same port under `/admin`. Without setting `targetBlank` to true, all the TeslaMate links within Grafana get picked up by its SPA and therefore don't render properly.

This PR makes all of those links open in a new tab, forcing it to break out of the Grafana SPA.

Let me know if you have any questions! Notes from Codex below.

--- 

## Summary

- open the top-level TeslaMate link in every bundled Grafana dashboard in a new tab
- leave dashboard-to-dashboard links unchanged

## Why

When Grafana and the TeslaMate UI share an origin, with TeslaMate mounted under `URL_PATH`, following the TeslaMate link in the current tab can leave the navigation under Grafana's client-side router instead of performing a fresh top-level navigation. This results in Grafana displaying an error for the TeslaMate path.

Opening the link in a new tab performs an independent browser navigation to the configured `base_url` while preserving the current dashboard.

## Validation

- validated every modified dashboard as JSON
- built the Grafana image against the repository's pinned Grafana 13.1.3 image
- provisioned all 23 bundled dashboards in a temporary local Grafana instance
- verified through the Grafana API that all 22 applicable TeslaMate links have `targetBlank: true`
- verified in Chrome that the rendered link has the configured `href`, `target="_blank"`, and `rel="noreferrer"`, and that clicking it opens a second tab
- `git diff --check`
