### PR TITLE
feat(mqtt): add missing Home Assistant discovery entities

### DIFF
--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -17,6 +17,70 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   @migration_delay :timer.seconds(1)
   @migration_payload Jason.encode!(%{migrate_discovery: true})
   @node "teslamate"
+  @legacy_discovery_entities [
+    {"sensor", "display_name"},
+    {"sensor", "state"},
+    {"sensor", "charging_state"},
+    {"sensor", "since"},
+    {"sensor", "version"},
+    {"sensor", "update_version"},
+    {"sensor", "model"},
+    {"sensor", "trim_badging"},
+    {"sensor", "exterior_color"},
+    {"sensor", "wheel_type"},
+    {"sensor", "spoiler_type"},
+    {"sensor", "geofence"},
+    {"sensor", "shift_state"},
+    {"binary_sensor", "park_brake"},
+    {"sensor", "power"},
+    {"sensor", "speed"},
+    {"sensor", "heading"},
+    {"sensor", "elevation"},
+    {"sensor", "inside_temp"},
+    {"sensor", "outside_temp"},
+    {"sensor", "odometer"},
+    {"sensor", "est_battery_range"},
+    {"sensor", "rated_battery_range"},
+    {"sensor", "ideal_battery_range"},
+    {"sensor", "battery_level"},
+    {"sensor", "usable_battery_level"},
+    {"sensor", "charge_energy_added"},
+    {"sensor", "charge_limit_soc"},
+    {"sensor", "charger_actual_current"},
+    {"sensor", "charger_phases"},
+    {"sensor", "charger_power"},
+    {"sensor", "charger_voltage"},
+    {"sensor", "scheduled_charging_start_time"},
+    {"sensor", "time_to_full_charge"},
+    {"sensor", "tpms_pressure_fl"},
+    {"sensor", "tpms_pressure_fr"},
+    {"sensor", "tpms_pressure_rl"},
+    {"sensor", "tpms_pressure_rr"},
+    {"sensor", "tpms_pressure_fl_psi"},
+    {"sensor", "tpms_pressure_fr_psi"},
+    {"sensor", "tpms_pressure_rl_psi"},
+    {"sensor", "tpms_pressure_rr_psi"},
+    {"sensor", "active_route_destination"},
+    {"sensor", "active_route_energy_at_arrival"},
+    {"sensor", "active_route_distance_to_arrival"},
+    {"sensor", "active_route_minutes_to_arrival"},
+    {"sensor", "active_route_traffic_minutes_delay"},
+    {"device_tracker", "location"},
+    {"device_tracker", "active_route_location"},
+    {"binary_sensor", "healthy"},
+    {"binary_sensor", "update_available"},
+    {"binary_sensor", "sentry_mode"},
+    {"binary_sensor", "windows_open"},
+    {"binary_sensor", "doors_open"},
+    {"binary_sensor", "trunk_open"},
+    {"binary_sensor", "frunk_open"},
+    {"binary_sensor", "is_user_present"},
+    {"binary_sensor", "is_climate_on"},
+    {"binary_sensor", "is_preconditioning"},
+    {"binary_sensor", "plugged_in"},
+    {"binary_sensor", "charge_port_door_open"},
+    {"binary_sensor", "locked"}
+  ]
   @version Mix.Project.config()[:version]
 
   @type publish_opts :: [
@@ -167,7 +231,12 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   end
 
   defp publish_legacy_configs(prefix, node, payload, publisher) do
-    Enum.reduce_while(entities(), :ok, fn {component, object_id, _config}, _acc ->
+    entities =
+      Enum.filter(entities(), fn {component, object_id, _config} ->
+        {component, object_id} in @legacy_discovery_entities
+      end)
+
+    Enum.reduce_while(entities, :ok, fn {component, object_id, _config}, _acc ->
       topic = component_discovery_topic(prefix, component, node, object_id)
 
       case call(publisher, :publish, [topic, payload, [retain: true, qos: 1]]) do

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -325,6 +325,21 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       {"sensor", "state", %{state_topic_key: :state, name: "State", icon: "mdi:car-connected"}},
       {"sensor", "charging_state",
        %{state_topic_key: :charging_state, name: "Charging State", icon: "mdi:ev-station"}},
+      {"sensor", "climate_keeper_mode",
+       %{
+         state_topic_key: :climate_keeper_mode,
+         name: "Climate Keeper",
+         icon: "mdi:air-conditioner",
+         value_template: "{{ value | title }}"
+       }},
+      {"sensor", "center_display_state",
+       %{
+         state_topic_key: :center_display_state,
+         name: "Center Display",
+         icon: "mdi:television",
+         value_template:
+           "{% set states = {0: 'off', 2: 'standby', 3: 'charging', 4: 'on', 5: 'large_charging', 6: 'ready_to_unlock', 7: 'sentry_mode', 8: 'dog_mode', 9: 'media'} %}{% set state = states.get(value | int(-1)) %}{% if state %}{{ state }}{% endif %}"
+       }},
       {"sensor", "since",
        %{
          state_topic_key: :since,
@@ -510,6 +525,24 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          unit_of_measurement: "A",
          icon: "mdi:lightning-bolt"
        }},
+      {"sensor", "charge_current_request",
+       %{
+         state_topic_key: :charge_current_request,
+         name: "Charge Current Request",
+         device_class: "current",
+         state_class: "measurement",
+         unit_of_measurement: "A",
+         suggested_display_precision: 0
+       }},
+      {"sensor", "charge_current_request_max",
+       %{
+         state_topic_key: :charge_current_request_max,
+         name: "Charge Current Request (Max)",
+         device_class: "current",
+         state_class: "measurement",
+         unit_of_measurement: "A",
+         suggested_display_precision: 0
+       }},
       {"sensor", "charger_phases",
        %{state_topic_key: :charger_phases, name: "Charger Phases", icon: "mdi:sine-wave"}},
       {"sensor", "charger_power",
@@ -542,6 +575,44 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          device_class: "duration",
          unit_of_measurement: "h",
          icon: "mdi:clock-outline"
+       }},
+      {"sensor", "download_perc",
+       %{
+         state_topic_key: :download_perc,
+         name: "Software Update Download",
+         entity_category: "diagnostic",
+         enabled_by_default: false,
+         state_class: "measurement",
+         unit_of_measurement: "%",
+         suggested_display_precision: 0,
+         icon: "mdi:download"
+       }},
+      {"sensor", "install_perc",
+       %{
+         state_topic_key: :install_perc,
+         name: "Software Update Installation",
+         entity_category: "diagnostic",
+         enabled_by_default: false,
+         state_class: "measurement",
+         unit_of_measurement: "%",
+         suggested_display_precision: 0,
+         icon: "mdi:update"
+       }},
+      {"sensor", "sun_roof_state",
+       %{
+         state_topic_key: :sun_roof_state,
+         name: "Sunroof State",
+         icon: "mdi:car-convertible",
+         value_template: "{{ value | replace('_', ' ') | title }}"
+       }},
+      {"sensor", "sun_roof_percent_open",
+       %{
+         state_topic_key: :sun_roof_percent_open,
+         name: "Sunroof Open",
+         state_class: "measurement",
+         unit_of_measurement: "%",
+         suggested_display_precision: 0,
+         icon: "mdi:car-convertible"
        }},
 
       # TPMS pressure (bar)
@@ -708,6 +779,12 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          entity_category: "diagnostic",
          enabled_by_default: false,
          icon: "mdi:car-convertible"
+       })},
+      {"binary_sensor", "service_mode",
+       Map.merge(true_false, %{
+         state_topic_key: :service_mode,
+         name: "Service Mode",
+         icon: "mdi:wrench"
        })},
       {"binary_sensor", "tpms_soft_warning_fl",
        Map.merge(true_false, %{

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -45,33 +45,52 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
   @doc """
   Migrates any existing single-component discovery configs to a device
-  discovery config and then clears the old retained configs.
+  discovery config and then clears the old retained configs. Components that
+  are disabled by default are omitted from the first device config and added
+  in a final device config after legacy cleanup. This prevents Home Assistant
+  from treating cleanup on a legacy topic as removal of a disabled component
+  from the shared device topic.
 
   Publishing stops at the first error. Every legacy migration marker must be
-  published successfully before waiting one second for Home Assistant to
-  process the markers and publishing the device config. Legacy cleanup starts
-  only after the device config succeeds. Retrying safely restarts the sequence.
+  published successfully before waiting for Home Assistant to process the
+  markers and publishing the migration device config. Legacy cleanup starts
+  only after that config succeeds, and the complete device config is published
+  only after cleanup succeeds. Retrying safely restarts the sequence.
   """
   @spec migrate(term(), publish_opts(), term()) :: :ok | {:error, term()}
   def migrate(%Summary{} = summary, opts, publisher) do
-    {prefix, node, device_payload} = discovery_config(summary, opts)
+    entity_configs = entities()
+    {prefix, node, device_payload} = discovery_config(summary, opts, entity_configs)
     migration_delay = Keyword.get(opts, :migration_delay, @migration_delay)
+
+    migration_entity_configs =
+      Enum.reject(entity_configs, fn {_component, _object_id, config} ->
+        Map.get(config, :enabled_by_default, true) == false
+      end)
+
+    {^prefix, ^node, migration_device_payload} =
+      discovery_config(summary, opts, migration_entity_configs)
 
     with :ok <- publish_legacy_configs(prefix, node, @migration_payload, publisher),
          :ok <- Process.sleep(migration_delay),
-         :ok <- publish_device_config(prefix, node, device_payload, publisher) do
-      publish_legacy_configs(prefix, node, "", publisher)
+         :ok <- publish_device_config(prefix, node, migration_device_payload, publisher),
+         :ok <- publish_legacy_configs(prefix, node, "", publisher) do
+      publish_device_config(prefix, node, device_payload, publisher)
     end
   end
 
   defp discovery_config(%Summary{} = summary, opts) do
+    discovery_config(summary, opts, entities())
+  end
+
+  defp discovery_config(%Summary{} = summary, opts, entity_configs) do
     car_id = Keyword.fetch!(opts, :car_id)
     namespace = Keyword.get(opts, :namespace)
     prefix = Keyword.get(opts, :discovery_prefix, @discovery_prefix)
     node = node(car_id, namespace)
 
     components =
-      Map.new(entities(), fn {component, object_id, config} ->
+      Map.new(entity_configs, fn {component, object_id, config} ->
         config
         |> resolve_topics(car_id, namespace)
         |> Map.put(:platform, component)
@@ -296,7 +315,13 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
     [
       # --- Generic sensors (string/raw values) ---
       {"sensor", "display_name",
-       %{state_topic_key: :display_name, name: "Display Name", icon: "mdi:car"}},
+       %{
+         state_topic_key: :display_name,
+         name: "Display Name",
+         entity_category: "diagnostic",
+         enabled_by_default: false,
+         icon: "mdi:form-textbox"
+       }},
       {"sensor", "state", %{state_topic_key: :state, name: "State", icon: "mdi:car-connected"}},
       {"sensor", "charging_state",
        %{state_topic_key: :charging_state, name: "Charging State", icon: "mdi:ev-station"}},
@@ -308,17 +333,49 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          icon: "mdi:clock-outline"
        }},
       {"sensor", "version",
-       %{state_topic_key: :version, name: "Version", icon: "mdi:alphabetical"}},
+       %{
+         state_topic_key: :version,
+         name: "Version",
+         entity_category: "diagnostic",
+         enabled_by_default: false,
+         icon: "mdi:numeric"
+       }},
       {"sensor", "update_version",
        %{state_topic_key: :update_version, name: "Update Version", icon: "mdi:alphabetical"}},
-      {"sensor", "model", %{state_topic_key: :model, name: "Model"}},
+      {"sensor", "model",
+       %{
+         state_topic_key: :model,
+         name: "Model",
+         entity_category: "diagnostic",
+         enabled_by_default: false,
+         icon: "mdi:form-textbox"
+       }},
       {"sensor", "trim_badging",
-       %{state_topic_key: :trim_badging, name: "Trim Badging", icon: "mdi:shield-star-outline"}},
+       %{
+         state_topic_key: :trim_badging,
+         name: "Trim Badging",
+         entity_category: "diagnostic",
+         enabled_by_default: false,
+         icon: "mdi:shield-star-outline"
+       }},
       {"sensor", "exterior_color",
        %{state_topic_key: :exterior_color, name: "Exterior Color", icon: "mdi:palette"}},
-      {"sensor", "wheel_type", %{state_topic_key: :wheel_type, name: "Wheel Type"}},
+      {"sensor", "wheel_type",
+       %{
+         state_topic_key: :wheel_type,
+         name: "Wheel Type",
+         entity_category: "diagnostic",
+         enabled_by_default: false,
+         icon: "mdi:tire"
+       }},
       {"sensor", "spoiler_type",
-       %{state_topic_key: :spoiler_type, name: "Spoiler Type", icon: "mdi:car-sports"}},
+       %{
+         state_topic_key: :spoiler_type,
+         name: "Spoiler Type",
+         entity_category: "diagnostic",
+         enabled_by_default: false,
+         icon: "mdi:car-sports"
+       }},
       {"sensor", "geofence", %{state_topic_key: :geofence, name: "Geofence", icon: "mdi:earth"}},
       {"sensor", "shift_state",
        %{state_topic_key: :shift_state, name: "Shift State", icon: "mdi:car-shift-pattern"}},
