### PR TITLE
fix(web): pin the size of Leaflet's SVG overlay so the vehicle arrow and geofence circle stay on the map at any Safari page zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Upgrading directly from 4.1.x no longer preserves entity registry customizations
 - feat: use Grafana 13.2.1 (#5694 - @swiffer)
 - fix(mqtt): stop re-running the Home Assistant discovery migration on every restart (#5685 - @nebhale)
 - fix(vehicle): keep the published state start time from jumping backwards after charging, updating or driving (#5706 - @JakobLichterfeld)
+- fix(web): pin the size of Leaflet's SVG overlay so the vehicle arrow and geofence circle stay on the map at any Safari page zoom (#5666 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -114,6 +114,7 @@ import {
   Icon,
   Circle,
   CircleMarker,
+  SVG,
 } from "leaflet";
 
 import markerIcon from "leaflet/dist/images/marker-icon.png";
@@ -159,8 +160,33 @@ const DirectionArrow = CircleMarker.extend({
   },
 });
 
+// Safari resolves an SVG's intrinsic size as attribute / page zoom, so Leaflet's
+// overlay pane renders displaced at any page zoom other than 100 % as soon as an
+// author rule takes sizing away from the width/height attributes - Bulma's global
+// `svg { width: auto; height: auto }` does exactly that. Mirroring the attributes
+// into inline styles pins the used size; it is a no-op in every other browser.
+// Layers on a custom pane get their own renderer and are not covered; the
+// direction arrow and the geofence circle both live in the default overlay pane.
+// Remove once Leaflet sets the size via style: Leaflet/Leaflet#10356
+function createSvgRenderer() {
+  const renderer = new SVG();
+
+  renderer.on("update", () => {
+    const el = renderer.getPane().querySelector("svg");
+    if (!el) return;
+
+    el.style.width = `${el.getAttribute("width")}px`;
+    el.style.height = `${el.getAttribute("height")}px`;
+  });
+
+  return renderer;
+}
+
 function createMap(opts) {
-  const map = new M(opts.elId != null ? `map_${opts.elId}` : "map", opts);
+  const map = new M(opts.elId != null ? `map_${opts.elId}` : "map", {
+    ...opts,
+    renderer: createSvgRenderer(),
+  });
 
   const osm = new TileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
     maxZoom: 19,


### PR DESCRIPTION
## What

In Safari, everything TeslaMate draws into Leaflet's SVG overlay pane is displaced whenever the page zoom is not 100 % — the direction arrow on the home page and the circle in the geofence editor. The offset is constant in pixels, so the error grows geographically as you zoom out: the arrow can sit hundreds of metres from the vehicle's actual position, silently and with nothing to connect it to the zoom setting. Safari stores page zoom per origin and permanently, so one accidental Cmd+− is enough to leave a user with a permanently wrong map.

## Cause

Bulma's generic reset contains `svg { height: auto; width: auto }`. By value that is a no-op — `auto` is the initial value of `width` — and its only effect is to take the sizing away from the `width`/`height` presentation attributes that Leaflet's `SVG._update` writes. At any page zoom other than 100 %, Safari then resolves the used size as attribute ÷ zoom while the `viewBox` keeps the unscaled values, so every point is displaced proportionally to its distance from the viewBox origin by a factor of 1/zoom. Below 100 % the offset is positive, above it the sign flips.

## How

Pass an `SVG` renderer that mirrors the two attributes into inline styles, which outrank any author rule. It writes the same numbers Leaflet already writes, so it is a no-op in every browser that resolves the size correctly — no change to rendering, animations or interaction anywhere else.

The renderer is passed via the documented `Map` `renderer` option and hooks the documented `Renderer` `update` event, so no private Leaflet API is touched and no shared prototype is mutated.

## Verification

Verified against the bundled Leaflet in a probe page (Chromium, with Bulma's declaration active):

| Assumption | Result |
| --- | --- |
| `Map.options.renderer` beats the default renderer | `map.getRenderer(circle) === renderer` → `true` |
| `update` fires, `getPane()` resolves | inline styles set to `883px × 480px` |
| styles track size changes | after `invalidateSize` + `setZoom`: attributes `600 × 360`, style `600px × 360px` |
| no regression | circle bbox centre == container centre, `[0, 0]` |

**Not verified here:** that the offset is gone in Safari. I have no WebKit available; Chromium is the browser that was never affected. @Corrugator, a confirmation at 75 %, 85 % and 125 % would be very welcome before this is merged.

## Workarounds & open questions

This is a workaround for a WebKit bug, and it is marked as such in the code with its removal criterion. Three upstream reports belong together here:

- **WebKit** — resolving an SVG's intrinsic size as attribute ÷ page zoom is the actual defect. Not yet filed.
- **Leaflet** — `SVG._update` should write the size to `container.style`, which would make the renderer immune to any CSS reset touching `svg`, not just Bulma's. Filed as Leaflet/Leaflet#10356; this workaround comes out once that lands.
- **Bulma** — the `svg { height: auto; width: auto }` rule is a no-op by value whose only possible effect is harm. Worth filing so all reports can reference each other. Not yet filed.

Known limitation: layers on a custom pane get their own renderer via `_getPaneRenderer` and are not covered. The direction arrow and the geofence circle both live in the default overlay pane.

Reported and diagnosed by @Corrugator, who traced it to the Bulma declaration and modelled the 1/zoom factor.

Closes #5660

---

🤖 Created with [Claude Code](https://claude.com/claude-code) (Opus 5 high) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)