### PR TITLE
fix(web): remove stray brace from the direction arrow SVG path, which made Safari log a parse error on every position update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Under the hood, this release adds a self-verifying black-box characterization su
 ### Improvements and bug fixes
 
 - fix(vehicle): cancel an update with the logged update row instead of the API payload, which crashed the vehicle process and left the update open forever (#5664 - @JakobLichterfeld)
+- fix(web): remove stray brace from the direction arrow SVG path, which made Safari log a parse error on every position update (#5665 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -153,7 +153,7 @@ const DirectionArrow = CircleMarker.extend({
       `translate(${x},${y}) rotate(${this._heading})`,
     );
 
-    const path = this._empty() ? "" : `M0,${3} L-4,${5} L0,${-5} L4,${5} z}`;
+    const path = this._empty() ? "" : "M0,3 L-4,5 L0,-5 L4,5 z";
 
     this._renderer._setPath(this, path);
   },


### PR DESCRIPTION
## What

The path data for the vehicle direction arrow ended in `z}`:

```js
const path = this._empty() ? "" : `M0,${3} L-4,${5} L0,${-5} L4,${5} z}`;
```

The trailing `}` is not valid SVG path data. Safari rejects the whole `d` attribute and logs `Error: Problem parsing d="M0,3 L-4,5 L0,-5 L4,5 z}"` every time the path is redrawn. Since `_updatePath()` runs on every position update, a driving vehicle fills the console with hundreds of identical errors, burying anything else one might be debugging. Chromium ignores the trailing garbage silently, which is why this went unnoticed.

The arrow itself rendered correctly all along — browsers draw the valid prefix — so this was console noise, not a visual defect.

## How

Drop the stray brace and replace the no-op template literals (`M0,${3}` just evaluates to `M0,3`) with a plain string:

```js
const path = this._empty() ? "" : "M0,3 L-4,5 L0,-5 L4,5 z";
```

The geometry is byte-for-byte the same as what browsers previously parsed, so the arrow is unchanged.

## Verification

- Safari 26.6.2 / macOS 26.6.2: no `Problem parsing d=...` entries in the Web Inspector console any more; the arrow still renders and rotates with the heading.
- `npx prettier --check js/hooks.js` passes.

## Workarounds & open questions

None. The invalid token is removed at the source, no compatibility shim or browser-specific handling was needed.

Reported and diagnosed by @Corrugator.

Closes #5661

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 5 high) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)