### PR TITLE
feat(mqtt): remove derived Home Assistant psi tire pressure sensors, mark manual YAML as legacy

### DIFF
--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -56,10 +56,6 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
     {"sensor", "tpms_pressure_fr"},
     {"sensor", "tpms_pressure_rl"},
     {"sensor", "tpms_pressure_rr"},
-    {"sensor", "tpms_pressure_fl_psi"},
-    {"sensor", "tpms_pressure_fr_psi"},
-    {"sensor", "tpms_pressure_rl_psi"},
-    {"sensor", "tpms_pressure_rr_psi"},
     {"sensor", "active_route_destination"},
     {"sensor", "active_route_energy_at_arrival"},
     {"sensor", "active_route_distance_to_arrival"},
@@ -81,7 +77,13 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
     {"binary_sensor", "charge_port_door_open"},
     {"binary_sensor", "locked"}
   ]
-  @removed_legacy_discovery_entities [{"binary_sensor", "update_available"}]
+  @removed_legacy_discovery_entities [
+    {"binary_sensor", "update_available"},
+    {"sensor", "tpms_pressure_fl_psi"},
+    {"sensor", "tpms_pressure_fr_psi"},
+    {"sensor", "tpms_pressure_rl_psi"},
+    {"sensor", "tpms_pressure_rr_psi"}
+  ]
   @version Mix.Project.config()[:version]
 
   @type publish_opts :: [
@@ -870,56 +872,6 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          unit_of_measurement: "bar",
          suggested_display_precision: 1,
          icon: "mdi:gauge"
-       }},
-
-      # TPMS pressure compatibility sensors (psi), derived from the bar topics
-      {"sensor", "tpms_pressure_fl_psi",
-       %{
-         state_topic_key: :tpms_pressure_fl,
-         name: "Tire Pressure (Front Left, PSI)",
-         device_class: "pressure",
-         state_class: "measurement",
-         enabled_by_default: false,
-         unit_of_measurement: "psi",
-         icon: "mdi:gauge",
-         value_template: "{{ (value | float * 14.50377) | round(2) }}",
-         suggested_display_precision: 1
-       }},
-      {"sensor", "tpms_pressure_fr_psi",
-       %{
-         state_topic_key: :tpms_pressure_fr,
-         name: "Tire Pressure (Front Right, PSI)",
-         device_class: "pressure",
-         state_class: "measurement",
-         enabled_by_default: false,
-         unit_of_measurement: "psi",
-         icon: "mdi:gauge",
-         value_template: "{{ (value | float * 14.50377) | round(2) }}",
-         suggested_display_precision: 1
-       }},
-      {"sensor", "tpms_pressure_rl_psi",
-       %{
-         state_topic_key: :tpms_pressure_rl,
-         name: "Tire Pressure (Rear Left, PSI)",
-         device_class: "pressure",
-         state_class: "measurement",
-         enabled_by_default: false,
-         unit_of_measurement: "psi",
-         icon: "mdi:gauge",
-         value_template: "{{ (value | float * 14.50377) | round(2) }}",
-         suggested_display_precision: 1
-       }},
-      {"sensor", "tpms_pressure_rr_psi",
-       %{
-         state_topic_key: :tpms_pressure_rr,
-         name: "Tire Pressure (Rear Right, PSI)",
-         device_class: "pressure",
-         state_class: "measurement",
-         enabled_by_default: false,
-         unit_of_measurement: "psi",
-         icon: "mdi:gauge",
-         value_template: "{{ (value | float * 14.50377) | round(2) }}",
-         suggested_display_precision: 1
        }},
 
       # --- Active route sensors (derived from the JSON active_route topic) ---

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -64,7 +64,6 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
     {"device_tracker", "location"},
     {"device_tracker", "active_route_location"},
     {"binary_sensor", "healthy"},
-    {"binary_sensor", "update_available"},
     {"binary_sensor", "sentry_mode"},
     {"binary_sensor", "windows_open"},
     {"binary_sensor", "doors_open"},

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -82,6 +82,14 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     refute update_available_topic in migration_topics
     refute update_available_topic in cleanup_topics
 
