### PR TITLE
fix(test): move the offline-resume scenario off the 15-minute boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Under the hood, this release adds a self-verifying black-box characterization su
 
 - fix(vehicle): cancel an update with the logged update row instead of the API payload, which crashed the vehicle process and left the update open forever (#5664 - @JakobLichterfeld)
 - fix(web): remove stray brace from the direction arrow SVG path, which made Safari log a parse error on every position update (#5665 - @JakobLichterfeld)
+- fix(test): move the offline-resume scenario off the 15-minute boundary (#5681 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/test/fixtures/characterization/scenarios/driving_offline_15min_new_drive.json
+++ b/test/fixtures/characterization/scenarios/driving_offline_15min_new_drive.json
@@ -7,7 +7,7 @@
     "vid": 1000,
     "vin": "5YJ3E1EA1KF000001"
   },
-  "description": "Conversion of 'logs a drive after a significant offline period while driving' (streaming enabled): 15 minutes offline mid-drive without SOC gain. The first drive is closed by timeout; the frames after the gap start a second drive. Streaming is declared explicitly: with an active stream the vehicle's suspend settings are hardcoded to {3, 10} and this scenario's suspend guards are dead \u2014 the asleep terminal exists because a parked streaming terminal grows positions without bound under repeats.",
+  "description": "Conversion of 'logs a drive after a significant offline period while driving' (streaming enabled): 16 minutes offline mid-drive without SOC gain — one minute past the 15-minute drive timeout rather than exactly on it, so the resume decision does not sit on the >= boundary (#5669). The first drive is closed by timeout; the frames after the gap start a second drive. Streaming is declared explicitly: with an active stream the vehicle's suspend settings are hardcoded to {3, 10} and this scenario's suspend guards are dead — the asleep terminal exists because a parked streaming terminal grows positions without bound under repeats.",
   "await": {
     "state": "asleep",
     "drives_closed": 2
@@ -277,14 +277,14 @@
           "charging_state": "Disconnected",
           "est_battery_range": 170.0,
           "ideal_battery_range": 190.0,
-          "timestamp": 1704068110001,
+          "timestamp": 1704068170001,
           "usable_battery_level": 18
         },
         "climate_state": {
           "inside_temp": 18.0,
           "is_climate_on": true,
           "outside_temp": 12.5,
-          "timestamp": 1704068110001
+          "timestamp": 1704068170001
         },
         "display_name": "blue",
         "drive_state": {
@@ -294,7 +294,7 @@
           "power": 15,
           "shift_state": "D",
           "speed": 20,
-          "timestamp": 1704068110001
+          "timestamp": 1704068170001
         },
         "id": 42,
         "state": "online",
@@ -302,7 +302,7 @@
           "car_type": "model3",
           "exterior_color": "DeepBlue",
           "spoiler_type": "None",
-          "timestamp": 1704068110001,
+          "timestamp": 1704068170001,
           "trim_badging": "74d",
           "wheel_type": "Pinwheel18"
         },
@@ -313,7 +313,7 @@
           "locked": false,
           "odometer": 10000.09,
           "sentry_mode": false,
-          "timestamp": 1704068110001
+          "timestamp": 1704068170001
         },
         "vin": "5YJ3E1EA1KF000001"
       }
@@ -327,14 +327,14 @@
           "charging_state": "Disconnected",
           "est_battery_range": 170.0,
           "ideal_battery_range": 190.0,
-          "timestamp": 1704068111001,
+          "timestamp": 1704068171001,
           "usable_battery_level": 18
         },
         "climate_state": {
           "inside_temp": 18.0,
           "is_climate_on": false,
           "outside_temp": 12.5,
-          "timestamp": 1704068111001
+          "timestamp": 1704068171001
         },
         "display_name": "blue",
         "drive_state": {
@@ -344,7 +344,7 @@
           "power": 0,
           "shift_state": null,
           "speed": null,
-          "timestamp": 1704068111001
+          "timestamp": 1704068171001
         },
         "id": 42,
         "state": "online",
@@ -352,7 +352,7 @@
           "car_type": "model3",
           "exterior_color": "DeepBlue",
           "spoiler_type": "None",
-          "timestamp": 1704068111001,
+          "timestamp": 1704068171001,
           "trim_badging": "74d",
           "wheel_type": "Pinwheel18"
         },
@@ -363,7 +363,7 @@
           "locked": true,
           "odometer": 10000.1,
           "sentry_mode": false,
-          "timestamp": 1704068111001
+          "timestamp": 1704068171001
         },
         "vin": "5YJ3E1EA1KF000001"
       }


### PR DESCRIPTION
Fixes #5669.

## What happened

`driving_offline_15min_new_drive` resumed exactly 15.0 event-minutes after going offline — precisely on the `>= @drive_timeout_min` edge of the resume decision — and once, on a cold-started record run, closed the first drive one position late. The bounded instrumented reproduction in the issue ruled out lost unavailable ticks for the probed runs and left the boundary as the prime suspect.

## The fix

The resume frames move 60 seconds later, so the gap is 16 minutes and the decision no longer sits on the boundary. The scenario description states the deviation from the original test's "15 minutes" and points to the issue.

The re-recorded golden is byte-identical: the shifted times are volatile-masked fields, and the drive layout (drive 1 = positions 2–3, drive 2 = positions 5–6) is unchanged — the scenario still pins the same two drives.

This is also the discriminating experiment named in the issue: if the signature ever recurs at 16 minutes, the boundary hypothesis is refuted and only the tick-loss path remains.

## Verification

Full test suite green: 600 passed.

## Workarounds & open questions

- The exact-15.0 boundary itself is not pinned; that becomes possible once the harness owns the clock (the `timebase: "now"` interim status from #5654 remains).

---


🤖 Generated with [Claude Code](https://claude.com/claude-code) (Fable 5.1 low) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)