### PR TITLE
ci(ghcr): allow manual dispatch to build images for .github PRs

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -82,10 +82,11 @@ runs:
         cache-to: type=registry,ref=ghcr.io/${{ inputs.repository }}:buildcache-${{ matrix.cache_id }}-${{ steps.normalize_version.outputs.normalized_version }},mode=max
         outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
     - name: Generate SBOM for pushed image
-      # Skip on pull_request: PR builds are unreviewed code. Attesting them
-      # would yield signed attestations that pass `gh attestation verify
-      # --repo teslamate-org/teslamate`, which consumers read as "official".
-      if: github.event_name != 'pull_request'
+      # Skip on pull_request and workflow_dispatch: both build unreviewed
+      # code. Attesting them would yield signed attestations that pass
+      # `gh attestation verify --repo teslamate-org/teslamate`, which
+      # consumers read as "official".
+      if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
       uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       with:
         image: ${{ env.REGISTRY_IMAGE }}@${{ steps.build.outputs.digest }}
@@ -94,7 +95,7 @@ runs:
         upload-artifact: false
         upload-release-assets: false
     - name: Attest build provenance
-      if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
       uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
       with:
         # attest-* reads the registry from the first path segment of subject-name,
@@ -106,7 +107,7 @@ runs:
         subject-digest: ${{ steps.build.outputs.digest }}
         push-to-registry: true
     - name: Attest SBOM
-      if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
       uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
       with:
         subject-name: >-

--- a/.github/actions/grafana/action.yml
+++ b/.github/actions/grafana/action.yml
@@ -44,8 +44,9 @@ runs:
     - name: Attest grafana provenance
       # grafana is a single multi-arch build, so steps.build.outputs.digest is
       # the manifest-list digest that `gh attestation verify oci://...:tag`
-      # resolves to. Skip on pull_request: see build action for the rationale.
-      if: github.event_name != 'pull_request'
+      # resolves to. Skip on unreviewed builds: see build action for the
+      # rationale.
+      if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
       uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
       with:
         # See build action: qualify Docker Hub short names with docker.io.

--- a/.github/actions/merge/action.yml
+++ b/.github/actions/merge/action.yml
@@ -50,8 +50,8 @@ runs:
         echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
         echo "manifest list digest: ${DIGEST}"
     - name: Attest manifest provenance
-      # Skip on pull_request: see build action for the rationale.
-      if: github.event_name != 'pull_request'
+      # Skip on unreviewed builds: see build action for the rationale.
+      if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
       uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
       with:
         # See build action: qualify Docker Hub short names with docker.io.

--- a/.github/workflows/ghcr_build.yml
+++ b/.github/workflows/ghcr_build.yml
@@ -15,6 +15,11 @@ on:
       - "!.github/**" # Important: Exclude PRs related to .github from auto-run
       - "!.github/workflows/**" # Important: Exclude PRs related to .github/workflows from auto-run
       - "!.github/actions/**" # Important: Exclude PRs related to .github/actions from auto-run
+  # Pull requests touching .github are excluded from the automatic runs above,
+  # since the workflow definition that would run is the one from the pull
+  # request. This is the deliberate way to run the ghcr build for them anyway, by
+  # someone with write access. The job conditions below allow for it.
+  workflow_dispatch:
 
 env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
@@ -32,7 +37,7 @@ jobs:
 
   check_if_pr_from_outside_repo:
     needs: check_paths
-    if: needs.check_paths.outputs.githubfolder == 'false'
+    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/check_if_pr_from_outside_repo.yml
 
   teslamate_build:
@@ -40,7 +45,7 @@ jobs:
     needs:
       - check_paths
       - check_if_pr_from_outside_repo
-    if: needs.check_paths.outputs.githubfolder == 'false' && needs.check_if_pr_from_outside_repo.outputs.is_pr_from_outside_repo == 'false'
+    if: (needs.check_paths.outputs.githubfolder == 'false' && needs.check_if_pr_from_outside_repo.outputs.is_pr_from_outside_repo == 'false') || (github.event_name == 'workflow_dispatch' && needs.check_if_pr_from_outside_repo.outputs.is_pr_from_outside_repo == 'false')
     strategy:
       fail-fast: false
       matrix:
@@ -73,7 +78,7 @@ jobs:
     needs:
       - check_paths
       - teslamate_build
-    if: needs.check_paths.outputs.githubfolder == 'false'
+    if: needs.check_paths.outputs.githubfolder == 'false' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -95,7 +100,7 @@ jobs:
     needs:
       - check_paths
       - check_if_pr_from_outside_repo
-    if: needs.check_paths.outputs.githubfolder == 'false' && needs.check_if_pr_from_outside_repo.outputs.is_pr_from_outside_repo == 'false'
+    if: (needs.check_paths.outputs.githubfolder == 'false' && needs.check_if_pr_from_outside_repo.outputs.is_pr_from_outside_repo == 'false') || (github.event_name == 'workflow_dispatch' && needs.check_if_pr_from_outside_repo.outputs.is_pr_from_outside_repo == 'false')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Breaking for automations on discovered entities: the Health sensor is inverted (
 - test: stop the app in test_helper instead of relying on --no-start (#5615 - @swiffer)
 - build(deps): update flake.lock (#5613)
 - build(deps): update flake.lock (#5645)
+- ci(ghcr): allow manual dispatch to build images for .github PRs (#5646 - @JakobLichterfeld)
 
 #### Dashboards
 


### PR DESCRIPTION
## Why

`ghcr_build.yml` deliberately excludes `.github/**` from its `push` and `pull_request` triggers: for such a pull request, the workflow definition that would run is the one from the pull request itself. The downside is that changes to the build pipeline cannot be exercised at all — the images are never built.

## What

- Add `workflow_dispatch` to `ghcr_build.yml` and widen the job conditions so a  maintainer with write access can start the build by hand, on any branch. Same  pattern that `buildx.yml` already uses.
- A manual run builds an arbitrary branch, so it is unreviewed code just like a pull request. Extend the attestation guards in the `build`, `merge` and  `grafana` actions from `!= 'pull_request'` to also exclude  `workflow_dispatch`. Manual runs push images, but unsigned ones.
- Wrap the two long job conditions in parentheses for readability. No semantic change — `&&` already binds tighter than `||`.

## Unchanged

Push to `main` and the nightly `schedule` run in `buildx.yml` still produce signed images with SBOM and provenance attestations.

## Testing

Merge this, then trigger the workflow manually on a branch and confirm the images are built and pushed while the attestation steps are skipped.