### PR TITLE
fix(vehicle): keep the stream connected while a drive is interrupted by an API outage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improvements and bug fixes
 
+- fix(vehicle): keep the stream connected while a drive is interrupted by an API outage (#5647 - @onevcat)
+
 #### Build, CI, internal
 
 #### Dashboards

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -485,18 +485,15 @@ defmodule TeslaMate.Vehicles.Vehicle do
       {:ok, %Vehicle{state: vehicle_state} = vehicle}
       when vehicle_state in ["offline", "asleep"] ->
         # disconnect stream in case we started it to detect real online
-        # (in that case we won't go through Start / :offline or Start / :asleep)
-        #
-        # Not while driving: there the vehicle is usually only unreachable for
-        # the API for a while, and the stream keeps delivering positions that
-        # belong to the running drive. The driving handlers keep polling and
-        # decide when the drive is over.
+        # (in that case we won't go through Start / :offline or Start / :asleep),
+        # except when a drive is running and only the API lost the vehicle: the
+        # stream keeps delivering positions for that drive.
         data =
-          case state do
-            {:driving, _status, _drive} ->
+          case {vehicle_state, state} do
+            {"offline", {:driving, _status, _drive}} ->
               data
 
-            _ ->
+            {_, _} ->
               :ok = disconnect_stream(data)
               %Data{data | stream_pid: nil}
           end
@@ -732,9 +729,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         %Data{} = data
       ) do
     case {status, stream_data} do
-      # Also while the API reports the vehicle unavailable or offline: the
-      # stream stays connected then, and only a successful fetch brings the
-      # status back to :available.
+      # Any status: while the API reports the vehicle offline the stream stays
+      # connected, and only a successful fetch restores :available.
       {_status, %Stream.Data{shift_state: shift_state}}
       when shift_state in ~w(D N R) and not is_nil(drv) ->
         {elevation, geofence} =
@@ -762,8 +758,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {:keep_state_and_data, schedule_fetch(0, data)}
 
       {_status, %Stream.Data{}} ->
-        # The offline handlers have a fetch scheduled already; one per frame
-        # would only add vehicle_data requests that are known to fail.
+        # The offline handlers already scheduled a fetch; one per frame would
+        # only repeat a request that is currently failing.
         :keep_state_and_data
     end
   end

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -482,10 +482,24 @@ defmodule TeslaMate.Vehicles.Vehicle do
             end
         end
 
-      {:ok, %Vehicle{state: state} = vehicle} when state in ["offline", "asleep"] ->
+      {:ok, %Vehicle{state: vehicle_state} = vehicle}
+      when vehicle_state in ["offline", "asleep"] ->
         # disconnect stream in case we started it to detect real online
         # (in that case we won't go through Start / :offline or Start / :asleep)
-        :ok = disconnect_stream(data)
+        #
+        # Not while driving: there the vehicle is usually only unreachable for
+        # the API for a while, and the stream keeps delivering positions that
+        # belong to the running drive. The driving handlers keep polling and
+        # decide when the drive is over.
+        data =
+          case state do
+            {:driving, _status, _drive} ->
+              data
+
+            _ ->
+              :ok = disconnect_stream(data)
+              %Data{data | stream_pid: nil}
+          end
 
         %Data{} =
           data =
@@ -494,10 +508,10 @@ defmodule TeslaMate.Vehicles.Vehicle do
             %Data{data | last_response: last_response, geofence: geofence}
           end
 
-        {:keep_state, %Data{data | pre_online_check: :idle, stream_pid: nil},
+        {:keep_state, %Data{data | pre_online_check: :idle},
          [
            broadcast_fetch(false),
-           {:next_event, :internal, {:update, {String.to_existing_atom(state), vehicle}}}
+           {:next_event, :internal, {:update, {String.to_existing_atom(vehicle_state), vehicle}}}
          ]}
 
       {:ok, %Vehicle{state: state} = vehicle} ->
@@ -718,7 +732,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
         %Data{} = data
       ) do
     case {status, stream_data} do