+    for position <- ["fl", "fr", "rl", "rr"] do
+      removed_topic =
+        "homeassistant/sensor/teslamate_0/tpms_pressure_#{position}_psi/config"
+
+      refute removed_topic in migration_topics
+      assert removed_topic in cleanup_topics
+    end
+
     migration_decoded = Jason.decode!(migration_payload)
     decoded = Jason.decode!(final_payload)
 
@@ -978,7 +986,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     refute Map.has_key?(update_available, "payload_off")
   end
 
-  test "publishes tire pressures in bar and psi", %{test: name} do
+  test "publishes tire pressures in bar without derived psi sensors", %{test: name} do
     publisher_name = start_publisher(name)
 
     :ok = HomeAssistant.publish(@summary, [car_id: 0], {MqttPublisherMock, publisher_name})
@@ -991,6 +999,8 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
           {"rl", "Tire Pressure (Rear Left)"},
           {"rr", "Tire Pressure (Rear Right)"}
         ] do
+      refute Map.has_key?(decoded["components"], "tpms_pressure_#{position}_psi")
+
       config = decoded["components"]["tpms_pressure_#{position}"]
       assert config["platform"] == "sensor"
       assert config["name"] == entity_name
@@ -1000,18 +1010,6 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       assert config["suggested_display_precision"] == 1
       assert config["icon"] == "mdi:gauge"
       assert config["state_topic"] == "teslamate/cars/0/tpms_pressure_#{position}"
-
-      psi_config = decoded["components"]["tpms_pressure_#{position}_psi"]
-      assert psi_config["platform"] == "sensor"
-      assert psi_config["name"] == String.replace(entity_name, ")", ", PSI)")
-      assert psi_config["device_class"] == "pressure"
-      assert psi_config["state_class"] == "measurement"
-      assert psi_config["enabled_by_default"] == false
-      assert psi_config["unit_of_measurement"] == "psi"
-      assert psi_config["suggested_display_precision"] == 1
-      assert psi_config["icon"] == "mdi:gauge"
-      assert psi_config["state_topic"] == "teslamate/cars/0/tpms_pressure_#{position}"
-      assert String.contains?(psi_config["value_template"], "14.50377")
     end
   end
 

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -672,6 +672,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     assert log =~ "retrying in 300s"
   end
 
+  @tag :capture_log
   test "retries Home Assistant discovery after a publishing failure", %{test: name} do
     legacy_topic = "homeassistant/sensor/teslamate_0/display_name/config"
 

--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -467,18 +467,6 @@ Don't forget to replace `<teslamate url>`, `<your tesla model>` and `<your tesla
     icon: mdi:car-tire-alert
 
 - sensor:
-    name: TPMS Pressure Front Left (psi)
-    default_entity_id: sensor.tesla_tpms_pressure_fl_psi
-    unique_id: teslamate_1_tpms_pressure_fl_psi
-    device: *teslamate_device_info
-    state_topic: "teslamate/cars/1/tpms_pressure_fl"
-    device_class: pressure
-    unit_of_measurement: psi
-    icon: mdi:car-tire-alert
-    value_template: "{{ value | float * 14.50377 }}"
-    suggested_display_precision: 2
-
-- sensor:
     name: TPMS Pressure Front Right
     default_entity_id: sensor.tesla_tpms_pressure_fr
     unique_id: teslamate_1_tpms_pressure_fr
@@ -487,18 +475,6 @@ Don't forget to replace `<teslamate url>`, `<your tesla model>` and `<your tesla
     device_class: pressure
     unit_of_measurement: bar
     icon: mdi:car-tire-alert