@@ -643,6 +700,14 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          state_topic_key: :update_available,
          name: "Update Available",
          icon: "mdi:alarm"
+       })},
+      {"binary_sensor", "sun_roof_installed",
+       Map.merge(true_false, %{
+         state_topic_key: :sun_roof_installed,
+         name: "Sunroof Installed",
+         entity_category: "diagnostic",
+         enabled_by_default: false,
+         icon: "mdi:car-convertible"
        })},
       {"binary_sensor", "sentry_mode",
        Map.merge(true_false, %{

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -91,12 +91,15 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
     components =
       Map.new(entity_configs, fn {component, object_id, config} ->
+        component_id = Map.get(config, :component_id, object_id)
+
         config
+        |> Map.delete(:component_id)
         |> resolve_topics(car_id, namespace)
         |> Map.put(:platform, component)
         |> Map.put(:unique_id, "#{node}_#{object_id}")
         |> Map.put(:object_id, "tesla_#{object_id}")
-        |> then(&{object_id, &1})
+        |> then(&{component_id, &1})
       end)
 
     device_payload =
@@ -321,6 +324,32 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          entity_category: "diagnostic",
          enabled_by_default: false,
          icon: "mdi:form-textbox"
+       }},
+      {"sensor", "latitude",
+       %{
+         state_topic_key: :latitude,
+         name: "Latitude",
+         enabled_by_default: false,
+         state_class: "measurement",
+         unit_of_measurement: "°",
+         icon: "mdi:latitude"
+       }},
+      {"sensor", "location",
+       %{
+         component_id: "raw_location",
+         state_topic_key: :location,
+         name: "Location",
+         enabled_by_default: false,
+         icon: "mdi:car"
+       }},
+      {"sensor", "longitude",
+       %{
+         state_topic_key: :longitude,
+         name: "Longitude",
+         enabled_by_default: false,
+         state_class: "measurement",
+         unit_of_measurement: "°",
+         icon: "mdi:longitude"
        }},
       {"sensor", "state", %{state_topic_key: :state, name: "State", icon: "mdi:car-connected"}},
       {"sensor", "charging_state",
@@ -748,7 +777,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
       # --- Device trackers (JSON attributes) ---
       {"device_tracker", "location",
-       %{json_attributes_topic_key: :location, name: "Location", icon: "mdi:crosshairs-gps"}},
+       %{json_attributes_topic_key: :location, name: nil, icon: "mdi:crosshairs-gps"}},
       {"device_tracker", "active_route_location",
        %{
          json_attributes_topic_key: :active_route,

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -709,6 +709,38 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          enabled_by_default: false,
          icon: "mdi:car-convertible"
        })},