-      {:available, %Stream.Data{shift_state: shift_state}} when shift_state in ~w(D N R) ->
+      # Also while the API reports the vehicle unavailable or offline: the
+      # stream stays connected then, and only a successful fetch brings the
+      # status back to :available.
+      {_status, %Stream.Data{shift_state: shift_state}}
+      when shift_state in ~w(D N R) and not is_nil(drv) ->
         {elevation, geofence} =
           Repo.checkout(fn ->
             {:ok, %{elevation: elevation} = position} =
@@ -740,8 +758,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
              geofence: geofence
          }, broadcast_summary()}
 
-      {_status, %Stream.Data{}} ->
+      {:available, %Stream.Data{}} ->
         {:keep_state_and_data, schedule_fetch(0, data)}
+
+      {_status, %Stream.Data{}} ->
+        # The offline handlers have a fetch scheduled already; one per frame
+        # would only add vehicle_data requests that are known to fail.
+        :keep_state_and_data
     end
   end
 

--- a/test/support/mocks/api.ex
+++ b/test/support/mocks/api.ex
@@ -58,7 +58,31 @@ defmodule ApiMock do
 
   def handle_call({:stream, _vid, _receiver} = event, _from, %State{pid: pid} = state) do
     send(pid, {ApiMock, event})
-    {:reply, {:ok, pid}, state}
+    {:reply, {:ok, spawn_stream(pid)}, state}
+  end
+
+  # Stand-in for the stream process: forwards everything to the test and, like
+  # WebSockex, terminates once it is told to disconnect. Being a process of its
+  # own lets tests kill it to simulate a stream that died unnoticed.
+  defp spawn_stream(pid) do
+    spawn(fn ->
+      ref = Process.monitor(pid)
+      forward_to_test(pid, ref)
+    end)
+  end
+
+  defp forward_to_test(pid, ref) do
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} ->
+        :ok
+
+      {:"$websockex_cast", :disconnect} = msg ->
+        send(pid, msg)
+
+      msg ->
+        send(pid, msg)
+        forward_to_test(pid, ref)
+    end
   end
 
   # Events tagged with :get_vehicle or :get_vehicle_with_state may only be

--- a/test/teslamate/vehicles/vehicle/driving_test.exs
+++ b/test/teslamate/vehicles/vehicle/driving_test.exs
@@ -648,6 +648,79 @@ defmodule TeslaMate.Vehicles.Vehicle.DrivingTest do
 
       refute_receive _
     end
+
+    @tag :capture_log
+    test "reconnects the stream if the stream process died while unavailable",
+         %{test: name} do
+      me = self()
+      now_ts = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+
+      events =
+        [
+          {:ok, online_event(now_ts)},
+          drive_event(now_ts, 0.1, 30, 20, 200, nil),
+          drive_event(now_ts + 1, 0.1, 30, 20, 200, nil),
+          fn ->
+            send(me, :continue?)
+
+            receive do
+              :continue -> {:ok, %TeslaApi.Vehicle{state: "offline"}}
+            after
+              5_000 -> raise "No :continue after 5s"
+            end
+          end
+        ] ++
+          List.duplicate({:ok, %TeslaApi.Vehicle{state: "offline"}}, 16) ++
+          [
+            drive_event(now_ts + :timer.minutes(4), 0.2, 20, 19, 190, nil),
+            {:ok,
+             online_event(now_ts + :timer.minutes(4) + 1,
+               drive_state: %{
+                 timestamp: now_ts + :timer.minutes(4) + 1,
+                 latitude: 0.3,
+                 longitude: 0.3
+               }
+             )}
+          ]
+
+      :ok = start_vehicle(name, events)
+
+      d0 = DateTime.from_unix!(now_ts, :millisecond)
+      assert_receive {:start_state, car, :online, date: ^d0}
+      assert_receive {ApiMock, {:stream, 1000, _}}
+      assert_receive {:insert_position, ^car, %{}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving}}}
+
+      assert_receive {:start_drive, ^car}
+      assert_receive {:insert_position, drive, %{longitude: 0.1, speed: 48}}
+      assert_receive {:insert_position, ^drive, %{longitude: 0.1, speed: 48}}
+
+      # The stream process dies unnoticed: it is not monitored, so this is only
+      # discovered when the drive resumes.
+      assert_receive :continue?
+      {_state, %{stream_pid: stream_pid}} = :sys.get_state(name)
+      assert is_pid(stream_pid)
+      Process.exit(stream_pid, :kill)
+      send(:"api_#{name}", :continue)
+
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :offline}}}, 500
+
+      # Vehicle comes back online mid-drive: the dead stream is replaced
+      assert_receive {ApiMock, {:stream, 1000, _}}, 500
+
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving}}}
+      assert_receive {:insert_position, drive, %{longitude: 0.2, speed: 32}}
+      assert_receive {:insert_position, ^drive, %{longitude: 0.3}}
+      assert_receive {:close_drive, ^drive, lookup_address: true}
+
+      d1 = DateTime.from_unix!(now_ts + :timer.minutes(4) + 1, :millisecond)
+      assert_receive {:start_state, ^car, :online, date: ^d1}
+      assert_receive {:insert_position, ^car, %{}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
+
+      refute_receive _
+    end
   end
 
   describe "geofencing" do

--- a/test/teslamate/vehicles/vehicle/driving_test.exs
+++ b/test/teslamate/vehicles/vehicle/driving_test.exs
@@ -458,15 +458,16 @@ defmodule TeslaMate.Vehicles.Vehicle.DrivingTest do
       assert_receive :continue?
       refute_receive _
       send(:"api_#{name}", :continue)
-      assert_receive {:"$websockex_cast", :disconnect}
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :offline}}}
+      refute_received {:"$websockex_cast", :disconnect}
 
       # Logs previous drive
       assert_receive {:close_drive, ^drive, lookup_address: true}, 250
 
