### PR TITLE
fix(drives): keep mileage when a position has no odometer

### DIFF
--- a/lib/teslamate/log.ex
+++ b/lib/teslamate/log.ex
@@ -258,9 +258,13 @@ defmodule TeslaMate.Log do
           power_min: min(p.power) |> over(:w),
           start_date: first_value(p.date) |> over(:w),
           end_date: last_value(p.date) |> over(:w),
-          start_km: first_value(p.odometer) |> over(:w),
-          end_km: last_value(p.odometer) |> over(:w),
-          distance: (last_value(p.odometer) |> over(:w)) - (first_value(p.odometer) |> over(:w)),
+          # min/max skip NULLs where first_value/last_value do not, so a position
+          # without an odometer no longer blanks out the mileage of a drive. The
+          # odometer never decreases within a drive, so these are the first and
+          # last readings that exist.
+          start_km: min(p.odometer) |> over(:w),
+          end_km: max(p.odometer) |> over(:w),
+          distance: (max(p.odometer) |> over(:w)) - (min(p.odometer) |> over(:w)),
           duration_min:
             fragment(
               "round(extract(epoch from (? - ?)) / 60)::integer",

--- a/priv/repo/migrations/20260819100000_repair_drives_with_missing_odometer.exs
+++ b/priv/repo/migrations/20260819100000_repair_drives_with_missing_odometer.exs
@@ -1,0 +1,40 @@
+defmodule TeslaMate.Repo.Migrations.RepairDrivesWithMissingOdometer do
+  use Ecto.Migration
+
+  # Drives closed before the switch from first_value/last_value to min/max kept
+  # a NULL start_km, end_km and distance whenever their first or last position
+  # carried no odometer. Recompute those three columns from the positions that
+  # are still around, so existing installations converge on the values the
+  # current code would write.
+  #
+  # Only rows that are actually broken are touched, and only when the retained
+  # positions prove a positive distance: a drive whose positions have since been
+  # purged, or that has a single odometer reading left, keeps its NULLs rather
+  # than gaining a fabricated 0.
+  def up do
+    execute("""
+    WITH recomputed AS (
+      SELECT p.drive_id AS id,
+             min(p.odometer) AS start_km,
+             max(p.odometer) AS end_km
+      FROM positions p
+      WHERE p.drive_id IS NOT NULL
+        AND p.odometer IS NOT NULL
+      GROUP BY 1
+    )
+    UPDATE drives d
+    SET start_km = r.start_km,
+        end_km = r.end_km,
+        distance = r.end_km - r.start_km
+    FROM recomputed r
+    WHERE d.id = r.id
+      AND (d.start_km IS NULL OR d.end_km IS NULL OR d.distance IS NULL)
+      AND r.end_km > r.start_km
+    """)
+  end
+
+  def down do
+    # The previous NULLs carry no information worth restoring.
+    :ok
+  end
+end

--- a/test/teslamate/log/log_drive_test.exs
+++ b/test/teslamate/log/log_drive_test.exs
@@ -154,6 +154,56 @@ defmodule TeslaMate.LogDriveTest do
       assert ^addr_id = drive.end_address_id
     end
 
+    test "aggregates drive data if positions are missing the odometer" do
+      car = car_fixture()
+
+      positions = [
+        %{
+          date: "2019-04-06 10:19:02",
+          latitude: 50.112198,
+          longitude: 11.597669,
+          ideal_battery_range_km: 338.8,
+          rated_battery_range_km: 308.8
+        },
+        %{
+          date: "2019-04-06 10:20:08",
+          latitude: 50.112214,
+          longitude: 11.598471,
+          odometer: 285.90556,
+          ideal_battery_range_km: 337.8,
+          rated_battery_range_km: 307.8
+        },
+        %{
+          date: "2019-04-06 10:21:14",
+          latitude: 50.112167,
+          longitude: 11.599395,
+          odometer: 288.045561,
+          ideal_battery_range_km: 336.8,
+          rated_battery_range_km: 306.8
+        },
+        %{
+          date: "2019-04-06 10:22:20",
+          latitude: 50.112118,
+          longitude: 11.599919,
+          ideal_battery_range_km: 335.8,
+          rated_battery_range_km: 305.8
+        }
+      ]
+
+      assert {:ok, drive} = Log.start_drive(car)
+
+      for p <- positions do
+        assert {:ok, _} = Log.insert_position(drive, p)
+      end
+
+      assert {:ok, drive} = Log.close_drive(drive)
+
+      assert drive.start_km == 285.90556
+      assert drive.end_km == 288.045561
+      assert drive.distance == 288.045561 - 285.90556
+      assert drive.duration_min == 3
+    end
+
     test "deletes a drive and if it has no positions" do
       car = car_fixture()
 


### PR DESCRIPTION
Addresses case 1 of #5583 — drives losing `start_km` — and stays inside the Log layer as direction 3 suggests, so no state machine changes.

## The bug

`close_drive/2` reads a drive's mileage with `first_value(p.odometer)` / `last_value(p.odometer)` over the drive's positions. Neither skips NULLs, so a drive whose first or last position carries no odometer is closed with `start_km`, `end_km` and `distance` all NULL — permanently, since a closed drive is never recomputed. That is the reported symptom on Fleet Telemetry setups, where a record can be built from a single partial payload.

`min` and `max` ignore NULLs, and since the odometer never decreases within a drive they return exactly the same values as `first_value`/`last_value` whenever every position carries one. The Owner API path is therefore unchanged.

## Changes

- `close_drive/2`: `start_km`, `end_km` and `distance` come from `min`/`max` over the same window.
- A migration recomputes those three columns for drives that are already affected, from the positions still retained. It only touches rows that are actually broken, and only when the retained positions prove a positive distance — a drive whose positions have been purged keeps its NULLs rather than gaining a fabricated `0`.
- A regression test where the odometer is missing from both the first and the last position.

## Verification

`mix test` against `postgres:18-trixie` on `elixir:1.20.2-otp-29`. The new test fails on current main and passes with the change; the rest of the suite is unaffected.

## Not covered

A drive where *no* position carries an odometer still ends up with NULLs. `distance` is nil there, and the `distance >= 0.01` guard accepts nil because atoms sort above numbers in Elixir, so the drive is kept rather than deleted. That behaviour is unchanged by this PR and seemed like a separate call — happy to fold it in if you would rather have those drives dropped.
