### PR TITLE
fix: hide map fullscreen tooltip on narrow viewports

### DIFF
--- a/lib/teslamate_web/live/car_live/summary.html.heex
+++ b/lib/teslamate_web/live/car_live/summary.html.heex
@@ -10,7 +10,7 @@
     >
       <button
         type="button"
-        class="map-fullscreen-button button is-small has-tooltip-left"
+        class="map-fullscreen-button button is-small has-tooltip-left has-tooltip-hidden-touch"
         data-tooltip={gettext("Maximize map")}
         data-exit-label={gettext("Minimize map")}
         aria-label={gettext("Maximize map")}

--- a/test/teslamate_web/live/car_summary_live_test.exs
+++ b/test/teslamate_web/live/car_summary_live_test.exs
@@ -371,6 +371,7 @@ defmodule TeslaMateWeb.CarLive.SummaryTest do
 
       attrs = Map.new(attrs)
       assert attrs["type"] == "button"
+      assert "has-tooltip-hidden-touch" in String.split(attrs["class"])
       assert attrs["data-tooltip"] == "Maximize map"
       assert attrs["data-exit-label"] == "Minimize map"
       assert attrs["aria-label"] == "Maximize map"


### PR DESCRIPTION
## What?

Apply the existing `has-tooltip-hidden-touch` class from the tooltip library to the map fullscreen button.

Extend the existing fullscreen-button test to verify that the responsive tooltip class is present.

## Why?

On mobile, tapping the maximize or minimize button leaves its tooltip visible until another part of the screen is tapped.

This is a follow-up to #5495.

## How?

The existing tooltip class suppresses the tooltip at viewport widths of 1023px or narrower. The button retains its translated `aria-label`, and desktop hover tooltips are unaffected.

## Testing

- Built and deployed a production image from the current `main` branch.
- Tested maximizing and minimizing the map on a physical phone.
- Confirmed that the tooltip no longer appears on mobile.
- Ran `mix ci`: 493 tests passed.