+      # The stream was kept through the offline period, nothing to reconnect
       d1 = DateTime.from_unix!(now_ts + 1 + :timer.minutes(15), :millisecond)
       assert_receive {:start_state, ^car, :online, date: ^d1}
-      assert_receive {ApiMock, {:stream, 1000, _}}
+      refute_received {ApiMock, {:stream, 1000, _}}
       assert_receive {:insert_position, ^car, %{}}
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
 
@@ -537,7 +538,7 @@ defmodule TeslaMate.Vehicles.Vehicle.DrivingTest do
     end
 
     @tag :capture_log
-    test "reconnects the stream when a drive resumes after an offline period",
+    test "keeps the stream connected through an offline period mid-drive",
          %{test: name} do
       now = DateTime.utc_now()
       now_ts = DateTime.to_unix(now, :millisecond)
@@ -574,14 +575,13 @@ defmodule TeslaMate.Vehicles.Vehicle.DrivingTest do
       assert_receive {:insert_position, drive, %{longitude: 0.1, speed: 48}}
       assert_receive {:insert_position, ^drive, %{longitude: 0.1, speed: 48}}
 
-      # Vehicle goes offline: the stream is disconnected
-      assert_receive {:"$websockex_cast", :disconnect}
+      # Vehicle goes offline: the stream stays connected
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :offline}}}, 500
+      refute_received {:"$websockex_cast", :disconnect}
 
-      # Vehicle comes back online mid-drive: the stream is reconnected
-      assert_receive {ApiMock, {:stream, 1000, _}}, 500
-
-      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving}}}
+      # Vehicle comes back online mid-drive: nothing to reconnect
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving}}}, 500
+      refute_received {ApiMock, {:stream, 1000, _}}
       assert_receive {:insert_position, drive, %{longitude: 0.2, speed: 32}}
       assert_receive {:insert_position, ^drive, %{longitude: 0.3}}
       assert_receive {:close_drive, ^drive, lookup_address: true}
@@ -595,7 +595,7 @@ defmodule TeslaMate.Vehicles.Vehicle.DrivingTest do
     end
 
     @tag :capture_log
-    test "reconnects the stream when a drive resumes after a short unavailability",
+    test "keeps the stream connected through a short unavailability mid-drive",
          %{test: name} do
       now = DateTime.utc_now()
       now_ts = DateTime.to_unix(now, :millisecond)
@@ -632,13 +632,11 @@ defmodule TeslaMate.Vehicles.Vehicle.DrivingTest do
       assert_receive {:insert_position, drive, %{longitude: 0.1, speed: 48}}
       assert_receive {:insert_position, ^drive, %{longitude: 0.1, speed: 48}}
 
