### PR TITLE
feat(grafana): add `total` period to the Statistics dashboard for one aggregated row over the selected time range

### DIFF
--- a/grafana/dashboards/statistics.json
+++ b/grafana/dashboards/statistics.json
@@ -1187,7 +1187,7 @@
         "label": "Period",
         "name": "period",
         "options": [],
-        "query": "day,week,month,year",
+        "query": "day,week,month,year,decade",
         "type": "custom",
         "valuesFormat": "csv"
       },


### PR DESCRIPTION
Add 'total' option to period query to achieve one aggregated row over the selected time range.

<img width="1325" height="295" alt="image" src="https://github.com/user-attachments/assets/d012a302-1bae-407f-9f6b-07b548f9d5de" />