-
-- sensor:
-    name: TPMS Pressure Front Right (psi)
-    default_entity_id: sensor.tesla_tpms_pressure_fr_psi
-    unique_id: teslamate_1_tpms_pressure_fr_psi
-    device: *teslamate_device_info
-    state_topic: "teslamate/cars/1/tpms_pressure_fr"
-    device_class: pressure
-    unit_of_measurement: psi
-    icon: mdi:car-tire-alert
-    value_template: "{{ value | float * 14.50377 }}"
-    suggested_display_precision: 2
 
 - sensor:
     name: TPMS Pressure Rear Left
@@ -511,18 +487,6 @@ Don't forget to replace `<teslamate url>`, `<your tesla model>` and `<your tesla
     icon: mdi:car-tire-alert
 
 - sensor:
-    name: TPMS Pressure Rear Left (psi)
-    default_entity_id: sensor.tesla_tpms_pressure_rl_psi
-    unique_id: teslamate_1_tpms_pressure_rl_psi
-    device: *teslamate_device_info
-    state_topic: "teslamate/cars/1/tpms_pressure_rl"
-    device_class: pressure
-    unit_of_measurement: psi
-    icon: mdi:car-tire-alert
-    value_template: "{{ value | float * 14.50377 }}"
-    suggested_display_precision: 2
-
-- sensor:
     name: TPMS Pressure Rear Right
     default_entity_id: sensor.tesla_tpms_pressure_rr
     unique_id: teslamate_1_tpms_pressure_rr
@@ -531,18 +495,6 @@ Don't forget to replace `<teslamate url>`, `<your tesla model>` and `<your tesla
     device_class: pressure
     unit_of_measurement: bar
     icon: mdi:car-tire-alert
-
-- sensor:
-    name: TPMS Pressure Rear Right (psi)
-    default_entity_id: sensor.tesla_tpms_pressure_rr_psi
-    unique_id: teslamate_1_tpms_pressure_rr_psi
-    device: *teslamate_device_info
-    state_topic: "teslamate/cars/1/tpms_pressure_rr"
-    device_class: pressure
-    unit_of_measurement: psi
-    icon: mdi:car-tire-alert
-    value_template: "{{ value | float * 14.50377 }}"
-    suggested_display_precision: 2
 
 - sensor:
     name: Active route destination
@@ -937,20 +889,12 @@ views:
             name: Time To Full Charge
           - entity: sensor.tesla_tpms_pressure_fl
             name: Front Left Tire Pressure (bar)
-          - entity: sensor.tesla_tpms_pressure_fl_psi
-            name: Front Left Tire Pressure (psi)
           - entity: sensor.tesla_tpms_pressure_fr
             name: Front Right Tire Pressure (bar)
-          - entity: sensor.tesla_tpms_pressure_fr_psi
-            name: Front Right Tire Pressure (psi)
           - entity: sensor.tesla_tpms_pressure_rl
             name: Rear Left Tire Pressure (bar)
-          - entity: sensor.tesla_tpms_pressure_rl_psi
-            name: Rear Left Tire Pressure (psi)
           - entity: sensor.tesla_tpms_pressure_rr
             name: Rear Right Tire Pressure (bar)
-          - entity: sensor.tesla_tpms_pressure_rr_psi
-            name: Rear Right Tire Pressure (psi)
           - entity: sensor.tesla_active_route_destination
             name: Active Route Destination
           - entity: sensor.tesla_active_route_energy_at_arrival

--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -79,6 +79,12 @@ the previous prefix.
 
 ## Configuration
 
+:::warning[Legacy configuration]
+
+Prefer [MQTT discovery](#mqtt-discovery-automatic-configuration) for new installations. The manual YAML remains available for older Home Assistant versions and custom setups, but it is frozen and will not receive new sensors.
+
+:::
+
 The following configurations assume a car ID of 1 (`teslamate/cars/1`). It usually starts at 1, but it can be different if you have multiple cars in TeslaMate for example.
 
 ### configuration.yaml


### PR DESCRIPTION
This removes the PSI pressure sensors and does the two minor cleanups mentioned #5638.

**Must be merged after #5638.**. I'll rebase to eliminate the extra commits once it has been squashed and merged.