-      # Vehicle becomes unavailable: the stream is disconnected
-      assert_receive {:"$websockex_cast", :disconnect}
-
-      # Vehicle comes back online mid-drive: the stream is reconnected
-      assert_receive {ApiMock, {:stream, 1000, _}}, 500
-
-      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving}}}
+      # Vehicle becomes unavailable and comes back online mid-drive: the stream
+      # stays connected, nothing to reconnect
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving}}}, 500
+      refute_received {:"$websockex_cast", :disconnect}
+      refute_received {ApiMock, {:stream, 1000, _}}
       assert_receive {:insert_position, drive, %{longitude: 0.2, speed: 32}}
       assert_receive {:insert_position, ^drive, %{longitude: 0.3}}
       assert_receive {:close_drive, ^drive, lookup_address: true}

--- a/test/teslamate/vehicles/vehicle/streaming_test.exs
+++ b/test/teslamate/vehicles/vehicle/streaming_test.exs
@@ -157,6 +157,82 @@ defmodule TeslaMate.Vehicles.Vehicle.StreamingTest do
       refute_receive _
     end
 
+    @tag :capture_log
+    test "keeps recording streamed positions while the vehicle is unavailable for the API",
+         %{test: name} do
+      me = self()
+      now = DateTime.utc_now()
+      now_ts = DateTime.to_unix(now, :millisecond)
+
+      wait_for_continue = fn result ->
+        fn ->
+          send(me, :continue?)
+
+          receive do
+            :continue -> result
+          after
+            5_000 -> raise "No :continue after 5s"
+          end
+        end
+      end
+
+      events = [
+        {:ok, online_event(now_ts)},
+        {:ok, online_event(now_ts, drive_state: %{timestamp: now_ts})},
+        wait_for_continue.({:ok, %TeslaApi.Vehicle{state: "offline"}}),
+        wait_for_continue.(
+          {:ok,
+           online_event(now_ts + 10,
+             drive_state: %{
+               timestamp: now_ts + 10,
+               latitude: 42.5,
+               longitude: 42.0,
+               shift_state: "D",
+               speed: 20,
+               power: 8
+             }
+           )}
+        ),
+        fn -> Process.sleep(10_000) end
+      ]
+
+      :ok = start_vehicle(name, events)
+
+      assert_receive {:start_state, car, :online, date: _}
+      assert_receive {:insert_position, ^car, %{}}
+      assert_receive {ApiMock, {:stream, _eid, func}} when is_function(func)
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
+
+      assert_receive :continue?
+      stream(name, %{shift_state: "D", speed: 10, power: 5, time: now})
+      assert_receive {:start_drive, ^car}
+      assert_receive {:insert_position, drive, %{speed: 16}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving, speed: 16}}}
+
+      # The API loses the vehicle mid-drive: the stream stays connected
+      send(:"api_#{name}", :continue)
+      assert_receive :continue?
+      refute_received {:"$websockex_cast", :disconnect}
+
+      # Streamed positions still belong to the drive
+      stream(name, %{shift_state: "D", speed: 15, power: 10, est_lat: 42.31, time: now})
+      assert_receive {:insert_position, ^drive, %{speed: 24, latitude: 42.31}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving, speed: 24}}}
+
+      # Everything else is left to the fetch that is already scheduled
+      stream(name, %{shift_state: "P", speed: nil, power: nil, time: now})
+      refute_receive _
+
+      # The API sees the vehicle again: the drive continues on the same stream
+      send(:"api_#{name}", :continue)
+      assert_receive {:insert_position, ^drive, %{latitude: 42.5, speed: 32}}
+      assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :driving}}}
+      refute_received {ApiMock, {:stream, _, _}}
+
+      refute_receive _
+    end
+
     test "updates the geofence from streaming positions", %{test: name} do
       now = DateTime.utc_now()
       now_ts = DateTime.to_unix(now, :millisecond)


### PR DESCRIPTION
Continues #5647 at its exact head commit (`5518e04`), all commits authored by @onevcat.

This repo-branch PR exists because merge evidence must be produced on project-built images, and for security reasons our CI does not build registry images from fork PRs. The CI image of this PR is byte-for-byte the tree reviewed in #5647.

Validation protocol is tracked in #5648. Fixes #5648.