### PR TITLE
feat(mqtt): refine Home Assistant discovery entity metadata and semantics

### DIFF
--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -587,10 +587,10 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       {"sensor", "battery_level",
        %{
          state_topic_key: :battery_level,
-         name: "Battery Level",
+         name: "Battery",
          device_class: "battery",
-         unit_of_measurement: "%",
-         icon: "mdi:battery-80"
+         state_class: "measurement",
+         unit_of_measurement: "%"
        }},
       {"sensor", "usable_battery_level",
        %{

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -972,6 +972,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
        Map.merge(true_false, %{
          state_topic_key: :service_mode,
          name: "Service Mode",
+         device_class: "running",
          icon: "mdi:wrench"
        })},
       {"binary_sensor", "tpms_soft_warning_fl",
@@ -1010,6 +1011,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
        Map.merge(true_false, %{
          state_topic_key: :sentry_mode,
          name: "Sentry Mode",
+         device_class: "running",
          icon: "mdi:cctv"
        })},
       {"binary_sensor", "windows_open",
@@ -1085,47 +1087,49 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       {"binary_sensor", "trunk_open",
        Map.merge(true_false, %{
          state_topic_key: :trunk_open,
-         name: "Trunk Open",
-         device_class: "opening",
-         icon: "mdi:car-side"
+         name: "Trunk",
+         device_class: "door",
+         icon: "mdi:car"
        })},
       {"binary_sensor", "frunk_open",
        Map.merge(true_false, %{
          state_topic_key: :frunk_open,
-         name: "Frunk Open",
-         device_class: "opening",
-         icon: "mdi:car-side"
+         name: "Frunk",
+         device_class: "door",
+         icon: "mdi:car"
        })},
       {"binary_sensor", "is_user_present",
        Map.merge(true_false, %{
          state_topic_key: :is_user_present,
-         name: "Is User Present",
+         name: "User",
          device_class: "presence",
          icon: "mdi:human-greeting"
        })},
       {"binary_sensor", "is_climate_on",
        Map.merge(true_false, %{
          state_topic_key: :is_climate_on,
-         name: "Is Climate On",
-         icon: "mdi:fan"
+         name: "Climate",
+         device_class: "running",
+         icon: "mdi:air-conditioner"
        })},
       {"binary_sensor", "is_preconditioning",
        Map.merge(true_false, %{
          state_topic_key: :is_preconditioning,
-         name: "Is Preconditioning",
-         icon: "mdi:fan"
+         name: "Preconditioning",
+         device_class: "running",
+         icon: "mdi:air-conditioner"
        })},
       {"binary_sensor", "plugged_in",
        Map.merge(true_false, %{
          state_topic_key: :plugged_in,
-         name: "Plugged In",
+         name: "Plug",
          device_class: "plug",
          icon: "mdi:ev-station"
        })},
       {"binary_sensor", "charge_port_door_open",
        Map.merge(true_false, %{
          state_topic_key: :charge_port_door_open,
-         name: "Charge Port Door OPEN",
+         name: "Charge Port",
          device_class: "opening",
          icon: "mdi:ev-plug-tesla"
        })},
@@ -1134,7 +1138,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       {"binary_sensor", "locked",
        %{
          state_topic_key: :locked,
-         name: "Locked",
+         name: "Lock",
          device_class: "lock",
          payload_on: "false",
          payload_off: "true"

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -81,6 +81,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
     {"binary_sensor", "charge_port_door_open"},
     {"binary_sensor", "locked"}
   ]
+  @removed_legacy_discovery_entities [{"binary_sensor", "update_available"}]
   @version Mix.Project.config()[:version]
 
   @type publish_opts :: [
@@ -232,11 +233,14 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
   defp publish_legacy_configs(prefix, node, payload, publisher) do
     entities =
-      Enum.filter(entities(), fn {component, object_id, _config} ->
-        {component, object_id} in @legacy_discovery_entities
-      end)
+      for {component, object_id, _config} <- entities(),
+          {component, object_id} in @legacy_discovery_entities,
+          do: {component, object_id}
 
-    Enum.reduce_while(entities, :ok, fn {component, object_id, _config}, _acc ->
+    entities =
+      if payload == "", do: entities ++ @removed_legacy_discovery_entities, else: entities
+
+    Enum.reduce_while(entities, :ok, fn {component, object_id}, _acc ->
       topic = component_discovery_topic(prefix, component, node, object_id)
 
       case call(publisher, :publish, [topic, payload, [retain: true, qos: 1]]) do
@@ -455,8 +459,21 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          enabled_by_default: false,
          icon: "mdi:numeric"
        }},
+      {"sensor", "update_available",
+       %{
+         state_topic_key: :update_available,
+         name: "Update Available",
+         entity_category: "diagnostic",
+         enabled_by_default: false
+       }},
       {"sensor", "update_version",
-       %{state_topic_key: :update_version, name: "Update Version", icon: "mdi:alphabetical"}},
+       %{
+         state_topic_key: :update_version,
+         name: "Update Version",
+         entity_category: "diagnostic",
+         enabled_by_default: false,
+         icon: "mdi:numeric"
+       }},
       {"sensor", "model",
        %{
          state_topic_key: :model,
@@ -705,6 +722,15 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          suggested_display_precision: 0,
          icon: "mdi:update"
        }},
+
+      # --- Software update ---
+      {"update", "update",
+       %{
+         state_topic_key: :software_update,
+         name: "Update",
+         device_class: "firmware",
+         entity_category: "diagnostic"
+       }},
       {"sensor", "sun_roof_state",
        %{
          state_topic_key: :sun_roof_state,
@@ -888,12 +914,6 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          state_topic_key: :healthy,
          name: "Healthy",
          icon: "mdi:heart-pulse"
-       })},
-      {"binary_sensor", "update_available",
-       Map.merge(true_false, %{
-         state_topic_key: :update_available,
-         name: "Update Available",
-         icon: "mdi:alarm"
        })},
       {"binary_sensor", "sun_roof_installed",
        Map.merge(true_false, %{

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -551,7 +551,8 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
        %{
          state_topic_key: :shift_state,
          name: "Parking Brake",
-         value_template: "{% if value == 'P' %}ON{% else %}OFF{% endif %}",
+         value_template:
+           "{% if value in ['', 'P'] %}ON{% elif value in ['D', 'N', 'R'] %}OFF{% else %}None{% endif %}",
          icon: "mdi:car-brake-parking"
        }},
 

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -277,7 +277,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       {:availability_topic_key, key}, acc ->
         availability = %{
           topic: topic(key, car_id, namespace),
-          value_template: "{{ 'offline' if value_json.error else 'online' }}"
+          value_template: active_route_availability_template()
         }
 
         Map.put(acc, :availability, availability)
@@ -386,6 +386,18 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
   defp humanize_value_template(:snake_case),
     do: "{{ value | replace('_', ' ') | title }}"
+
+  defp active_route_availability_template do
+    "{{ 'online' if value_json is mapping and not value_json.get('error') else 'offline' }}"
+  end
+
+  defp active_route_value_template(key) do
+    "{% if value_json is mapping and not value_json.get('error') and value_json.get('#{key}') is not none %}{{ value_json.get('#{key}') }}{% endif %}"
+  end
+
+  defp active_route_location_template do
+    "{% if value_json is mapping and not value_json.get('error') and value_json.get('location') is mapping %}{{ value_json.get('location') | tojson }}{% else %}{}{% endif %}"
+  end
 
   defp non_empty(value) when is_binary(value) and value != "", do: value
   defp non_empty(_value), do: nil
@@ -879,54 +891,49 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       {"sensor", "active_route_destination",
        %{
          state_topic_key: :active_route,
-         name: "Active route destination",
+         name: "Active Route Destination",
          icon: "mdi:map-marker",
-         value_template:
-           "{% if not value_json.error and value_json.destination %}{{ value_json.destination }}{% endif %}",
+         value_template: active_route_value_template("destination"),
          availability_topic_key: :active_route
        }},
       {"sensor", "active_route_energy_at_arrival",
        %{
          state_topic_key: :active_route,
-         name: "Active route energy at arrival",
+         name: "Active Route Energy At Arrival",
          device_class: "battery",
          unit_of_measurement: "%",
          icon: "mdi:battery-80",
-         value_template:
-           "{% if not value_json.error and value_json.energy_at_arrival %}{{ value_json.energy_at_arrival }}{% endif %}",
+         value_template: active_route_value_template("energy_at_arrival"),
          availability_topic_key: :active_route
        }},
       {"sensor", "active_route_distance_to_arrival",
        %{
          state_topic_key: :active_route,
-         name: "Active route distance to arrival",
+         name: "Active Route Distance To Arrival",
          device_class: "distance",
-         unit_of_measurement: "km",
+         unit_of_measurement: "mi",
          icon: "mdi:map-marker-distance",
-         value_template:
-           "{% if not value_json.error and value_json.miles_to_arrival %}{{ (value_json.miles_to_arrival | float * 1.60934) | round(2) }}{% endif %}",
+         value_template: active_route_value_template("miles_to_arrival"),
          availability_topic_key: :active_route
        }},
       {"sensor", "active_route_minutes_to_arrival",
        %{
          state_topic_key: :active_route,
-         name: "Active route minutes to arrival",
+         name: "Active Route Minutes To Arrival",
          device_class: "duration",
          unit_of_measurement: "min",
          icon: "mdi:clock-outline",
-         value_template:
-           "{% if not value_json.error and value_json.minutes_to_arrival %}{{ value_json.minutes_to_arrival }}{% endif %}",
+         value_template: active_route_value_template("minutes_to_arrival"),
          availability_topic_key: :active_route
        }},
       {"sensor", "active_route_traffic_minutes_delay",
        %{
          state_topic_key: :active_route,
-         name: "Active route traffic minutes delay",
+         name: "Active Route Traffic Minutes Delay",
          device_class: "duration",
          unit_of_measurement: "min",
          icon: "mdi:clock-alert-outline",
-         value_template:
-           "{% if not value_json.error and value_json.traffic_minutes_delay %}{{ value_json.traffic_minutes_delay }}{% endif %}",
+         value_template: active_route_value_template("traffic_minutes_delay"),
          availability_topic_key: :active_route
        }},
 
@@ -936,10 +943,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       {"device_tracker", "active_route_location",
        %{
          json_attributes_topic_key: :active_route,
-         name: "Active route location",
+         name: "Active Route Location",
          icon: "mdi:crosshairs-gps",
-         json_attributes_template:
-           "{% if not value_json.error and value_json.location %}{{ value_json.location | tojson }}{% else %}{}{% endif %}",
+         json_attributes_template: active_route_location_template(),
          availability_topic_key: :active_route
        }},
 

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -379,6 +379,14 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
   defp split_camel_case(value), do: Regex.replace(~r/(?<=[a-z])(?=[A-Z])/, value, " ")
 
+  defp humanize_value_template(:title_case), do: "{{ value | title }}"
+
+  defp humanize_value_template(:camel_case),
+    do: "{{ value | regex_replace('(?<=[a-z])(?=[A-Z])', ' ') }}"
+
+  defp humanize_value_template(:snake_case),
+    do: "{{ value | replace('_', ' ') | title }}"
+
   defp non_empty(value) when is_binary(value) and value != "", do: value
   defp non_empty(_value), do: nil
 
@@ -434,15 +442,26 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          unit_of_measurement: "°",
          icon: "mdi:longitude"
        }},
-      {"sensor", "state", %{state_topic_key: :state, name: "State", icon: "mdi:car-connected"}},
+      {"sensor", "state",
+       %{
+         state_topic_key: :state,
+         name: "State",
+         icon: "mdi:car-connected",
+         value_template: humanize_value_template(:title_case)
+       }},
       {"sensor", "charging_state",
-       %{state_topic_key: :charging_state, name: "Charging State", icon: "mdi:ev-station"}},
+       %{
+         state_topic_key: :charging_state,
+         name: "Charging State",
+         icon: "mdi:ev-station",
+         value_template: humanize_value_template(:camel_case)
+       }},
       {"sensor", "climate_keeper_mode",
        %{
          state_topic_key: :climate_keeper_mode,
          name: "Climate Keeper",
          icon: "mdi:air-conditioner",
-         value_template: "{{ value | title }}"
+         value_template: humanize_value_template(:title_case)
        }},
       {"sensor", "center_display_state",
        %{
@@ -505,7 +524,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          entity_category: "diagnostic",
          enabled_by_default: false,
          icon: "mdi:palette",
-         value_template: "{{ value | regex_replace('(?<=[a-z])(?=[A-Z])', ' ') }}"
+         value_template: humanize_value_template(:camel_case)
        }},
       {"sensor", "wheel_type",
        %{
@@ -751,7 +770,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          state_topic_key: :sun_roof_state,
          name: "Sunroof State",
          icon: "mdi:car-convertible",
-         value_template: "{{ value | replace('_', ' ') | title }}"
+         value_template: humanize_value_template(:snake_case)
        }},
       {"sensor", "sun_roof_percent_open",
        %{

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -486,9 +486,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       {"sensor", "since",
        %{
          state_topic_key: :since,
-         name: "Since",
+         name: "Last Seen",
          device_class: "timestamp",
-         icon: "mdi:clock-outline"
+         icon: "mdi:timer-sand"
        }},
       {"sensor", "version",
        %{
@@ -574,22 +574,27 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          state_topic_key: :power,
          name: "Power",
          device_class: "power",
+         state_class: "measurement",
          unit_of_measurement: "kW",
-         icon: "mdi:flash"
+         suggested_display_precision: 0
        }},
       {"sensor", "speed",
        %{
          state_topic_key: :speed,
          name: "Speed",
          device_class: "speed",
+         state_class: "measurement",
          unit_of_measurement: "km/h",
+         suggested_display_precision: 0,
          icon: "mdi:speedometer"
        }},
       {"sensor", "heading",
        %{
          state_topic_key: :heading,
          name: "Heading",
+         state_class: "measurement",
          unit_of_measurement: "°",
+         suggested_display_precision: 0,
          icon: "mdi:compass"
        }},
       {"sensor", "elevation",
@@ -597,23 +602,29 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          state_topic_key: :elevation,
          name: "Elevation",
          device_class: "distance",
+         state_class: "measurement",
          unit_of_measurement: "m",
+         suggested_display_precision: 0,
          icon: "mdi:image-filter-hdr"
        }},
       {"sensor", "inside_temp",
        %{
          state_topic_key: :inside_temp,
-         name: "Inside Temp",
+         name: "Temperature (Inside)",
          device_class: "temperature",
+         state_class: "measurement",
          unit_of_measurement: "°C",
+         suggested_display_precision: 1,
          icon: "mdi:thermometer-lines"
        }},
       {"sensor", "outside_temp",
        %{
          state_topic_key: :outside_temp,
-         name: "Outside Temp",
+         name: "Temperature (Outside)",
          device_class: "temperature",
+         state_class: "measurement",
          unit_of_measurement: "°C",
+         suggested_display_precision: 1,
          icon: "mdi:thermometer-lines"
        }},
       {"sensor", "odometer",
@@ -621,32 +632,40 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          state_topic_key: :odometer,
          name: "Odometer",
          device_class: "distance",
+         state_class: "total_increasing",
          unit_of_measurement: "km",
+         suggested_display_precision: 0,
          icon: "mdi:counter"
        }},
       {"sensor", "est_battery_range",
        %{
          state_topic_key: :est_battery_range_km,
-         name: "Est Battery Range",
+         name: "Range (Estimated)",
          device_class: "distance",
+         state_class: "measurement",
          unit_of_measurement: "km",
-         icon: "mdi:gauge"
+         suggested_display_precision: 0,
+         icon: "mdi:map-marker-distance"
        }},
       {"sensor", "rated_battery_range",
        %{
          state_topic_key: :rated_battery_range_km,
-         name: "Rated Battery Range",
+         name: "Range (Rated)",
          device_class: "distance",
+         state_class: "measurement",
          unit_of_measurement: "km",
-         icon: "mdi:gauge"
+         suggested_display_precision: 0,
+         icon: "mdi:map-marker-distance"
        }},
       {"sensor", "ideal_battery_range",
        %{
          state_topic_key: :ideal_battery_range_km,
-         name: "Ideal Battery Range",
+         name: "Range (Ideal)",
          device_class: "distance",
+         state_class: "measurement",
          unit_of_measurement: "km",
-         icon: "mdi:gauge"
+         suggested_display_precision: 0,
+         icon: "mdi:map-marker-distance"
        }},
       {"sensor", "battery_level",
        %{
@@ -659,35 +678,38 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       {"sensor", "usable_battery_level",
        %{
          state_topic_key: :usable_battery_level,
-         name: "Usable Battery Level",
+         name: "Usable Battery",
          device_class: "battery",
-         unit_of_measurement: "%",
-         icon: "mdi:battery-80"
+         state_class: "measurement",
+         unit_of_measurement: "%"
        }},
       {"sensor", "charge_energy_added",
        %{
          state_topic_key: :charge_energy_added,
-         name: "Charge Energy Added",
+         name: "Energy Added",
          device_class: "energy",
          state_class: "total_increasing",
          unit_of_measurement: "kWh",
+         suggested_display_precision: 1,
          icon: "mdi:battery-charging"
        }},
       {"sensor", "charge_limit_soc",
        %{
          state_topic_key: :charge_limit_soc,
-         name: "Charge Limit Soc",
-         device_class: "battery",
+         name: "Charge Limit",
+         state_class: "measurement",
          unit_of_measurement: "%",
-         icon: "mdi:battery-charging-100"
+         suggested_display_precision: 0,
+         icon: "mdi:battery-charging-90"
        }},
       {"sensor", "charger_actual_current",
        %{
          state_topic_key: :charger_actual_current,
-         name: "Charger Actual Current",
+         name: "Charger Current",
          device_class: "current",
+         state_class: "measurement",
          unit_of_measurement: "A",
-         icon: "mdi:lightning-bolt"
+         suggested_display_precision: 0
        }},
       {"sensor", "charge_current_request",
        %{
@@ -721,31 +743,33 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          state_topic_key: :charger_power,
          name: "Charger Power",
          device_class: "power",
+         state_class: "measurement",
          unit_of_measurement: "kW",
-         icon: "mdi:lightning-bolt"
+         suggested_display_precision: 0
        }},
       {"sensor", "charger_voltage",
        %{
          state_topic_key: :charger_voltage,
          name: "Charger Voltage",
          device_class: "voltage",
+         state_class: "measurement",
          unit_of_measurement: "V",
-         icon: "mdi:lightning-bolt"
+         suggested_display_precision: 0
        }},
       {"sensor", "scheduled_charging_start_time",
        %{
          state_topic_key: :scheduled_charging_start_time,
-         name: "Scheduled Charging Start Time",
-         device_class: "timestamp",
-         icon: "mdi:clock-outline"
+         name: "Charging Start Time",
+         device_class: "timestamp"
        }},
       {"sensor", "time_to_full_charge",
        %{
          state_topic_key: :time_to_full_charge,
-         name: "Time To Full Charge",
+         name: "Charging Time Remaining",
          device_class: "duration",
+         state_class: "measurement",
          unit_of_measurement: "h",
-         icon: "mdi:clock-outline"
+         icon: "mdi:timer"
        }},
       {"sensor", "download_perc",
        %{

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -468,6 +468,17 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          icon: "mdi:ev-station",
          value_template: humanize_value_template(:camel_case)
        }},
+      {"binary_sensor", "charging_state",
+       %{
+         component_id: "charging",
+         state_topic_key: :charging_state,
+         name: "Charging",
+         device_class: "battery_charging",
+         payload_on: "true",
+         payload_off: "false",
+         value_template: "{{ 'true' if value == 'Charging' else 'false' }}",
+         icon: "mdi:battery-charging"
+       }},
       {"sensor", "climate_keeper_mode",
        %{
          state_topic_key: :climate_keeper_mode,

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -603,7 +603,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
        %{
          state_topic_key: :heading,
          name: "Heading",
-         state_class: "measurement",
+         state_class: "measurement_angle",
          unit_of_measurement: "°",
          suggested_display_precision: 0,
          icon: "mdi:compass"

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -910,11 +910,15 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
       # --- Binary sensors (generic true/false on/off) ---
       {"binary_sensor", "healthy",
-       Map.merge(true_false, %{
+       %{
          state_topic_key: :healthy,
-         name: "Healthy",
+         name: "Health",
+         device_class: "problem",
+         entity_category: "diagnostic",
+         payload_on: "false",
+         payload_off: "true",
          icon: "mdi:heart-pulse"
-       })},
+       }},
       {"binary_sensor", "sun_roof_installed",
        Map.merge(true_false, %{
          state_topic_key: :sun_roof_installed,

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -644,7 +644,14 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          suggested_display_precision: 0
        }},
       {"sensor", "charger_phases",
-       %{state_topic_key: :charger_phases, name: "Charger Phases", icon: "mdi:sine-wave"}},
+       %{
+         state_topic_key: :charger_phases,
+         name: "Charger Phases",
+         state_class: "measurement",
+         unit_of_measurement: "phases",
+         suggested_display_precision: 0,
+         icon: "mdi:sine-wave"
+       }},
       {"sensor", "charger_power",
        %{
          state_topic_key: :charger_power,

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -316,6 +316,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
     details =
       []
+      |> maybe_add_exterior_color(summary.exterior_color)
       |> maybe_add_wheels(summary.wheel_type)
       |> maybe_add_spoiler(summary.spoiler_type)
       |> maybe_add_sunroof(summary.sun_roof_installed)
@@ -324,6 +325,13 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
       {nil, _details} -> nil
       {model, []} -> model
       {model, details} -> "#{model} (#{Enum.join(details, ", ")})"
+    end
+  end
+
+  defp maybe_add_exterior_color(details, exterior_color) do
+    case non_empty(exterior_color) do
+      nil -> details
+      exterior_color -> details ++ [split_camel_case(exterior_color)]
     end
   end
 
@@ -491,7 +499,14 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          icon: "mdi:shield-star-outline"
        }},
       {"sensor", "exterior_color",
-       %{state_topic_key: :exterior_color, name: "Exterior Color", icon: "mdi:palette"}},
+       %{
+         state_topic_key: :exterior_color,
+         name: "Exterior Color",
+         entity_category: "diagnostic",
+         enabled_by_default: false,
+         icon: "mdi:palette",
+         value_template: "{{ value | regex_replace('(?<=[a-z])(?=[A-Z])', ' ') }}"
+       }},
       {"sensor", "wheel_type",
        %{
          state_topic_key: :wheel_type,

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -126,6 +126,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
     values =
       %{}
       |> add_simple_values(summary)
+      |> add_software_update(state.last_values)
       |> add_car_latitude_longitude(summary)
       |> add_geofence(summary)
       |> add_active_route(summary)
@@ -300,6 +301,27 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
 
   defp add_simple_values(map, %Summary{} = summary) do
     Map.merge(map, Map.take(summary, @simple_values))
+  end
+
+  defp add_software_update(map, last_values) do
+    values =
+      (last_values || %{})
+      |> Map.merge(Map.reject(map, fn {_key, value} -> value in [nil, :unknown] end))
+
+    with version when is_binary(version) <- values[:version],
+         update_available when is_boolean(update_available) <- values[:update_available],
+         latest_version when is_binary(latest_version) <-
+           if(update_available, do: values[:update_version], else: version) do
+      software_update =
+        Jason.encode!(%{
+          installed_version: version,
+          latest_version: latest_version
+        })
+
+      Map.put(map, :software_update, software_update)
+    else
+      _value -> map
+    end
   end
 
   defp add_car_latitude_longitude(map, %Summary{} = summary) do

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -384,6 +384,157 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
                      [retain: true, qos: 1]}}
   end
 
+  test "aligns measurement sensors with the custom integration", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+
+    sensor = %{"platform" => "sensor"}
+    measurement = Map.put(sensor, "state_class", "measurement")
+    integer_measurement = Map.put(measurement, "suggested_display_precision", 0)
+
+    distance =
+      Map.merge(integer_measurement, %{
+        "device_class" => "distance",
+        "unit_of_measurement" => "km",
+        "icon" => "mdi:map-marker-distance"
+      })
+
+    temperature =
+      Map.merge(measurement, %{
+        "device_class" => "temperature",
+        "unit_of_measurement" => "°C",
+        "suggested_display_precision" => 1,
+        "icon" => "mdi:thermometer-lines"
+      })
+
+    expected = %{
+      "charge_energy_added" =>
+        {"charge_energy_added",
+         Map.merge(sensor, %{
+           "name" => "Energy Added",
+           "device_class" => "energy",
+           "state_class" => "total_increasing",
+           "unit_of_measurement" => "kWh",
+           "suggested_display_precision" => 1,
+           "icon" => "mdi:battery-charging"
+         })},
+      "charge_limit_soc" =>
+        {"charge_limit_soc",
+         Map.merge(integer_measurement, %{
+           "name" => "Charge Limit",
+           "unit_of_measurement" => "%",
+           "icon" => "mdi:battery-charging-90"
+         })},
+      "charger_actual_current" =>
+        {"charger_actual_current",
+         Map.merge(integer_measurement, %{
+           "name" => "Charger Current",
+           "device_class" => "current",
+           "unit_of_measurement" => "A"
+         })},
+      "charger_power" =>
+        {"charger_power",
+         Map.merge(integer_measurement, %{
+           "name" => "Charger Power",
+           "device_class" => "power",
+           "unit_of_measurement" => "kW"
+         })},
+      "charger_voltage" =>
+        {"charger_voltage",
+         Map.merge(integer_measurement, %{
+           "name" => "Charger Voltage",
+           "device_class" => "voltage",
+           "unit_of_measurement" => "V"
+         })},
+      "elevation" =>
+        {"elevation",
+         Map.merge(integer_measurement, %{
+           "name" => "Elevation",
+           "device_class" => "distance",
+           "unit_of_measurement" => "m",
+           "icon" => "mdi:image-filter-hdr"
+         })},
+      "heading" =>
+        {"heading",
+         Map.merge(integer_measurement, %{
+           "name" => "Heading",
+           "unit_of_measurement" => "°",
+           "icon" => "mdi:compass"
+         })},
+      "speed" =>
+        {"speed",
+         Map.merge(integer_measurement, %{
+           "name" => "Speed",
+           "device_class" => "speed",
+           "unit_of_measurement" => "km/h",
+           "icon" => "mdi:speedometer"
+         })},
+      "est_battery_range" =>
+        {"est_battery_range_km", Map.put(distance, "name", "Range (Estimated)")},
+      "ideal_battery_range" =>
+        {"ideal_battery_range_km", Map.put(distance, "name", "Range (Ideal)")},
+      "rated_battery_range" =>
+        {"rated_battery_range_km", Map.put(distance, "name", "Range (Rated)")},
+      "inside_temp" => {"inside_temp", Map.put(temperature, "name", "Temperature (Inside)")},
+      "outside_temp" => {"outside_temp", Map.put(temperature, "name", "Temperature (Outside)")},
+      "odometer" =>
+        {"odometer",
+         Map.merge(sensor, %{
+           "name" => "Odometer",
+           "device_class" => "distance",
+           "state_class" => "total_increasing",
+           "unit_of_measurement" => "km",
+           "suggested_display_precision" => 0,
+           "icon" => "mdi:counter"
+         })},
+      "power" =>
+        {"power",
+         Map.merge(integer_measurement, %{
+           "name" => "Power",
+           "device_class" => "power",
+           "unit_of_measurement" => "kW"
+         })},
+      "scheduled_charging_start_time" =>
+        {"scheduled_charging_start_time",
+         Map.merge(sensor, %{
+           "name" => "Charging Start Time",
+           "device_class" => "timestamp"
+         })},
+      "since" =>
+        {"since",
+         Map.merge(sensor, %{
+           "name" => "Last Seen",
+           "device_class" => "timestamp",
+           "icon" => "mdi:timer-sand"
+         })},
+      "time_to_full_charge" =>
+        {"time_to_full_charge",
+         Map.merge(measurement, %{
+           "name" => "Charging Time Remaining",
+           "device_class" => "duration",
+           "unit_of_measurement" => "h",
+           "icon" => "mdi:timer"
+         })},
+      "usable_battery_level" =>
+        {"usable_battery_level",
+         Map.merge(measurement, %{
+           "name" => "Usable Battery",
+           "device_class" => "battery",
+           "unit_of_measurement" => "%"
+         })}
+    }
+
+    for {object_id, {topic_key, expected_config}} <- expected do
+      config = decoded["components"][object_id]
+
+      assert Map.drop(config, ["object_id", "unique_id"]) ==
+               Map.put(expected_config, "state_topic", "teslamate/cars/0/#{topic_key}")
+    end
+  end
+
   test "locked binary sensor is inverted", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -234,6 +234,32 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
              "{{ value | replace('_', ' ') | title }}"
   end
 
+  test "derives charging status from the charging state", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+    components = decoded["components"]
+
+    charging_state = components["charging_state"]
+    assert charging_state["platform"] == "sensor"
+    assert charging_state["state_topic"] == "teslamate/cars/0/charging_state"
+
+    charging = components["charging"]
+    assert charging["platform"] == "binary_sensor"
+    assert charging["name"] == "Charging"
+    assert charging["device_class"] == "battery_charging"
+    assert charging["payload_on"] == "true"
+    assert charging["payload_off"] == "false"
+    assert charging["value_template"] == "{{ 'true' if value == 'Charging' else 'false' }}"
+    assert charging["icon"] == "mdi:battery-charging"
+    assert charging["state_topic"] == "teslamate/cars/0/charging_state"
+    assert charging["unique_id"] == "teslamate_0_charging"
+    assert charging["object_id"] == "tesla_charging_state"
+    refute Map.has_key?(charging, "component_id")
+  end
+
   test "derives the parking brake from documented shift states", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -602,6 +602,20 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     refute Map.has_key?(config, "icon")
   end
 
+  test "publishes charger phases as an integer measurement", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+    config = decoded["components"]["charger_phases"]
+    assert config["name"] == "Charger Phases"
+    assert config["state_class"] == "measurement"
+    assert config["unit_of_measurement"] == "phases"
+    assert config["suggested_display_precision"] == 0
+    assert config["icon"] == "mdi:sine-wave"
+  end
+
   test "publishes tire pressures in bar and psi", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -212,6 +212,28 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert sunroof["state_topic"] == "teslamate/cars/0/sun_roof_installed"
   end
 
+  test "humanizes enum-like sensor values with Home Assistant templates", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+    components = decoded["components"]
+
+    assert components["state"]["value_template"] == "{{ value | title }}"
+
+    assert components["charging_state"]["value_template"] ==
+             "{{ value | regex_replace('(?<=[a-z])(?=[A-Z])', ' ') }}"
+
+    assert components["climate_keeper_mode"]["value_template"] == "{{ value | title }}"
+
+    assert components["exterior_color"]["value_template"] ==
+             "{{ value | regex_replace('(?<=[a-z])(?=[A-Z])', ' ') }}"
+
+    assert components["sun_roof_state"]["value_template"] ==
+             "{{ value | replace('_', ' ') | title }}"
+  end
+
   test "falls back to raw trim badging when the marketing name is unavailable", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -392,10 +392,45 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     {_topic, decoded} = receive_device_config()
     config = decoded["components"]["locked"]
     assert config["platform"] == "binary_sensor"
+    assert config["name"] == "Lock"
     assert config["payload_on"] == "false"
     assert config["payload_off"] == "true"
     assert config["device_class"] == "lock"
     assert config["state_topic"] == "teslamate/cars/0/locked"
+  end
+
+  test "aligns vehicle status binary sensors with the custom integration", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+
+    expected = [
+      {"charge_port_door_open", "Charge Port", "opening", "mdi:ev-plug-tesla"},
+      {"frunk_open", "Frunk", "door", "mdi:car"},
+      {"trunk_open", "Trunk", "door", "mdi:car"},
+      {"is_climate_on", "Climate", "running", "mdi:air-conditioner"},
+      {"is_preconditioning", "Preconditioning", "running", "mdi:air-conditioner"},
+      {"is_user_present", "User", "presence", "mdi:human-greeting"},
+      {"plugged_in", "Plug", "plug", "mdi:ev-station"},
+      {"service_mode", "Service Mode", "running", "mdi:wrench"},
+      {"sentry_mode", "Sentry Mode", "running", "mdi:cctv"}
+    ]
+
+    for {object_id, entity_name, device_class, icon} <- expected do
+      config = decoded["components"][object_id]
+
+      assert config["platform"] == "binary_sensor"
+      assert config["name"] == entity_name
+      assert config["device_class"] == device_class
+      assert config["payload_on"] == "true"
+      assert config["payload_off"] == "false"
+      assert config["icon"] == icon
+      assert config["state_topic"] == "teslamate/cars/0/#{object_id}"
+      refute Map.has_key?(config, "entity_category")
+      refute Map.has_key?(config, "enabled_by_default")
+    end
   end
 
   test "publishes aggregate and individual cabin door sensors", %{test: name} do
@@ -516,6 +551,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       "service_mode" => %{
         "platform" => "binary_sensor",
         "name" => "Service Mode",
+        "device_class" => "running",
         "payload_on" => "true",
         "payload_off" => "false",
         "icon" => "mdi:wrench"

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -69,8 +69,18 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     migration_topics = Enum.map(migrations, &elem(&1, 0))
     cleanup_topics = Enum.map(cleanup, &elem(&1, 0))
 
-    assert migration_topics == cleanup_topics
+    assert MapSet.subset?(MapSet.new(migration_topics), MapSet.new(cleanup_topics))
     assert Enum.all?(cleanup, &match?({_topic, "", [retain: true, qos: 1]}, &1))
+
+    removed_update_available_topic =
+      "homeassistant/binary_sensor/teslamate_0/update_available/config"
+
+    refute removed_update_available_topic in migration_topics
+    assert removed_update_available_topic in cleanup_topics
+
+    update_available_topic = "homeassistant/sensor/teslamate_0/update_available/config"
+    refute update_available_topic in migration_topics
+    refute update_available_topic in cleanup_topics
 
     migration_decoded = Jason.decode!(migration_payload)
     decoded = Jason.decode!(final_payload)
@@ -616,6 +626,47 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert config["icon"] == "mdi:sine-wave"
   end
 
+  test "publishes software update entities", %{test: name} do
+    publisher_name = start_publisher(name)
+    summary = %{@summary | update_available: true}
+
+    :ok = HomeAssistant.publish(summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+    components = decoded["components"]
+
+    update = components["update"]
+    assert update["platform"] == "update"
+    assert update["name"] == "Update"
+    assert update["device_class"] == "firmware"
+    assert update["entity_category"] == "diagnostic"
+    assert update["state_topic"] == "teslamate/cars/0/software_update"
+    refute Map.has_key?(update, "latest_version_topic")
+    refute Map.has_key?(update, "command_topic")
+
+    version = components["version"]
+    assert version["platform"] == "sensor"
+    assert version["name"] == "Version"
+    assert version["entity_category"] == "diagnostic"
+    assert version["enabled_by_default"] == false
+    assert version["icon"] == "mdi:numeric"
+
+    update_version = components["update_version"]
+    assert update_version["platform"] == "sensor"
+    assert update_version["entity_category"] == "diagnostic"
+    assert update_version["enabled_by_default"] == false
+    assert update_version["icon"] == "mdi:numeric"
+
+    update_available = components["update_available"]
+    assert update_available["platform"] == "sensor"
+    assert update_available["entity_category"] == "diagnostic"
+    assert update_available["enabled_by_default"] == false
+    refute Map.has_key?(update_available, "device_class")
+    refute Map.has_key?(update_available, "icon")
+    refute Map.has_key?(update_available, "payload_on")
+    refute Map.has_key?(update_available, "payload_off")
+  end
+
   test "publishes tire pressures in bar and psi", %{test: name} do
     publisher_name = start_publisher(name)
 
@@ -694,7 +745,15 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
            end)
 
     assert Enum.any?(legacy_cleanup, fn {topic, _, _} ->
+             topic == "homeassistant/binary_sensor/teslamate_0/update_available/config"
+           end)
+
+    assert Enum.any?(legacy_cleanup, fn {topic, _, _} ->
              topic == "homeassistant/sensor/teslamate_0/tpms_pressure_fl_psi/config"
+           end)
+
+    refute Enum.any?(legacy_cleanup, fn {topic, _, _} ->
+             topic == "homeassistant/update/teslamate_0/update/config"
            end)
   end
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -420,6 +420,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     sensor = %{"platform" => "sensor"}
     measurement = Map.put(sensor, "state_class", "measurement")
     integer_measurement = Map.put(measurement, "suggested_display_precision", 0)
+    integer_angle_measurement = Map.put(integer_measurement, "state_class", "measurement_angle")
 
     distance =
       Map.merge(integer_measurement, %{
@@ -485,7 +486,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
          })},
       "heading" =>
         {"heading",
-         Map.merge(integer_measurement, %{
+         Map.merge(integer_angle_measurement, %{
            "name" => "Heading",
            "unit_of_measurement" => "°",
            "icon" => "mdi:compass"

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -234,6 +234,20 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
              "{{ value | replace('_', ' ') | title }}"
   end
 
+  test "derives the parking brake from documented shift states", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+    parking_brake = decoded["components"]["park_brake"]
+
+    assert parking_brake["name"] == "Parking Brake"
+
+    assert parking_brake["value_template"] ==
+             "{% if value in ['', 'P'] %}ON{% elif value in ['D', 'N', 'R'] %}OFF{% else %}None{% endif %}"
+  end
+
   test "falls back to raw trim badging when the marketing name is unavailable", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -644,16 +644,55 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert config["state_topic"] == "teslamate/cars/0/healthy"
   end
 
-  test "active route sensors include availability and template", %{test: name} do
+  test "publishes active route entities with canonical values and robust availability", %{
+    test: name
+  } do
     publisher_name = start_publisher(name)
 
     :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
 
     {_topic, decoded} = receive_device_config()
-    config = decoded["components"]["active_route_destination"]
-    assert config["state_topic"] == "teslamate/cars/0/active_route"
-    assert String.contains?(config["value_template"], "value_json.destination")
-    assert %{"topic" => "teslamate/cars/0/active_route"} = config["availability"]
+    components = decoded["components"]
+
+    availability = %{
+      "topic" => "teslamate/cars/0/active_route",
+      "value_template" =>
+        "{{ 'online' if value_json is mapping and not value_json.get('error') else 'offline' }}"
+    }
+
+    for {object_id, entity_name, field} <- [
+          {"active_route_destination", "Active Route Destination", "destination"},
+          {"active_route_energy_at_arrival", "Active Route Energy At Arrival",
+           "energy_at_arrival"},
+          {"active_route_distance_to_arrival", "Active Route Distance To Arrival",
+           "miles_to_arrival"},
+          {"active_route_minutes_to_arrival", "Active Route Minutes To Arrival",
+           "minutes_to_arrival"},
+          {"active_route_traffic_minutes_delay", "Active Route Traffic Minutes Delay",
+           "traffic_minutes_delay"}
+        ] do
+      config = components[object_id]
+
+      assert config["name"] == entity_name
+      assert config["state_topic"] == "teslamate/cars/0/active_route"
+      assert config["availability"] == availability
+
+      assert config["value_template"] ==
+               "{% if value_json is mapping and not value_json.get('error') and value_json.get('#{field}') is not none %}{{ value_json.get('#{field}') }}{% endif %}"
+    end
+
+    distance = components["active_route_distance_to_arrival"]
+    assert distance["device_class"] == "distance"
+    assert distance["unit_of_measurement"] == "mi"
+    refute String.contains?(distance["value_template"], "1.609")
+
+    tracker = components["active_route_location"]
+    assert tracker["name"] == "Active Route Location"
+    assert tracker["availability"] == availability
+    assert tracker["json_attributes_topic"] == "teslamate/cars/0/active_route"
+
+    assert tracker["json_attributes_template"] ==
+             "{% if value_json is mapping and not value_json.get('error') and value_json.get('location') is mapping %}{{ value_json.get('location') | tojson }}{% else %}{}{% endif %}"
   end
 
   test "publishes battery as device entity", %{test: name} do

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -152,6 +152,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       @summary
       | model: "S",
         trim_badging: "74D",
+        exterior_color: "DeepBlue",
         wheel_type: "AeroTurbine19",
         spoiler_type: "CarbonFiber",
         sun_roof_installed: true,
@@ -164,7 +165,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     {_topic, decoded} = receive_device_config()
 
     assert decoded["device"]["model"] ==
-             ~s|Model S LR AWD (Aero Turbine 19" Wheels, Carbon Fiber Spoiler, Sunroof)|
+             ~s|Model S LR AWD (Deep Blue, Aero Turbine 19" Wheels, Carbon Fiber Spoiler, Sunroof)|
 
     assert decoded["device"]["sw_version"] == "2026.26.1"
   end
@@ -178,6 +179,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     expected = %{
       "display_name" => {"Display Name", "mdi:form-textbox"},
+      "exterior_color" => {"Exterior Color", "mdi:palette"},
       "model" => {"Model", "mdi:form-textbox"},
       "spoiler_type" => {"Spoiler Type", "mdi:car-sports"},
       "trim_badging" => {"Trim Badging", "mdi:shield-star-outline"},
@@ -195,6 +197,9 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       assert config["icon"] == icon
       assert config["state_topic"] == "teslamate/cars/0/#{object_id}"
     end
+
+    assert decoded["components"]["exterior_color"]["value_template"] ==
+             "{{ value | regex_replace('(?<=[a-z])(?=[A-Z])', ' ') }}"
 
     sunroof = decoded["components"]["sun_roof_installed"]
     assert sunroof["platform"] == "binary_sensor"

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -586,6 +586,23 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     refute Map.has_key?(tracker, "enabled_by_default")
   end
 
+  test "health binary sensor reports problems", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+    config = decoded["components"]["healthy"]
+    assert config["platform"] == "binary_sensor"
+    assert config["name"] == "Health"
+    assert config["device_class"] == "problem"
+    assert config["entity_category"] == "diagnostic"
+    assert config["payload_on"] == "false"
+    assert config["payload_off"] == "true"
+    assert config["icon"] == "mdi:heart-pulse"
+    assert config["state_topic"] == "teslamate/cars/0/healthy"
+  end
+
   test "active route sensors include availability and template", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -588,6 +588,20 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert %{"topic" => "teslamate/cars/0/active_route"} = config["availability"]
   end
 
+  test "publishes battery as device entity", %{test: name} do
+    publisher_name = start_publisher(name)
+
+    :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
+
+    {_topic, decoded} = receive_device_config()
+    config = decoded["components"]["battery_level"]
+    assert config["name"] == "Battery"
+    assert config["device_class"] == "battery"
+    assert config["state_class"] == "measurement"
+    assert config["unit_of_measurement"] == "%"
+    refute Map.has_key?(config, "icon")
+  end
+
   test "publishes tire pressures in bar and psi", %{test: name} do
     publisher_name = start_publisher(name)
 

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -500,6 +500,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
       display_name: "Foo",
       model: "3",
       trim_badging: "74D",
+      exterior_color: "DeepBlue",
       wheel_type: "AeroTurbine19",
       state: :online,
       car: %Car{name: "Foo", marketing_name: "LR AWD"}
@@ -518,7 +519,9 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     assert Map.has_key?(decoded, "device")
     assert Map.has_key?(decoded, "components")
     assert Map.has_key?(decoded, "origin")
-    assert decoded["device"]["model"] == ~s|Model 3 LR AWD (Aero Turbine 19" Wheels)|
+
+    assert decoded["device"]["model"] ==
+             ~s|Model 3 LR AWD (Deep Blue, Aero Turbine 19" Wheels)|
 
     drain_discovery_configs()
 
@@ -527,6 +530,19 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     # Changes unrelated to device metadata do not republish discovery.
     refute_receive {MqttPublisherMock,
                     {:publish, "homeassistant/" <> _, _, [retain: true, qos: 1]}}
+
+    summary = %Summary{summary | exterior_color: "PearlWhiteMultiCoat"}
+    send(pid, summary)
+
+    assert_receive {MqttPublisherMock,
+                    {:publish, "homeassistant/device/teslamate_0/config", payload,
+                     [retain: true, qos: 1]}},
+                   500
+
+    assert Jason.decode!(payload)["device"]["model"] ==
+             ~s|Model 3 LR AWD (Pearl White Multi Coat, Aero Turbine 19" Wheels)|
+
+    refute_receive {MqttPublisherMock, {:publish, "homeassistant/" <> _, _, _}}
 
     send(pid, %Summary{summary | sun_roof_installed: false})
     :sys.get_state(pid)
@@ -551,7 +567,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
                    500
 
     assert Jason.decode!(payload)["device"]["model"] ==
-             ~s|Model 3 Performance (Aero Turbine 19" Wheels)|
+             ~s|Model 3 Performance (Pearl White Multi Coat, Aero Turbine 19" Wheels)|
 
     refute_receive {MqttPublisherMock, {:publish, "homeassistant/" <> _, _, _}}
 
@@ -563,7 +579,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
                    500
 
     assert Jason.decode!(payload)["device"]["model"] ==
-             ~s|Model 3 LR AWD (Aero Turbine 19" Wheels, Sunroof)|
+             ~s|Model 3 LR AWD (Pearl White Multi Coat, Aero Turbine 19" Wheels, Sunroof)|
 
     refute_receive {MqttPublisherMock, {:publish, "homeassistant/" <> _, _, _}}
 

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -217,6 +217,14 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
              "longitude" => 41.129182
            }
 
+    assert_receive {MqttPublisherMock,
+                    {:publish, "teslamate/cars/0/software_update", data, [retain: true, qos: 1]}}
+
+    assert Jason.decode!(data) == %{
+             "installed_version" => "2019.42",
+             "latest_version" => "2019.42"
+           }
+
     # Published as nil
     for key <- [
           :active_route_destination,
@@ -242,6 +250,28 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
                     {:publish, "teslamate/cars/0/healthy", "", [retain: true, qos: 1]}}
 
     refute_receive _
+  end
+
+  test "publishes available software update state", %{test: name} do
+    {:ok, pid} = start_subscriber(name, 0)
+
+    assert_receive {VehiclesMock, {:subscribe_to_summary, 0}}
+
+    drain_discovery_configs()
+
+    send(pid, %Summary{
+      version: "2026.14.1",
+      update_available: true,
+      update_version: "2026.20.1"
+    })
+
+    assert_receive {MqttPublisherMock,
+                    {:publish, "teslamate/cars/0/software_update", data, [retain: true, qos: 1]}}
+
+    assert Jason.decode!(data) == %{
+             "installed_version" => "2026.14.1",
+             "latest_version" => "2026.20.1"
+           }
   end
 
   test "publishes charging data", %{test: name} do
@@ -502,6 +532,13 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     :sys.get_state(pid)
 
     # nil and false both omit the sunroof detail, so the rendered device is unchanged.
+    refute_receive {MqttPublisherMock,
+                    {:publish, "homeassistant/" <> _, _, [retain: true, qos: 1]}}
+
+    send(pid, %Summary{summary | update_available: true, update_version: "2026.20.1"})
+    :sys.get_state(pid)
+
+    # Software update state changes do not require discovery to be republished.
     refute_receive {MqttPublisherMock,
                     {:publish, "homeassistant/" <> _, _, [retain: true, qos: 1]}}
 


### PR DESCRIPTION
This is the final tranche of MQTT Discovery Updates.  This addresses many quality-of-life changes around icons, device classes, names, units, and state classes (mentioned in #5635).

**Must be merged after #5629.**. I'll rebase to eliminate the extra commits once it has been squashed and merged.