### PR TITLE
test(characterization): enforce the two-call-terminal limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ Under the hood, this release adds a self-verifying black-box characterization su
 
 - fix(vehicle): cancel an update with the logged update row instead of the API payload, which crashed the vehicle process and left the update open forever (#5664 - @JakobLichterfeld)
 - fix(web): remove stray brace from the direction arrow SVG path, which made Safari log a parse error on every position update (#5665 - @JakobLichterfeld)
-- fix(test): move the offline-resume scenario off the 15-minute boundary (#5681 - @JakobLichterfeld)
 
 #### Build, CI, internal
 
@@ -20,6 +19,8 @@ Under the hood, this release adds a self-verifying black-box characterization su
 - test(characterization): convert updating scenarios to characterization fixtures. Pins the update-cancel crash (#5656) that mock-based tests could not see (#5658 - @JakobLichterfeld)
 - test(characterization): convert streaming scenarios to characterization fixtures (#5668 - @JakobLichterfeld)
 - fix(test): give the error_event selftest a settled terminal cycle (#5670 - @JakobLichterfeld)
+- fix(test): move the offline-resume scenario off the 15-minute boundary (#5681 - @JakobLichterfeld)
+- test(characterization): enforce the two-call-terminal limit (#5683 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/test/support/characterization.ex
+++ b/test/support/characterization.ex
@@ -60,7 +60,11 @@ defmodule TeslaMate.Characterization do
   the vehicle is free), and only then serves the API event. The
   interleaving of the events list is deterministic, without a wall-clock
   wait. A scenario cannot end in a stream or call event: the terminal must
-  be an API event, because the causal barrier repeats it. `timebase`
+  be an API event, because the causal barrier repeats it — and not in an
+  error event either, whose unavailable counter keeps running under
+  repeats. The barrier also refuses a terminal reached through the probe
+  and strict fetch of a single cycle: both serves would come from one
+  fetch and prove nothing. `timebase`
   combined with stream events raises — the time field inside the wire CSV
   value would stay unshifted (mixed epochs).
 
@@ -175,6 +179,14 @@ defmodule TeslaMate.Characterization do
       (`ApiMock.await_call_outcome/2`); an unsupported call raises
       (`call_event!/1`), and a rejected, dying or never-completing call
       raises instead of hanging (`ApiMock.await_call_outcome/2`).
+    * The barrier proves two processed fetch cycles: a terminal whose two
+      serves are a probe followed by a strict fetch raises
+      (`two_call_cycle?/2`, `replay/2`). The pair is treated as one cycle;
+      the reachable error-fallback probe is the one two-fetch shape this
+      over-approximates — its result is discarded as incomplete, so the
+      terminal is equally unprocessed at capture, it fails loudly, and the
+      remedy is the same settling event. A scenario cannot end in an error
+      event, which is never repeat-neutral (`build_events/1`).
     * A replay that ends in `:suspended` raises after the awaited outcomes,
       and a barrier starved by the suspend poll interval names the state
       instead of timing out opaquely (`replay/2`, `await_serve/4`).
@@ -202,9 +214,6 @@ defmodule TeslaMate.Characterization do
     * Cross-topic MQTT publish order is concurrent by design
       (`Task.async_stream(ordered: false)`); goldens hold per-topic ordered
       sequences with consecutive duplicates collapsed.
-    * The end-of-replay barrier counts API serves, not fetch cycles; states
-      whose handling makes two API calls per cycle are not expressible as
-      terminals yet.
     * With an active stream the vehicle's suspend settings are hardcoded to
       {3, 10} minutes and scenario suspend guards are dead: streaming
       scenarios must end asleep, and a loaded runner can still turn the two
@@ -432,8 +441,8 @@ defmodule TeslaMate.Characterization do
     # collector — never in the closure, a raise in handle_call would tear
     # down the vehicle's fetch task.
     wrap = fn result, index ->
-      fn ->
-        send(collector, {:api_event_served, index})
+      fn action ->
+        send(collector, {:api_event_served, index, action})
 
         if index == total do
           :counters.add(vacuity, 1, 1)
@@ -501,12 +510,18 @@ defmodule TeslaMate.Characterization do
     {:ok, vehicle_pid} = start_supervised(vehicle_spec)
     crash_monitor = if expect_restart?, do: Process.monitor(vehicle_pid)
 
-    await_serve(total, vehicle, "initial serve", input["description"])
+    first = await_serve(total, vehicle, "initial serve", input["description"])
 
     # Causal barrier, not a wait: the terminal event repeats, so its next
     # serve proves the state machine finished the previous cycle — including
     # every persistence and publishing effect — and started the next one.
-    await_serve(total, vehicle, "causal barrier", input["description"])
+    second = await_serve(total, vehicle, "causal barrier", input["description"])
+
+    if two_call_cycle?(first, second) do
+      raise "the terminal event was reached through a two-call cycle — both barrier " <>
+              "serves came from the probe and strict fetch of one fetch, which proves " <>
+              "nothing; add a settling API event (#{input["description"]})"
+    end
 
     if run_id != :compare and await != %{} do
       assert_receive {:awaits_vacuous?, vacuous?}, 5_000
@@ -614,13 +629,32 @@ defmodule TeslaMate.Characterization do
           {:call_delivery, call_event!(call)}
       end)
 
-    if match?({tag, _} when tag in [:stream_delivery, :call_delivery], List.last(events)) do
-      raise "a scenario cannot end in a stream or call event — the terminal must be an API " <>
-              "event, because the causal barrier repeats it"
-    end
+    case List.last(events) do
+      {tag, _} when tag in [:stream_delivery, :call_delivery] ->
+        raise "a scenario cannot end in a stream or call event — the terminal must be an " <>
+                "API event, because the causal barrier repeats it"
 
-    events
+      {:error, _} ->
+        raise "a scenario cannot end in an error event — the unavailable counter keeps " <>
+                "running under repeats, so an error terminal is never repeat-neutral"
+
+      _ ->
+        events
+    end
   end
+
+  # A probe followed by a strict fetch is treated as one fetch cycle. In the
+  # unreachable-assumption fetch it is one; in the reachable path the probe
+  # can be the vehicle_unavailable fallback ending cycle N and the strict
+  # fetch cycle N+1 — two fetches, but the fallback's result is discarded as
+  # incomplete, so the terminal is equally unprocessed at capture and the
+  # remedy is the same settling event. Every other pair spans two processed
+  # cycles (a snapshot executes once per cycle, a strict fetch that got
+  # asleep or offline is followed by the next cycle's probe, a call's strict
+  # fetch by the next poll).
+  @doc false
+  def two_call_cycle?(:get_vehicle, :get_vehicle_with_state), do: true
+  def two_call_cycle?(_first, _second), do: false
 
   # User-action calls are staged like await facts: the whitelist grows with
   # the conversion PRs whose scenarios first need an action.
@@ -760,7 +794,7 @@ defmodule TeslaMate.Characterization do
 
   defp await_serve(total, vehicle, phase, description) do
     receive do
-      {:api_event_served, ^total} -> :ok
+      {:api_event_served, ^total, action} -> action
     after
       5_000 ->
         case vehicle_state(vehicle) do
@@ -797,7 +831,7 @@ defmodule TeslaMate.Characterization do
       outcomes_met?(await, car) ->
         # Termination barrier: the outcome cycle's own effects (its commit
         # precedes its broadcast) are proven complete by one further serve.
-        assert_receive {:api_event_served, _}, 5_000
+        assert_receive {:api_event_served, _, _}, 5_000
         :ok
 
       System.monotonic_time(:millisecond) >= deadline ->
@@ -808,7 +842,7 @@ defmodule TeslaMate.Characterization do
 
       true ->
         receive do
-          {:api_event_served, _} -> wait_outcomes(await, car, name, deadline)
+          {:api_event_served, _, _} -> wait_outcomes(await, car, name, deadline)
         after
           1_000 -> wait_outcomes(await, car, name, deadline)
         end
@@ -910,7 +944,7 @@ defmodule TeslaMate.Characterization do
       {mock, _} when mock in [ApiMock, SettingsMock, VehiclesMock] ->
         flush_notifications()
 
-      {:api_event_served, _} ->
+      {:api_event_served, _, _} ->
         flush_notifications()
 
       {:awaits_vacuous?, _} ->

--- a/test/support/mocks/api.ex
+++ b/test/support/mocks/api.ex
@@ -175,7 +175,10 @@ defmodule ApiMock do
     exec(event, action)
   end
 
-  defp exec(event, _action) when is_function(event), do: event.()
+  # Characterization serve closures take the API action so the harness can
+  # tell one fetch cycle (probe + strict fetch) from two.
+  defp exec(event, action) when is_function(event, 1), do: event.(action)
+  defp exec(event, _action) when is_function(event, 0), do: event.()
   defp exec(event, _action), do: event
 
   defp snapshot?({:snapshot, _event}), do: true

--- a/test/teslamate/characterization_harness_test.exs
+++ b/test/teslamate/characterization_harness_test.exs
@@ -56,6 +56,15 @@ defmodule TeslaMate.CharacterizationHarnessTest do
     end
   end
 
+  describe "two_call_cycle?/2" do
+    test "only probe followed by strict fetch is one cycle" do
+      assert Characterization.two_call_cycle?(:get_vehicle, :get_vehicle_with_state)
+      refute Characterization.two_call_cycle?(:get_vehicle_with_state, :get_vehicle)
+      refute Characterization.two_call_cycle?(:get_vehicle_with_state, :get_vehicle_with_state)
+      refute Characterization.two_call_cycle?(:get_vehicle, :get_vehicle)
+    end
+  end
+
   describe "expect_restart?/1" do
     test "true declares it, absence does not" do
       assert Characterization.expect_restart?(%{

--- a/test/teslamate/characterization_test.exs
+++ b/test/teslamate/characterization_test.exs
@@ -121,6 +121,36 @@ defmodule TeslaMate.CharacterizationTest do
   end
 
   @tag :tmp_dir
+  test "a scenario ending in an error event raises", %{tmp_dir: tmp} do
+    scenario =
+      base_scenario("error terminal probe", [
+        park_event(1_704_067_200_000),
+        %{"error" => "vehicle_unavailable"}
+      ])
+
+    assert_raise RuntimeError, ~r/cannot end in an error event/, fn ->
+      Characterization.record_pair(tmp_pair(tmp, "error_terminal", scenario))
+    end
+  end
+
+  @tag :tmp_dir
+  test "a terminal reached through a two-call cycle raises", %{tmp_dir: tmp} do
+    t0 = 1_704_067_200_000
+
+    scenario =
+      base_scenario("two-call terminal probe", [
+        park_event(t0),
+        %{"error" => "vehicle_unavailable"},
+        park_event(t0 + 10_000)
+      ])
+      |> put_in(["settings", "use_streaming_api"], false)
+
+    assert_raise RuntimeError, ~r/reached through a two-call cycle/, fn ->
+      Characterization.record_pair(tmp_pair(tmp, "two_call_terminal", scenario))
+    end
+  end
+
+  @tag :tmp_dir
   test "a scenario ending in a call event raises", %{tmp_dir: tmp} do
     scenario =
       base_scenario("call terminal probe", [


### PR DESCRIPTION
Fixes #5682.

## What happened

The harness moduledoc documented a limit without enforcing it: the end-of-replay barrier counted API serves, not fetch cycles. A terminal reached through the probe and strict fetch of a single `fetch` produced both barrier serves from one cycle — the barrier proved nothing, and `error_event` recorded a race outcome as its golden (#5670).

## The fix

- **Static rule:** a scenario cannot end in an error event (`build_events/1`, named raise). An error terminal is never repeat-neutral — the unavailable counter keeps running under repeats — and it is the only shape in which a strict fetch is followed by a probe *within* one cycle (the `vehicle_unavailable` fallback).
- **Dynamic rule:** `ApiMock.exec/2` passes the API action to the harness serve closures (mock-based tests keep their 0-arity events); `await_serve/4` returns the action of each barrier serve, and a probe followed by a strict fetch raises with a named error in **both** record and compare (`two_call_cycle?/2`, unit-tested). With error terminals excluded, that pair is the only single-cycle shape left: snapshots execute once per cycle, a strict fetch that got asleep/offline is followed by the next cycle's probe, a call's strict fetch by the next poll.
- The moduledoc limit moves into the invariants with its checks named; two tmp-scenario probes pin the raises (`[park, error]`, `[park, error, park]` — the pre-#5670 `error_event` shape).

## Verification

Full test suite green: 603 passed (600 + 3 new probes).

## Workarounds & open questions

None.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Fable 5.1 low) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)