### PR TITLE
fix(test): give the error_event selftest a settled terminal cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Under the hood, this release adds a self-verifying black-box characterization su
 - test(characterization): convert charging scenarios to characterization fixtures (#5655 - @JakobLichterfeld)
 - test(characterization): convert updating scenarios to characterization fixtures. Pins the update-cancel crash (#5656) that mock-based tests could not see (#5658 - @JakobLichterfeld)
 - test(characterization): convert streaming scenarios to characterization fixtures (#5668 - @JakobLichterfeld)
+- fix(test): give the error_event selftest a settled terminal cycle (#5670 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/test/fixtures/characterization/selftest/goldens/error_event.json
+++ b/test/fixtures/characterization/selftest/goldens/error_event.json
@@ -18,28 +18,77 @@
         "display_priority": 1,
         "efficiency": 0.153,
         "eid": 42,
-        "exterior_color": null,
+        "exterior_color": "DeepBlue",
         "id": "$car",
         "inserted_at": "<volatile>",
-        "marketing_name": null,
+        "marketing_name": "LR AWD",
         "model": "3",
         "name": "blue",
         "settings_id": "car_setting_1",
-        "spoiler_type": null,
-        "trim_badging": null,
+        "spoiler_type": "None",
+        "trim_badging": "74D",
         "updated_at": "<volatile>",
         "vid": 1000,
         "vin": "5YJ3E1EA1KF000001",
-        "wheel_type": null
+        "wheel_type": "Pinwheel18"
       }
     ],
     "charges": [],
     "charging_processes": [],
     "drives": [],
     "geofences": [],
-    "positions": [],
-    "states": [],
-    "updates": []
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:20.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.95",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:20.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:20.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:20.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
   },
   "mqtt": {
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
@@ -129,18 +178,48 @@
     "teslamate/cars/$car/active_route_destination": ["nil"],
     "teslamate/cars/$car/active_route_latitude": ["nil"],
     "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
     "teslamate/cars/$car/charge_energy_added": [""],
     "teslamate/cars/$car/charger_actual_current": [""],
     "teslamate/cars/$car/charger_phases": [""],
     "teslamate/cars/$car/charger_power": [""],
     "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
     "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["120"],
     "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
     "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
     "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
     "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/state": ["unavailable"],
+    "teslamate/cars/$car/since": ["<volatile>"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["unavailable", "online"],
     "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""]
+    "teslamate/cars/$car/trim_badging": ["", "74D"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
   }
 }

--- a/test/fixtures/characterization/selftest/scenarios/error_event.json
+++ b/test/fixtures/characterization/selftest/scenarios/error_event.json
@@ -1,5 +1,5 @@
 {
-  "description": "Harness self-test \u2014 machinery evidence, not a behaviour contract. Exercises the error-event path: a vehicle_unavailable result between two online frames.",
+  "description": "Harness self-test — machinery evidence, not a behaviour contract. Exercises the error-event path: a vehicle_unavailable result between two online frames. A fourth online frame separates the terminal from the error recovery, so the barrier proves a settled cycle.",
   "car": {
     "eid": 42,
     "vid": 1000,
@@ -107,6 +107,55 @@
         },
         "vehicle_config": {
           "timestamp": 1704067210000,
+          "car_type": "model3",
+          "trim_badging": "74d",
+          "exterior_color": "DeepBlue",
+          "wheel_type": "Pinwheel18",
+          "spoiler_type": "None"
+        }
+      }
+    },
+    {
+      "vehicle": {
+        "id": 42,
+        "vehicle_id": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "state": "online",
+        "display_name": "blue",
+        "charge_state": {
+          "timestamp": 1704067220000,
+          "battery_level": 80,
+          "usable_battery_level": 79,
+          "ideal_battery_range": 250.0,
+          "battery_range": 240.0,
+          "est_battery_range": 230.5,
+          "charging_state": "Disconnected"
+        },
+        "drive_state": {
+          "timestamp": 1704067220000,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "heading": 120,
+          "power": 0,
+          "shift_state": null,
+          "speed": null
+        },
+        "climate_state": {
+          "timestamp": 1704067220000,
+          "outside_temp": 12.5,
+          "inside_temp": 18.0,
+          "is_climate_on": false
+        },
+        "vehicle_state": {
+          "timestamp": 1704067220000,
+          "car_version": "2026.20.1 abc123",
+          "odometer": 10000.0,
+          "locked": true,
+          "sentry_mode": false,
+          "is_user_present": false
+        },
+        "vehicle_config": {
+          "timestamp": 1704067220000,
           "car_type": "model3",
           "trim_badging": "74d",
           "exterior_color": "DeepBlue",


### PR DESCRIPTION
The scenario reached its terminal through the two-call unavailable fallback, so both causal-barrier serves came from one fetch cycle and teardown raced identify: fast machines recorded and compared nil for the car's config attributes, CI let identify land and failed on DeepBlue. A fourth online event separates the terminal from the error recovery; the re-recorded golden now pins the identified car — the documented serve-vs-cycle limit caught shipping its first violation.

---

🤖 Created with [Claude Code](https://claude.com/claude-code) (Fable 5 high) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)