+      {"binary_sensor", "tpms_soft_warning_fl",
+       Map.merge(true_false, %{
+         state_topic_key: :tpms_soft_warning_fl,
+         name: "Tire Soft (Front Left)",
+         device_class: "problem",
+         entity_category: "diagnostic",
+         icon: "mdi:car-tire-alert"
+       })},
+      {"binary_sensor", "tpms_soft_warning_fr",
+       Map.merge(true_false, %{
+         state_topic_key: :tpms_soft_warning_fr,
+         name: "Tire Soft (Front Right)",
+         device_class: "problem",
+         entity_category: "diagnostic",
+         icon: "mdi:car-tire-alert"
+       })},
+      {"binary_sensor", "tpms_soft_warning_rl",
+       Map.merge(true_false, %{
+         state_topic_key: :tpms_soft_warning_rl,
+         name: "Tire Soft (Rear Left)",
+         device_class: "problem",
+         entity_category: "diagnostic",
+         icon: "mdi:car-tire-alert"
+       })},
+      {"binary_sensor", "tpms_soft_warning_rr",
+       Map.merge(true_false, %{
+         state_topic_key: :tpms_soft_warning_rr,
+         name: "Tire Soft (Rear Right)",
+         device_class: "problem",
+         entity_category: "diagnostic",
+         icon: "mdi:car-tire-alert"
+       })},
       {"binary_sensor", "sentry_mode",
        Map.merge(true_false, %{
          state_topic_key: :sentry_mode,

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -840,7 +840,35 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       {"binary_sensor", "doors_open",
        Map.merge(true_false, %{
          state_topic_key: :doors_open,
-         name: "Doors Open",
+         name: "Doors",
+         device_class: "door",
+         icon: "mdi:car-door"
+       })},
+      {"binary_sensor", "driver_front_door_open",
+       Map.merge(true_false, %{
+         state_topic_key: :driver_front_door_open,
+         name: "Door (Driver Front)",
+         device_class: "door",
+         icon: "mdi:car-door"
+       })},
+      {"binary_sensor", "driver_rear_door_open",
+       Map.merge(true_false, %{
+         state_topic_key: :driver_rear_door_open,
+         name: "Door (Driver Rear)",
+         device_class: "door",
+         icon: "mdi:car-door"
+       })},
+      {"binary_sensor", "passenger_front_door_open",
+       Map.merge(true_false, %{
+         state_topic_key: :passenger_front_door_open,
+         name: "Door (Passenger Front)",
+         device_class: "door",
+         icon: "mdi:car-door"
+       })},
+      {"binary_sensor", "passenger_rear_door_open",
+       Map.merge(true_false, %{
+         state_topic_key: :passenger_rear_door_open,
+         name: "Door (Passenger Rear)",
          device_class: "door",
          icon: "mdi:car-door"
        })},

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -99,7 +99,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
         |> Map.delete(:component_id)
         |> resolve_topics(car_id, namespace)
         |> Map.put(:platform, component)
-        |> Map.put(:unique_id, "#{node}_#{object_id}")
+        |> Map.put(:unique_id, "#{node}_#{component_id}")
         |> Map.put(:object_id, "tesla_#{object_id}")
         |> then(&{component_id, &1})
       end)

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -54,8 +54,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   Publishing stops at the first error. Every legacy migration marker must be
   published successfully before waiting for Home Assistant to process the
   markers and publishing the migration device config. Legacy cleanup starts
-  only after that config succeeds, and the complete device config is published
-  only after cleanup succeeds. Retrying safely restarts the sequence.
+  only after that config succeeds. After cleanup, Home Assistant is given the
+  same processing delay before the complete device config is published.
+  Retrying safely restarts the sequence.
   """
   @spec migrate(term(), publish_opts(), term()) :: :ok | {:error, term()}
   def migrate(%Summary{} = summary, opts, publisher) do
@@ -74,7 +75,8 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
     with :ok <- publish_legacy_configs(prefix, node, @migration_payload, publisher),
          :ok <- Process.sleep(migration_delay),
          :ok <- publish_device_config(prefix, node, migration_device_payload, publisher),
-         :ok <- publish_legacy_configs(prefix, node, "", publisher) do
+         :ok <- publish_legacy_configs(prefix, node, "", publisher),
+         :ok <- Process.sleep(migration_delay) do
       publish_device_config(prefix, node, device_payload, publisher)
     end
   end

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -833,7 +833,35 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       {"binary_sensor", "windows_open",
        Map.merge(true_false, %{
          state_topic_key: :windows_open,
-         name: "Windows Open",
+         name: "Windows",
+         device_class: "window",
+         icon: "mdi:car-door"
+       })},
+      {"binary_sensor", "driver_front_window_open",
+       Map.merge(true_false, %{
+         state_topic_key: :driver_front_window_open,
+         name: "Window (Driver Front)",
+         device_class: "window",
+         icon: "mdi:car-door"
+       })},
+      {"binary_sensor", "driver_rear_window_open",
+       Map.merge(true_false, %{
+         state_topic_key: :driver_rear_window_open,
+         name: "Window (Driver Rear)",
+         device_class: "window",
+         icon: "mdi:car-door"
+       })},
+      {"binary_sensor", "passenger_front_window_open",
+       Map.merge(true_false, %{
+         state_topic_key: :passenger_front_window_open,
+         name: "Window (Passenger Front)",
+         device_class: "window",
+         icon: "mdi:car-door"
+       })},
+      {"binary_sensor", "passenger_rear_window_open",
+       Map.merge(true_false, %{
+         state_topic_key: :passenger_rear_window_open,
+         name: "Window (Passenger Rear)",
          device_class: "window",
          icon: "mdi:car-door"
        })},

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -17,12 +17,6 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   @migration_delay :timer.seconds(1)
   @migration_payload Jason.encode!(%{migrate_discovery: true})
   @node "teslamate"
-  @removed_entities [
-    {"sensor", "tpms_pressure_fl_psi"},
-    {"sensor", "tpms_pressure_fr_psi"},
-    {"sensor", "tpms_pressure_rl_psi"},
-    {"sensor", "tpms_pressure_rr_psi"}
-  ]
   @version Mix.Project.config()[:version]
 
   @type publish_opts :: [
@@ -171,12 +165,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   end
 
   defp publish_legacy_configs(prefix, node, payload, publisher) do
-    entities =
-      Enum.map(entities(), fn {component, object_id, _config} -> {component, object_id} end)
-
-    entities = if payload == "", do: entities ++ @removed_entities, else: entities
-
-    Enum.reduce_while(entities, :ok, fn {component, object_id}, _acc ->
+    Enum.reduce_while(entities(), :ok, fn {component, object_id, _config}, _acc ->
       topic = component_discovery_topic(prefix, component, node, object_id)
 
       case call(publisher, :publish, [topic, payload, [retain: true, qos: 1]]) do
@@ -695,6 +684,56 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          unit_of_measurement: "bar",
          suggested_display_precision: 1,
          icon: "mdi:gauge"
+       }},
+
+      # TPMS pressure compatibility sensors (psi), derived from the bar topics
+      {"sensor", "tpms_pressure_fl_psi",
+       %{
+         state_topic_key: :tpms_pressure_fl,
+         name: "Tire Pressure (Front Left, PSI)",
+         device_class: "pressure",
+         state_class: "measurement",
+         enabled_by_default: false,
+         unit_of_measurement: "psi",
+         icon: "mdi:gauge",
+         value_template: "{{ (value | float * 14.50377) | round(2) }}",
+         suggested_display_precision: 1
+       }},
+      {"sensor", "tpms_pressure_fr_psi",
+       %{
+         state_topic_key: :tpms_pressure_fr,
+         name: "Tire Pressure (Front Right, PSI)",
+         device_class: "pressure",
+         state_class: "measurement",
+         enabled_by_default: false,
+         unit_of_measurement: "psi",
+         icon: "mdi:gauge",
+         value_template: "{{ (value | float * 14.50377) | round(2) }}",
+         suggested_display_precision: 1
+       }},
+      {"sensor", "tpms_pressure_rl_psi",
+       %{
+         state_topic_key: :tpms_pressure_rl,
+         name: "Tire Pressure (Rear Left, PSI)",
+         device_class: "pressure",
+         state_class: "measurement",
+         enabled_by_default: false,
+         unit_of_measurement: "psi",
+         icon: "mdi:gauge",
+         value_template: "{{ (value | float * 14.50377) | round(2) }}",
+         suggested_display_precision: 1
+       }},
+      {"sensor", "tpms_pressure_rr_psi",
+       %{
+         state_topic_key: :tpms_pressure_rr,
+         name: "Tire Pressure (Rear Right, PSI)",
+         device_class: "pressure",
+         state_class: "measurement",
+         enabled_by_default: false,
+         unit_of_measurement: "psi",
+         icon: "mdi:gauge",
+         value_template: "{{ (value | float * 14.50377) | round(2) }}",
+         suggested_display_precision: 1
        }},
 
       # --- Active route sensors (derived from the JSON active_route topic) ---

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -17,6 +17,12 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   @migration_delay :timer.seconds(1)
   @migration_payload Jason.encode!(%{migrate_discovery: true})
   @node "teslamate"
+  @removed_entities [
+    {"sensor", "tpms_pressure_fl_psi"},
+    {"sensor", "tpms_pressure_fr_psi"},
+    {"sensor", "tpms_pressure_rl_psi"},
+    {"sensor", "tpms_pressure_rr_psi"}
+  ]
   @version Mix.Project.config()[:version]
 
   @type publish_opts :: [
@@ -165,7 +171,12 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   end
 
   defp publish_legacy_configs(prefix, node, payload, publisher) do
-    Enum.reduce_while(entities(), :ok, fn {component, object_id, _config}, _acc ->
+    entities =
+      Enum.map(entities(), fn {component, object_id, _config} -> {component, object_id} end)
+
+    entities = if payload == "", do: entities ++ @removed_entities, else: entities
+
+    Enum.reduce_while(entities, :ok, fn {component, object_id}, _acc ->
       topic = component_discovery_topic(prefix, component, node, object_id)
 
       case call(publisher, :publish, [topic, payload, [retain: true, qos: 1]]) do
@@ -648,76 +659,42 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       {"sensor", "tpms_pressure_fl",
        %{
          state_topic_key: :tpms_pressure_fl,
-         name: "TPMS Pressure Front Left",
+         name: "Tire Pressure (Front Left)",
          device_class: "pressure",
+         state_class: "measurement",
          unit_of_measurement: "bar",
-         icon: "mdi:car-tire-alert"
+         suggested_display_precision: 1,
+         icon: "mdi:gauge"
        }},
       {"sensor", "tpms_pressure_fr",
        %{
          state_topic_key: :tpms_pressure_fr,
-         name: "TPMS Pressure Front Right",
+         name: "Tire Pressure (Front Right)",
          device_class: "pressure",
+         state_class: "measurement",
          unit_of_measurement: "bar",
-         icon: "mdi:car-tire-alert"
+         suggested_display_precision: 1,
+         icon: "mdi:gauge"
        }},
       {"sensor", "tpms_pressure_rl",
        %{
          state_topic_key: :tpms_pressure_rl,
-         name: "TPMS Pressure Rear Left",
+         name: "Tire Pressure (Rear Left)",
          device_class: "pressure",
+         state_class: "measurement",
          unit_of_measurement: "bar",
-         icon: "mdi:car-tire-alert"
+         suggested_display_precision: 1,
+         icon: "mdi:gauge"
        }},
       {"sensor", "tpms_pressure_rr",
        %{
          state_topic_key: :tpms_pressure_rr,
-         name: "TPMS Pressure Rear Right",
+         name: "Tire Pressure (Rear Right)",
          device_class: "pressure",
+         state_class: "measurement",
          unit_of_measurement: "bar",
-         icon: "mdi:car-tire-alert"
-       }},
-
-      # TPMS pressure (psi) - derived via value_template from the bar topic
-      {"sensor", "tpms_pressure_fl_psi",
-       %{
-         state_topic_key: :tpms_pressure_fl,
-         name: "TPMS Pressure Front Left (psi)",
-         device_class: "pressure",
-         unit_of_measurement: "psi",
-         icon: "mdi:car-tire-alert",
-         value_template: "{{ (value | float * 14.50377) | round(2) }}",
-         suggested_display_precision: 2
-       }},
-      {"sensor", "tpms_pressure_fr_psi",
-       %{
-         state_topic_key: :tpms_pressure_fr,
-         name: "TPMS Pressure Front Right (psi)",
-         device_class: "pressure",
-         unit_of_measurement: "psi",
-         icon: "mdi:car-tire-alert",
-         value_template: "{{ (value | float * 14.50377) | round(2) }}",
-         suggested_display_precision: 2
-       }},
-      {"sensor", "tpms_pressure_rl_psi",
-       %{
-         state_topic_key: :tpms_pressure_rl,
-         name: "TPMS Pressure Rear Left (psi)",
-         device_class: "pressure",
-         unit_of_measurement: "psi",
-         icon: "mdi:car-tire-alert",
-         value_template: "{{ (value | float * 14.50377) | round(2) }}",
-         suggested_display_precision: 2
-       }},
-      {"sensor", "tpms_pressure_rr_psi",
-       %{
-         state_topic_key: :tpms_pressure_rr,
-         name: "TPMS Pressure Rear Right (psi)",
-         device_class: "pressure",
-         unit_of_measurement: "psi",
-         icon: "mdi:car-tire-alert",
-         value_template: "{{ (value | float * 14.50377) | round(2) }}",
-         suggested_display_precision: 2
+         suggested_display_precision: 1,
+         icon: "mdi:gauge"
        }},
 
       # --- Active route sensors (derived from the JSON active_route topic) ---

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -366,6 +366,34 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     end
   end
 
+  test "publishes aggregate and individual cabin window sensors", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+
+    for {object_id, entity_name} <- [
+          {"windows_open", "Windows"},
+          {"driver_front_window_open", "Window (Driver Front)"},
+          {"driver_rear_window_open", "Window (Driver Rear)"},
+          {"passenger_front_window_open", "Window (Passenger Front)"},
+          {"passenger_rear_window_open", "Window (Passenger Rear)"}
+        ] do
+      config = decoded["components"][object_id]
+
+      assert config["platform"] == "binary_sensor"
+      assert config["name"] == entity_name
+      assert config["device_class"] == "window"
+      assert config["payload_on"] == "true"
+      assert config["payload_off"] == "false"
+      assert config["icon"] == "mdi:car-door"
+      assert config["state_topic"] == "teslamate/cars/0/#{object_id}"
+      refute Map.has_key?(config, "entity_category")
+      refute Map.has_key?(config, "enabled_by_default")
+    end
+  end
+
   test "publishes tire soft warnings as diagnostic problems", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -544,7 +544,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert raw_location["enabled_by_default"] == false
     assert raw_location["icon"] == "mdi:car"
     assert raw_location["state_topic"] == "teslamate/cars/0/location"
-    assert raw_location["unique_id"] == "teslamate_0_location"
+    assert raw_location["unique_id"] == "teslamate_0_raw_location"
     assert raw_location["object_id"] == "tesla_location"
     refute Map.has_key?(raw_location, "component_id")
     refute Map.has_key?(raw_location, "entity_category")
@@ -555,6 +555,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert tracker["name"] == nil
     assert tracker["json_attributes_topic"] == "teslamate/cars/0/location"
     assert tracker["unique_id"] == "teslamate_0_location"
+    refute tracker["unique_id"] == raw_location["unique_id"]
     refute Map.has_key?(tracker, "enabled_by_default")
   end
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -354,6 +354,106 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     end
   end
 
+  test "publishes missing MQTT topics as Home Assistant entities", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+
+    enabled = %{
+      "charge_current_request" => %{
+        "platform" => "sensor",
+        "name" => "Charge Current Request",
+        "device_class" => "current",
+        "state_class" => "measurement",
+        "unit_of_measurement" => "A",
+        "suggested_display_precision" => 0
+      },
+      "charge_current_request_max" => %{
+        "platform" => "sensor",
+        "name" => "Charge Current Request (Max)",
+        "device_class" => "current",
+        "state_class" => "measurement",
+        "unit_of_measurement" => "A",
+        "suggested_display_precision" => 0
+      },
+      "climate_keeper_mode" => %{
+        "platform" => "sensor",
+        "name" => "Climate Keeper",
+        "icon" => "mdi:air-conditioner",
+        "value_template" => "{{ value | title }}"
+      },
+      "service_mode" => %{
+        "platform" => "binary_sensor",
+        "name" => "Service Mode",
+        "payload_on" => "true",
+        "payload_off" => "false",
+        "icon" => "mdi:wrench"
+      },
+      "sun_roof_percent_open" => %{
+        "platform" => "sensor",
+        "name" => "Sunroof Open",
+        "state_class" => "measurement",
+        "unit_of_measurement" => "%",
+        "suggested_display_precision" => 0,
+        "icon" => "mdi:car-convertible"
+      },
+      "sun_roof_state" => %{
+        "platform" => "sensor",
+        "name" => "Sunroof State",
+        "icon" => "mdi:car-convertible",
+        "value_template" => "{{ value | replace('_', ' ') | title }}"
+      }
+    }
+
+    for {object_id, expected} <- enabled do
+      config = decoded["components"][object_id]
+
+      for {key, value} <- expected, do: assert(config[key] == value)
+      assert config["state_topic"] == "teslamate/cars/0/#{object_id}"
+      refute Map.has_key?(config, "enabled_by_default")
+    end
+
+    center_display = decoded["components"]["center_display_state"]
+    assert center_display["platform"] == "sensor"
+    assert center_display["name"] == "Center Display"
+    assert center_display["icon"] == "mdi:television"
+    assert center_display["state_topic"] == "teslamate/cars/0/center_display_state"
+    refute Map.has_key?(center_display, "enabled_by_default")
+
+    for {code, state} <- [
+          {0, "off"},
+          {2, "standby"},
+          {3, "charging"},
+          {4, "on"},
+          {5, "large_charging"},
+          {6, "ready_to_unlock"},
+          {7, "sentry_mode"},
+          {8, "dog_mode"},
+          {9, "media"}
+        ] do
+      assert String.contains?(center_display["value_template"], "#{code}: '#{state}'")
+    end
+
+    for {object_id, entity_name, icon} <- [
+          {"download_perc", "Software Update Download", "mdi:download"},
+          {"install_perc", "Software Update Installation", "mdi:update"}
+        ] do
+      config = decoded["components"][object_id]
+
+      assert config["platform"] == "sensor"
+      assert config["name"] == entity_name
+      assert config["entity_category"] == "diagnostic"
+      assert config["enabled_by_default"] == false
+      assert config["state_class"] == "measurement"
+      assert config["unit_of_measurement"] == "%"
+      assert config["suggested_display_precision"] == 0
+      assert config["icon"] == icon
+      assert config["state_topic"] == "teslamate/cars/0/#{object_id}"
+    end
+  end
+
   test "active route sensors include availability and template", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -51,7 +51,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       end)
 
     {cleanup, [{final_topic, final_payload, final_publish_opts}]} =
-      Enum.split(remaining, length(migrations))
+      Enum.split_while(remaining, fn {topic, _payload, _opts} ->
+        topic != "homeassistant/device/teslamate_0/config"
+      end)
 
     assert migrations != []
 
@@ -65,8 +67,19 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert final_topic == topic
     assert final_publish_opts == publish_opts
 
-    assert Enum.map(migrations, &elem(&1, 0)) == Enum.map(cleanup, &elem(&1, 0))
+    migration_topics = Enum.map(migrations, &elem(&1, 0))
+    cleanup_topics = Enum.map(cleanup, &elem(&1, 0))
+
+    assert MapSet.subset?(MapSet.new(migration_topics), MapSet.new(cleanup_topics))
     assert Enum.all?(cleanup, &match?({_topic, "", [retain: true, qos: 1]}, &1))
+
+    for position <- ["fl", "fr", "rl", "rr"] do
+      removed_topic =
+        "homeassistant/sensor/teslamate_0/tpms_pressure_#{position}_psi/config"
+
+      refute removed_topic in migration_topics
+      assert removed_topic in cleanup_topics
+    end
 
     migration_decoded = Jason.decode!(migration_payload)
     decoded = Jason.decode!(final_payload)
@@ -509,16 +522,31 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert %{"topic" => "teslamate/cars/0/active_route"} = config["availability"]
   end
 
-  test "psi sensor derives value from the bar topic", %{test: name} do
+  test "publishes tire pressures in bar without derived psi sensors", %{test: name} do
     publisher_name = start_publisher(name)
 
     :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
     {_topic, decoded} = receive_device_config()
-    config = decoded["components"]["tpms_pressure_fl_psi"]
-    assert config["state_topic"] == "teslamate/cars/0/tpms_pressure_fl"
-    assert config["unit_of_measurement"] == "psi"
-    assert String.contains?(config["value_template"], "14.50377")
+
+    for {position, entity_name} <- [
+          {"fl", "Tire Pressure (Front Left)"},
+          {"fr", "Tire Pressure (Front Right)"},
+          {"rl", "Tire Pressure (Rear Left)"},
+          {"rr", "Tire Pressure (Rear Right)"}
+        ] do
+      refute Map.has_key?(decoded["components"], "tpms_pressure_#{position}_psi")
+
+      config = decoded["components"]["tpms_pressure_#{position}"]
+      assert config["platform"] == "sensor"
+      assert config["name"] == entity_name
+      assert config["device_class"] == "pressure"
+      assert config["state_class"] == "measurement"
+      assert config["unit_of_measurement"] == "bar"
+      assert config["suggested_display_precision"] == 1
+      assert config["icon"] == "mdi:gauge"
+      assert config["state_topic"] == "teslamate/cars/0/tpms_pressure_#{position}"
+    end
   end
 
   test "entity ids match the manual mqtt_sensors.yaml naming", %{test: name} do
@@ -559,6 +587,10 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     assert Enum.any?(legacy_cleanup, fn {topic, _, _} ->
              topic == "homeassistant/binary_sensor/teslamate_0/locked/config"
+           end)
+
+    assert Enum.any?(legacy_cleanup, fn {topic, _, _} ->
+             topic == "homeassistant/sensor/teslamate_0/tpms_pressure_fl_psi/config"
            end)
   end
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -325,6 +325,35 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert config["state_topic"] == "teslamate/cars/0/locked"
   end
 
+  test "publishes tire soft warnings as diagnostic problems", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+
+    tires = [
+      {"tpms_soft_warning_fl", "Tire Soft (Front Left)"},
+      {"tpms_soft_warning_fr", "Tire Soft (Front Right)"},
+      {"tpms_soft_warning_rl", "Tire Soft (Rear Left)"},
+      {"tpms_soft_warning_rr", "Tire Soft (Rear Right)"}
+    ]
+
+    for {object_id, entity_name} <- tires do
+      config = decoded["components"][object_id]
+
+      assert config["platform"] == "binary_sensor"
+      assert config["name"] == entity_name
+      assert config["device_class"] == "problem"
+      assert config["entity_category"] == "diagnostic"
+      assert config["payload_on"] == "true"
+      assert config["payload_off"] == "false"
+      assert config["icon"] == "mdi:car-tire-alert"
+      assert config["state_topic"] == "teslamate/cars/0/#{object_id}"
+      refute Map.has_key?(config, "enabled_by_default")
+    end
+  end
+
   test "active route sensors include availability and template", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -31,7 +31,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     car: %Car{id: 0, name: "Tesla Model 3", model: "3"}
   }
 
-  test "migrates legacy configs around one device config containing every entity", %{test: name} do
+  test "migrates enabled components before cleanup and disabled components after cleanup", %{
+    test: name
+  } do
     publisher_name = start_publisher(name)
 
     opts =
@@ -43,10 +45,13 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     messages = receive_configs()
 
-    {migrations, [{topic, payload, publish_opts} | cleanup]} =
+    {migrations, [{topic, migration_payload, publish_opts} | remaining]} =
       Enum.split_while(messages, fn {topic, _payload, _opts} ->
         topic != "homeassistant/device/teslamate_0/config"
       end)
+
+    {cleanup, [{final_topic, final_payload, final_publish_opts}]} =
+      Enum.split(remaining, length(migrations))
 
     assert migrations != []
 
@@ -57,14 +62,25 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     assert topic == "homeassistant/device/teslamate_0/config"
     assert publish_opts == [retain: true, qos: 1]
+    assert final_topic == topic
+    assert final_publish_opts == publish_opts
 
     assert Enum.map(migrations, &elem(&1, 0)) == Enum.map(cleanup, &elem(&1, 0))
     assert Enum.all?(cleanup, &match?({_topic, "", [retain: true, qos: 1]}, &1))
 
-    decoded = Jason.decode!(payload)
+    migration_decoded = Jason.decode!(migration_payload)
+    decoded = Jason.decode!(final_payload)
 
     components = decoded["components"]
     assert map_size(components) == length(migrations)
+
+    disabled_component_ids =
+      for {object_id, %{"enabled_by_default" => false}} <- components, do: object_id
+
+    assert disabled_component_ids != []
+
+    assert Map.keys(migration_decoded["components"]) |> Enum.sort() ==
+             Map.keys(components) |> Kernel.--(disabled_component_ids) |> Enum.sort()
 
     for config <- Map.values(components) do
       assert Map.has_key?(config, "platform")
@@ -119,6 +135,44 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
              ~s|Model S LR AWD (Aero Turbine 19" Wheels, Carbon Fiber Spoiler, Sunroof)|
 
     assert decoded["device"]["sw_version"] == "2026.26.1"
+  end
+
+  test "publishes device metadata sources as disabled diagnostics", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+
+    expected = %{
+      "display_name" => {"Display Name", "mdi:form-textbox"},
+      "model" => {"Model", "mdi:form-textbox"},
+      "spoiler_type" => {"Spoiler Type", "mdi:car-sports"},
+      "trim_badging" => {"Trim Badging", "mdi:shield-star-outline"},
+      "version" => {"Version", "mdi:numeric"},
+      "wheel_type" => {"Wheel Type", "mdi:tire"}
+    }
+
+    for {object_id, {entity_name, icon}} <- expected do
+      config = decoded["components"][object_id]
+
+      assert config["platform"] == "sensor"
+      assert config["name"] == entity_name
+      assert config["entity_category"] == "diagnostic"
+      assert config["enabled_by_default"] == false
+      assert config["icon"] == icon
+      assert config["state_topic"] == "teslamate/cars/0/#{object_id}"
+    end
+
+    sunroof = decoded["components"]["sun_roof_installed"]
+    assert sunroof["platform"] == "binary_sensor"
+    assert sunroof["name"] == "Sunroof Installed"
+    assert sunroof["entity_category"] == "diagnostic"
+    assert sunroof["enabled_by_default"] == false
+    assert sunroof["payload_on"] == "true"
+    assert sunroof["payload_off"] == "false"
+    assert sunroof["icon"] == "mdi:car-convertible"
+    assert sunroof["state_topic"] == "teslamate/cars/0/sun_roof_installed"
   end
 
   test "falls back to raw trim badging when the marketing name is unavailable", %{test: name} do
@@ -244,8 +298,12 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert speed["unique_id"] == "teslamate_ns1_0_speed"
     assert speed["state_topic"] == "teslamate/ns1/cars/0/speed"
     assert decoded["device"]["identifiers"] == ["teslamate_ns1_car_0"]
+    refute Map.has_key?(decoded["components"], "display_name")
 
-    assert decoded["components"]["display_name"]["unique_id"] ==
+    {final_topic, final_decoded} = receive_device_config()
+    assert final_topic == topic
+
+    assert final_decoded["components"]["display_name"]["unique_id"] ==
              "teslamate_ns1_0_display_name"
 
     assert_receive {MqttPublisherMock,
@@ -384,6 +442,28 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert Enum.count(messages, fn {topic, payload, _opts} ->
              topic == legacy_topic and payload == @migration_payload
            end) == 1
+
+    assert Enum.count(messages, fn {topic, _payload, _opts} ->
+             topic == "homeassistant/device/teslamate_0/config"
+           end) == 1
+  end
+
+  test "returns an error when the complete device config cannot be published", %{test: name} do
+    device_topic = "homeassistant/device/teslamate_0/config"
+
+    publisher_name =
+      start_publisher(name, %{device_topic => [:ok, {:error, :disconnected}]})
+
+    assert {:error, :disconnected} =
+             HomeAssistant.migrate(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    messages = receive_configs()
+    assert {^device_topic, final_payload, [retain: true, qos: 1]} = List.last(messages)
+
+    assert Jason.decode!(final_payload)["components"]["display_name"]["enabled_by_default"] ==
+             false
+
+    assert Enum.count(messages, fn {topic, _payload, _opts} -> topic == device_topic end) == 2
   end
 
   defp receive_device_config(timeout \\ 200) do

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -41,7 +41,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     started_at = System.monotonic_time(:millisecond)
     :ok = HomeAssistant.migrate(@summary, opts, {MqttPublisherMock, publisher_name})
-    assert System.monotonic_time(:millisecond) - started_at >= @migration_delay
+    assert System.monotonic_time(:millisecond) - started_at >= 2 * @migration_delay
 
     messages = receive_configs()
 
@@ -717,7 +717,11 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       start_publisher(name, %{device_topic => [:ok, {:error, :disconnected}]})
 
     assert {:error, :disconnected} =
-             HomeAssistant.migrate(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+             HomeAssistant.migrate(
+               @summary,
+               migration_opts(car_id: 0),
+               {MqttPublisherMock, publisher_name}
+             )
 
     messages = receive_configs()
     assert {^device_topic, final_payload, [retain: true, qos: 1]} = List.last(messages)

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -338,6 +338,34 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert config["state_topic"] == "teslamate/cars/0/locked"
   end
 
+  test "publishes aggregate and individual cabin door sensors", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+
+    for {object_id, entity_name} <- [
+          {"doors_open", "Doors"},
+          {"driver_front_door_open", "Door (Driver Front)"},
+          {"driver_rear_door_open", "Door (Driver Rear)"},
+          {"passenger_front_door_open", "Door (Passenger Front)"},
+          {"passenger_rear_door_open", "Door (Passenger Rear)"}
+        ] do
+      config = decoded["components"][object_id]
+
+      assert config["platform"] == "binary_sensor"
+      assert config["name"] == entity_name
+      assert config["device_class"] == "door"
+      assert config["payload_on"] == "true"
+      assert config["payload_off"] == "false"
+      assert config["icon"] == "mdi:car-door"
+      assert config["state_topic"] == "teslamate/cars/0/#{object_id}"
+      refute Map.has_key?(config, "entity_category")
+      refute Map.has_key?(config, "enabled_by_default")
+    end
+  end
+
   test "publishes tire soft warnings as diagnostic problems", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -31,9 +31,8 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     car: %Car{id: 0, name: "Tesla Model 3", model: "3"}
   }
 
-  test "migrates enabled components before cleanup and disabled components after cleanup", %{
-    test: name
-  } do
+  test "migrates legacy enabled components before cleanup and disabled components after cleanup",
+       %{test: name} do
     publisher_name = start_publisher(name)
 
     opts =
@@ -77,7 +76,25 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     decoded = Jason.decode!(final_payload)
 
     components = decoded["components"]
-    assert map_size(components) == length(migrations)
+    assert map_size(components) > length(migrations)
+
+    assert "homeassistant/device_tracker/teslamate_0/location/config" in migration_topics
+
+    for {component_id, legacy_topic} <- [
+          {"latitude", "homeassistant/sensor/teslamate_0/latitude/config"},
+          {"raw_location", "homeassistant/sensor/teslamate_0/location/config"},
+          {"charge_current_request",
+           "homeassistant/sensor/teslamate_0/charge_current_request/config"},
+          {"service_mode", "homeassistant/binary_sensor/teslamate_0/service_mode/config"},
+          {"driver_front_window_open",
+           "homeassistant/binary_sensor/teslamate_0/driver_front_window_open/config"},
+          {"driver_front_door_open",
+           "homeassistant/binary_sensor/teslamate_0/driver_front_door_open/config"}
+        ] do
+      assert Map.has_key?(components, component_id)
+      refute legacy_topic in migration_topics
+      refute legacy_topic in cleanup_topics
+    end
 
     disabled_component_ids =
       for {object_id, %{"enabled_by_default" => false}} <- components, do: object_id

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -454,6 +454,49 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     end
   end
 
+  test "publishes raw location sensors disabled by default", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+
+    for {object_id, entity_name, icon} <- [
+          {"latitude", "Latitude", "mdi:latitude"},
+          {"longitude", "Longitude", "mdi:longitude"}
+        ] do
+      config = decoded["components"][object_id]
+
+      assert config["platform"] == "sensor"
+      assert config["name"] == entity_name
+      assert config["enabled_by_default"] == false
+      assert config["state_class"] == "measurement"
+      assert config["unit_of_measurement"] == "°"
+      assert config["icon"] == icon
+      assert config["state_topic"] == "teslamate/cars/0/#{object_id}"
+      refute Map.has_key?(config, "entity_category")
+    end
+
+    raw_location = decoded["components"]["raw_location"]
+    assert raw_location["platform"] == "sensor"
+    assert raw_location["name"] == "Location"
+    assert raw_location["enabled_by_default"] == false
+    assert raw_location["icon"] == "mdi:car"
+    assert raw_location["state_topic"] == "teslamate/cars/0/location"
+    assert raw_location["unique_id"] == "teslamate_0_location"
+    assert raw_location["object_id"] == "tesla_location"
+    refute Map.has_key?(raw_location, "component_id")
+    refute Map.has_key?(raw_location, "entity_category")
+
+    tracker = decoded["components"]["location"]
+    assert tracker["platform"] == "device_tracker"
+    assert Map.has_key?(tracker, "name")
+    assert tracker["name"] == nil
+    assert tracker["json_attributes_topic"] == "teslamate/cars/0/location"
+    assert tracker["unique_id"] == "teslamate_0_location"
+    refute Map.has_key?(tracker, "enabled_by_default")
+  end
+
   test "active route sensors include availability and template", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -70,16 +70,8 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     migration_topics = Enum.map(migrations, &elem(&1, 0))
     cleanup_topics = Enum.map(cleanup, &elem(&1, 0))
 
-    assert MapSet.subset?(MapSet.new(migration_topics), MapSet.new(cleanup_topics))
+    assert migration_topics == cleanup_topics
     assert Enum.all?(cleanup, &match?({_topic, "", [retain: true, qos: 1]}, &1))
-
-    for position <- ["fl", "fr", "rl", "rr"] do
-      removed_topic =
-        "homeassistant/sensor/teslamate_0/tpms_pressure_#{position}_psi/config"
-
-      refute removed_topic in migration_topics
-      assert removed_topic in cleanup_topics
-    end
 
     migration_decoded = Jason.decode!(migration_payload)
     decoded = Jason.decode!(final_payload)
@@ -578,7 +570,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert %{"topic" => "teslamate/cars/0/active_route"} = config["availability"]
   end
 
-  test "publishes tire pressures in bar without derived psi sensors", %{test: name} do
+  test "publishes tire pressures in bar and psi", %{test: name} do
     publisher_name = start_publisher(name)
 
     :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
@@ -591,8 +583,6 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
           {"rl", "Tire Pressure (Rear Left)"},
           {"rr", "Tire Pressure (Rear Right)"}
         ] do
-      refute Map.has_key?(decoded["components"], "tpms_pressure_#{position}_psi")
-
       config = decoded["components"]["tpms_pressure_#{position}"]
       assert config["platform"] == "sensor"
       assert config["name"] == entity_name
@@ -602,6 +592,18 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       assert config["suggested_display_precision"] == 1
       assert config["icon"] == "mdi:gauge"
       assert config["state_topic"] == "teslamate/cars/0/tpms_pressure_#{position}"
+
+      psi_config = decoded["components"]["tpms_pressure_#{position}_psi"]
+      assert psi_config["platform"] == "sensor"
+      assert psi_config["name"] == String.replace(entity_name, ")", ", PSI)")
+      assert psi_config["device_class"] == "pressure"
+      assert psi_config["state_class"] == "measurement"
+      assert psi_config["enabled_by_default"] == false
+      assert psi_config["unit_of_measurement"] == "psi"
+      assert psi_config["suggested_display_precision"] == 1
+      assert psi_config["icon"] == "mdi:gauge"
+      assert psi_config["state_topic"] == "teslamate/cars/0/tpms_pressure_#{position}"
+      assert String.contains?(psi_config["value_template"], "14.50377")
     end
   end
 

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -545,7 +545,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
   test "backs off failed discovery publishes and retries the latest metadata", %{test: name} do
     topic = "homeassistant/device/teslamate_0/config"
     error = {:error, :disconnected}
-    responses = %{topic => List.duplicate(error, 7) ++ [:ok, error]}
+    responses = %{topic => List.duplicate(error, 7) ++ [:ok, :ok, error]}
 
     log =
       ExUnit.CaptureLog.capture_log(fn ->


### PR DESCRIPTION
Addresses #5624 by adding and updating various entities to the discovery payload.

**Must be merged after #5618.**. I'll rebase to eliminate the extra commits once it has been squashed and merged.