### PR TITLE
fix(vehicle): cancel an update with the logged update row instead of the API payload, which crashed the vehicle process and left the update open forever 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Under the hood, this release adds a self-verifying black-box characterization su
 
 ### Improvements and bug fixes
 
+- fix(vehicle): cancel an update with the logged update row instead of the API payload, which crashed the vehicle process and left the update open forever (#5664 - @JakobLichterfeld)
+
 #### Build, CI, internal
 
 - test: add characterization harness replaying API fixtures against persisted rows and MQTT (#5653 - @JakobLichterfeld)

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1429,10 +1429,10 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {:keep_state, %{data | last_used: DateTime.utc_now()},
          schedule_fetch(default_interval(), data)}
 
-      %VehicleState{software_update: %SW{status: "available"} = update} ->
+      %VehicleState{software_update: %SW{status: "available"} = software_update} ->
         {:ok, %Log.Update{}} = call(data.deps.log, :cancel_update, [update])
 
-        Logger.warning("Update canceled:\n\n#{inspect(update, pretty: true)}",
+        Logger.warning("Update canceled:\n\n#{inspect(software_update, pretty: true)}",
           car_id: data.car.id
         )
 

--- a/test/fixtures/characterization/goldens/updating_cancel.json
+++ b/test/fixtures/characterization/goldens/updating_cancel.json
@@ -119,13 +119,6 @@
         "id": "update_1",
         "start_date": "2024-01-01T00:00:10.000000",
         "version": "2019.8.4 530d1d3"
-      },
-      {
-        "car_id": "$car",
-        "end_date": null,
-        "id": "update_2",
-        "start_date": "2024-01-01T00:00:10.000000",
-        "version": null
       }
     ]
   },

--- a/test/fixtures/characterization/scenarios/updating_cancel.json
+++ b/test/fixtures/characterization/scenarios/updating_cancel.json
@@ -7,11 +7,7 @@
     "vid": 1000,
     "vin": "5YJ3E1EA1KF000001"
   },
-  "description": "Conversion of 'cancels an update': installing, then the status falls back to 'available'. PINNED BUG #5656: the cancel branch passes the API software_update struct to Log.cancel_update, which crashes the vehicle process (FunctionClauseError) and leaves the started update row open forever. This golden pins the crash behaviour; it gets re-recorded in the fix commit.",
-  "await": {
-    "positions": 2
-  },
-  "expect_restart": true,
+  "description": "Conversion of 'cancels an update': installing, then the status falls back to 'available'. The started update row is canceled (fix for #5656 — the cancel branch previously passed the API software_update struct instead of the Log.Update row and crashed the vehicle) and the vehicle returns to online.",
   "events": [
     {
       "vehicle": {

--- a/test/teslamate/vehicles/vehicle/updating_test.exs
+++ b/test/teslamate/vehicles/vehicle/updating_test.exs
@@ -137,7 +137,7 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
                     {:broadcast, _server, _topic,
                      %Summary{state: :updating, version: "2019.8.4", update_version: "2019.8.5"}}}
 
-    assert_receive {:cancel_update, _update_id}, 200
+    assert_receive {:cancel_update, %TeslaMate.Log.Update{}}, 200
 
     d1 = DateTime.from_unix!(now_ts + 10, :millisecond)
     assert_receive {:start_state, ^car_id, :online, date: ^d1}, 600


### PR DESCRIPTION
Fixes #5656.

## What happened

The cancel branch of the `:updating` state shadowed the `%Log.Update{}` row held in the state with the API `software_update` struct (`%SW{status: "available"} = update`) and passed the wrong one to `Log.cancel_update/1`. Every fetch then died in a `FunctionClauseError` crash loop and the started update row stayed open forever. The mock-based test could not see it: `LogMock.cancel_update` accepts any argument, and the test asserted `{:cancel_update, _update_id}`.

The characterization suite (#5652, #5658) exposed the crash — `updating_cancel` pinned it as a marked bug with an `expect_restart` declaration.

## The fix

- Bind the API struct under its own name (mirroring the finish branch below it) and cancel with the `Log.Update` row; the log line keeps printing the API struct.
- Tighten the mock assertion to `{:cancel_update, %TeslaMate.Log.Update{}}` so this bug class is visible to the mock test as well.
- `updating_cancel` drops `expect_restart` and its `await` (the harness would rightly fail a declared restart that no longer happens) and its golden is re-recorded: the update row now closes (`end_date` set) and the vehicle returns to online — no crash artifacts.

## Verification

Full test suite green: 580 passed (characterization replays, harness unit tests, mock-based updating tests).

## Workarounds & open questions

None.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Fable 5 max) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)