### PR TITLE
fix(mqtt): stop re-running the Home Assistant discovery migration on every restart

### DIFF
--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -124,9 +124,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   @spec migrate(term(), publish_opts(), term()) :: :ok | {:error, term()}
   def migrate(%Summary{} = summary, opts, publisher) do
     car_id = Keyword.fetch!(opts, :car_id)
-    namespace = Keyword.get(opts, :namespace)
-    prefix = Keyword.get(opts, :discovery_prefix, @discovery_prefix)
-    node = node(car_id, namespace)
+    {prefix, node} = discovery_topic_context(car_id, opts)
     migration_delay = Keyword.get(opts, :migration_delay, @migration_delay)
 
     with :ok <- clear_legacy_configs(prefix, node, publisher),
@@ -138,8 +136,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   defp discovery_config(%Summary{} = summary, opts) do
     car_id = Keyword.fetch!(opts, :car_id)
     namespace = Keyword.get(opts, :namespace)
-    prefix = Keyword.get(opts, :discovery_prefix, @discovery_prefix)
-    node = node(car_id, namespace)
+    {prefix, node} = discovery_topic_context(car_id, opts)
 
     components =
       Map.new(entities(), fn {component, object_id, config} ->
@@ -202,9 +199,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   """
   @spec clear(pos_integer(), publish_opts(), term()) :: :ok | {:error, term()}
   def clear(car_id, opts, publisher) do
-    namespace = Keyword.get(opts, :namespace)
-    prefix = Keyword.get(opts, :discovery_prefix, @discovery_prefix)
-    node = node(car_id, namespace)
+    {prefix, node} = discovery_topic_context(car_id, opts)
 
     with :ok <-
            call(publisher, :publish, [
@@ -214,6 +209,13 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
            ]) do
       clear_legacy_configs(prefix, node, publisher)
     end
+  end
+
+  defp discovery_topic_context(car_id, opts) do
+    namespace = Keyword.get(opts, :namespace)
+    prefix = Keyword.get(opts, :discovery_prefix, @discovery_prefix)
+
+    {prefix, node(car_id, namespace)}
   end
 
   defp clear_legacy_configs(prefix, node, publisher) do

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -15,7 +15,6 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
   @discovery_prefix "homeassistant"
   @migration_delay :timer.seconds(1)
-  @migration_payload Jason.encode!(%{migrate_discovery: true})
   @node "teslamate"
   @legacy_discovery_entities [
     {"sensor", "display_name"},
@@ -74,9 +73,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
     {"binary_sensor", "is_preconditioning"},
     {"binary_sensor", "plugged_in"},
     {"binary_sensor", "charge_port_door_open"},
-    {"binary_sensor", "locked"}
-  ]
-  @removed_legacy_discovery_entities [
+    {"binary_sensor", "locked"},
     {"binary_sensor", "update_available"},
     {"sensor", "tpms_pressure_fl_psi"},
     {"sensor", "tpms_pressure_fr_psi"},
@@ -111,54 +108,36 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
   @doc """
   Migrates any existing single-component discovery configs to a device
-  discovery config and then clears the old retained configs. Components that
-  are disabled by default are omitted from the first device config and added
-  in a final device config after legacy cleanup. This prevents Home Assistant
-  from treating cleanup on a legacy topic as removal of a disabled component
-  from the shared device topic.
+  discovery config by clearing all historical legacy topics, waiting for Home
+  Assistant to process the removals, and publishing one complete device
+  config.
 
-  Publishing stops at the first error. Every legacy migration marker must be
-  published successfully before waiting for Home Assistant to process the
-  markers and publishing the migration device config. Legacy cleanup starts
-  only after that config succeeds. After cleanup, Home Assistant is given the
-  same processing delay before the complete device config is published.
-  Retrying safely restarts the sequence.
+  Publishing stops at the first error. Every legacy config must be cleared
+  successfully before waiting and publishing the device config. Retrying
+  safely restarts the sequence.
   """
   @spec migrate(term(), publish_opts(), term()) :: :ok | {:error, term()}
   def migrate(%Summary{} = summary, opts, publisher) do
-    entity_configs = entities()
-    {prefix, node, device_payload} = discovery_config(summary, opts, entity_configs)
+    car_id = Keyword.fetch!(opts, :car_id)
+    namespace = Keyword.get(opts, :namespace)
+    prefix = Keyword.get(opts, :discovery_prefix, @discovery_prefix)
+    node = node(car_id, namespace)
     migration_delay = Keyword.get(opts, :migration_delay, @migration_delay)
 
-    migration_entity_configs =
-      Enum.reject(entity_configs, fn {_component, _object_id, config} ->
-        Map.get(config, :enabled_by_default, true) == false
-      end)
-
-    {^prefix, ^node, migration_device_payload} =
-      discovery_config(summary, opts, migration_entity_configs)
-
-    with :ok <- publish_legacy_configs(prefix, node, @migration_payload, publisher),
-         :ok <- Process.sleep(migration_delay),
-         :ok <- publish_device_config(prefix, node, migration_device_payload, publisher),
-         :ok <- publish_legacy_configs(prefix, node, "", publisher),
+    with :ok <- clear_legacy_configs(prefix, node, publisher),
          :ok <- Process.sleep(migration_delay) do
-      publish_device_config(prefix, node, device_payload, publisher)
+      publish(summary, opts, publisher)
     end
   end
 
   defp discovery_config(%Summary{} = summary, opts) do
-    discovery_config(summary, opts, entities())
-  end
-
-  defp discovery_config(%Summary{} = summary, opts, entity_configs) do
     car_id = Keyword.fetch!(opts, :car_id)
     namespace = Keyword.get(opts, :namespace)
     prefix = Keyword.get(opts, :discovery_prefix, @discovery_prefix)
     node = node(car_id, namespace)
 
     components =
-      Map.new(entity_configs, fn {component, object_id, config} ->
+      Map.new(entities(), fn {component, object_id, config} ->
         component_id = Map.get(config, :component_id, object_id)
 
         config
@@ -228,23 +207,15 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
              "",
              [retain: true, qos: 1]
            ]) do
-      publish_legacy_configs(prefix, node, "", publisher)
+      clear_legacy_configs(prefix, node, publisher)
     end
   end
 
-  defp publish_legacy_configs(prefix, node, payload, publisher) do
-    entities =
-      for {component, object_id, _config} <- entities(),
-          {component, object_id} in @legacy_discovery_entities,
-          do: {component, object_id}
-
-    entities =
-      if payload == "", do: entities ++ @removed_legacy_discovery_entities, else: entities
-
-    Enum.reduce_while(entities, :ok, fn {component, object_id}, _acc ->
+  defp clear_legacy_configs(prefix, node, publisher) do
+    Enum.reduce_while(@legacy_discovery_entities, :ok, fn {component, object_id}, _acc ->
       topic = component_discovery_topic(prefix, component, node, object_id)
 
-      case call(publisher, :publish, [topic, payload, [retain: true, qos: 1]]) do
+      case call(publisher, :publish, [topic, "", [retain: true, qos: 1]]) do
         :ok -> {:cont, :ok}
         {:error, _} = error -> {:halt, error}
       end

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -114,7 +114,10 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
 
   Publishing stops at the first error. Every legacy config must be cleared
   successfully before waiting and publishing the device config. Retrying
-  safely restarts the sequence.
+  safely restarts the sequence. On installations already using device
+  discovery, each retry or TeslaMate restart causes Home Assistant to log one
+  harmless "conflicting MQTT discovery message" warning for each of the 62
+  legacy topics for that vehicle. Existing entities remain unchanged.
   """
   @spec migrate(term(), publish_opts(), term()) :: :ok | {:error, term()}
   def migrate(%Summary{} = summary, opts, publisher) do

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -16,6 +16,8 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
   @discovery_prefix "homeassistant"
   @migration_delay :timer.seconds(1)
   @node "teslamate"
+  # Frozen snapshot of every single-component topic TeslaMate has ever published.
+  # Only append when an entity is removed or renamed; never add new entities.
   @legacy_discovery_entities [
     {"sensor", "display_name"},
     {"sensor", "state"},

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -6,7 +6,6 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
   alias TeslaMate.Log.Car
 
   @migration_delay 10
-  @migration_payload Jason.encode!(%{migrate_discovery: true})
 
   defp migration_opts(opts), do: Keyword.put(opts, :migration_delay, @migration_delay)
 
@@ -31,8 +30,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     car: %Car{id: 0, name: "Tesla Model 3", model: "3"}
   }
 
-  test "migrates legacy enabled components before cleanup and disabled components after cleanup",
-       %{test: name} do
+  test "clears every legacy config before publishing one complete device config", %{test: name} do
     publisher_name = start_publisher(name)
 
     opts =
@@ -40,63 +38,40 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     started_at = System.monotonic_time(:millisecond)
     :ok = HomeAssistant.migrate(@summary, opts, {MqttPublisherMock, publisher_name})
-    assert System.monotonic_time(:millisecond) - started_at >= 2 * @migration_delay
+    assert System.monotonic_time(:millisecond) - started_at >= @migration_delay
 
     messages = receive_configs()
 
-    {migrations, [{topic, migration_payload, publish_opts} | remaining]} =
-      Enum.split_while(messages, fn {topic, _payload, _opts} ->
-        topic != "homeassistant/device/teslamate_0/config"
-      end)
-
-    {cleanup, [{final_topic, final_payload, final_publish_opts}]} =
-      Enum.split_while(remaining, fn {topic, _payload, _opts} ->
-        topic != "homeassistant/device/teslamate_0/config"
-      end)
-
-    assert migrations != []
-
-    assert Enum.all?(
-             migrations,
-             &match?({_topic, @migration_payload, [retain: true, qos: 1]}, &1)
-           )
+    {cleanup, [{topic, payload, publish_opts}]} = Enum.split(messages, -1)
 
     assert topic == "homeassistant/device/teslamate_0/config"
     assert publish_opts == [retain: true, qos: 1]
-    assert final_topic == topic
-    assert final_publish_opts == publish_opts
-
-    migration_topics = Enum.map(migrations, &elem(&1, 0))
     cleanup_topics = Enum.map(cleanup, &elem(&1, 0))
 
-    assert MapSet.subset?(MapSet.new(migration_topics), MapSet.new(cleanup_topics))
+    assert length(cleanup_topics) == 62
+    assert MapSet.size(MapSet.new(cleanup_topics)) == 62
     assert Enum.all?(cleanup, &match?({_topic, "", [retain: true, qos: 1]}, &1))
 
     removed_update_available_topic =
       "homeassistant/binary_sensor/teslamate_0/update_available/config"
 
-    refute removed_update_available_topic in migration_topics
     assert removed_update_available_topic in cleanup_topics
 
     update_available_topic = "homeassistant/sensor/teslamate_0/update_available/config"
-    refute update_available_topic in migration_topics
     refute update_available_topic in cleanup_topics
 
     for position <- ["fl", "fr", "rl", "rr"] do
       removed_topic =
         "homeassistant/sensor/teslamate_0/tpms_pressure_#{position}_psi/config"
 
-      refute removed_topic in migration_topics
       assert removed_topic in cleanup_topics
     end
 
-    migration_decoded = Jason.decode!(migration_payload)
-    decoded = Jason.decode!(final_payload)
+    decoded = Jason.decode!(payload)
 
     components = decoded["components"]
-    assert map_size(components) > length(migrations)
 
-    assert "homeassistant/device_tracker/teslamate_0/location/config" in migration_topics
+    assert "homeassistant/device_tracker/teslamate_0/location/config" in cleanup_topics
 
     for {component_id, legacy_topic} <- [
           {"latitude", "homeassistant/sensor/teslamate_0/latitude/config"},
@@ -110,7 +85,6 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
            "homeassistant/binary_sensor/teslamate_0/driver_front_door_open/config"}
         ] do
       assert Map.has_key?(components, component_id)
-      refute legacy_topic in migration_topics
       refute legacy_topic in cleanup_topics
     end
 
@@ -118,9 +92,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       for {object_id, %{"enabled_by_default" => false}} <- components, do: object_id
 
     assert disabled_component_ids != []
-
-    assert Map.keys(migration_decoded["components"]) |> Enum.sort() ==
-             Map.keys(components) |> Kernel.--(disabled_component_ids) |> Enum.sort()
+    assert components["display_name"]["enabled_by_default"] == false
 
     for config <- Map.values(components) do
       assert Map.has_key?(config, "platform")
@@ -138,6 +110,25 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert decoded["origin"]["name"] == "TeslaMate"
     assert is_binary(decoded["origin"]["sw_version"])
     assert decoded["origin"]["support_url"] == "https://docs.teslamate.org/"
+  end
+
+  test "repeated migrations publish byte-identical complete device configs", %{test: name} do
+    publisher_name = start_publisher(name)
+    opts = migration_opts(car_id: 0)
+    publisher = {MqttPublisherMock, publisher_name}
+
+    :ok = HomeAssistant.migrate(@summary, opts, publisher)
+    :ok = HomeAssistant.migrate(@summary, opts, publisher)
+
+    [first, second] = receive_configs() |> Enum.chunk_every(63)
+
+    assert {"homeassistant/device/teslamate_0/config", first_payload, [retain: true, qos: 1]} =
+             List.last(first)
+
+    assert {"homeassistant/device/teslamate_0/config", second_payload, [retain: true, qos: 1]} =
+             List.last(second)
+
+    assert first_payload == second_payload
   end
 
   test "publishes a device config without touching legacy topics", %{test: name} do
@@ -372,15 +363,20 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     publisher_name = start_publisher(name)
 
     :ok =
-      HomeAssistant.publish(
+      HomeAssistant.migrate(
         @summary,
-        [car_id: 0, discovery_prefix: "custom_prefix"],
+        migration_opts(car_id: 0, discovery_prefix: "custom_prefix"),
         {MqttPublisherMock, publisher_name}
       )
 
-    assert_receive {MqttPublisherMock,
-                    {:publish, "custom_prefix/device/teslamate_0/config", _payload,
-                     [retain: true, qos: 1]}}
+    messages = receive_configs()
+
+    assert Enum.all?(messages, fn {topic, _payload, _opts} ->
+             String.starts_with?(topic, "custom_prefix/")
+           end)
+
+    assert {"custom_prefix/device/teslamate_0/config", _payload, [retain: true, qos: 1]} =
+             List.last(messages)
   end
 
   test "scopes device topic, unique_id and device by namespace", %{test: name} do
@@ -393,29 +389,23 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
         {MqttPublisherMock, publisher_name}
       )
 
-    assert_receive {MqttPublisherMock,
-                    {:publish, "homeassistant/sensor/teslamate_ns1_0/speed/config",
-                     @migration_payload, [retain: true, qos: 1]}}
+    messages = receive_configs()
+    {cleanup, [{topic, payload, publish_opts}]} = Enum.split(messages, -1)
 
-    {topic, decoded} = receive_device_config()
+    assert {"homeassistant/sensor/teslamate_ns1_0/speed/config", "", publish_opts} in cleanup
     assert topic == "homeassistant/device/teslamate_ns1_0/config"
+    assert publish_opts == [retain: true, qos: 1]
+
+    decoded = Jason.decode!(payload)
 
     speed = decoded["components"]["speed"]
     assert speed["object_id"] == "tesla_speed"
     assert speed["unique_id"] == "teslamate_ns1_0_speed"
     assert speed["state_topic"] == "teslamate/ns1/cars/0/speed"
     assert decoded["device"]["identifiers"] == ["teslamate_ns1_car_0"]
-    refute Map.has_key?(decoded["components"], "display_name")
 
-    {final_topic, final_decoded} = receive_device_config()
-    assert final_topic == topic
-
-    assert final_decoded["components"]["display_name"]["unique_id"] ==
+    assert decoded["components"]["display_name"]["unique_id"] ==
              "teslamate_ns1_0_display_name"
-
-    assert_receive {MqttPublisherMock,
-                    {:publish, "homeassistant/sensor/teslamate_ns1_0/speed/config", "",
-                     [retain: true, qos: 1]}}
   end
 
   test "aligns measurement sensors with the custom integration", %{test: name} do
@@ -1042,7 +1032,8 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     assert device_topic == "homeassistant/device/teslamate_0/config"
     assert publish_opts == [retain: true, qos: 1]
-    assert legacy_cleanup != []
+    assert length(legacy_cleanup) == 62
+    assert legacy_cleanup |> Enum.map(&elem(&1, 0)) |> MapSet.new() |> MapSet.size() == 62
     assert Enum.all?(legacy_cleanup, &match?({_topic, "", [retain: true, qos: 1]}, &1))
 
     assert Enum.any?(legacy_cleanup, fn {topic, _, _} ->
@@ -1066,7 +1057,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
            end)
   end
 
-  test "stops before device discovery when a migration marker fails", %{test: name} do
+  test "stops before device discovery when legacy cleanup fails", %{test: name} do
     legacy_topic = "homeassistant/sensor/teslamate_0/display_name/config"
     publisher_name = start_publisher(name, %{legacy_topic => [{:error, :disconnected}]})
 
@@ -1077,10 +1068,11 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
                {MqttPublisherMock, publisher_name}
              )
 
-    assert [{^legacy_topic, @migration_payload, [retain: true, qos: 1]}] = receive_configs()
+    assert [{^legacy_topic, "", [retain: true, qos: 1]}] = receive_configs()
   end
 
-  test "does not clear legacy topics when device discovery publishing fails", %{test: name} do
+  test "clears all legacy topics before returning a device discovery publishing error",
+       %{test: name} do
     device_topic = "homeassistant/device/teslamate_0/config"
     publisher_name = start_publisher(name, %{device_topic => [{:error, :disconnected}]})
 
@@ -1092,58 +1084,13 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
              )
 
     messages = receive_configs()
-    assert {^device_topic, _payload, [retain: true, qos: 1]} = List.last(messages)
+    {cleanup, [{^device_topic, payload, [retain: true, qos: 1]}]} = Enum.split(messages, -1)
 
-    assert messages
-           |> Enum.drop(-1)
-           |> Enum.all?(&match?({_topic, @migration_payload, [retain: true, qos: 1]}, &1))
-  end
+    assert length(cleanup) == 62
+    assert Enum.all?(cleanup, &match?({_topic, "", [retain: true, qos: 1]}, &1))
 
-  test "stops legacy cleanup on the first failure", %{test: name} do
-    legacy_topic = "homeassistant/sensor/teslamate_0/display_name/config"
-
-    publisher_name =
-      start_publisher(name, %{legacy_topic => [:ok, {:error, :disconnected}]})
-
-    assert {:error, :disconnected} =
-             HomeAssistant.migrate(
-               @summary,
-               migration_opts(car_id: 0),
-               {MqttPublisherMock, publisher_name}
-             )
-
-    messages = receive_configs()
-    assert {^legacy_topic, "", [retain: true, qos: 1]} = List.last(messages)
-
-    assert Enum.count(messages, fn {topic, payload, _opts} ->
-             topic == legacy_topic and payload == @migration_payload
-           end) == 1
-
-    assert Enum.count(messages, fn {topic, _payload, _opts} ->
-             topic == "homeassistant/device/teslamate_0/config"
-           end) == 1
-  end
-
-  test "returns an error when the complete device config cannot be published", %{test: name} do
-    device_topic = "homeassistant/device/teslamate_0/config"
-
-    publisher_name =
-      start_publisher(name, %{device_topic => [:ok, {:error, :disconnected}]})
-
-    assert {:error, :disconnected} =
-             HomeAssistant.migrate(
-               @summary,
-               migration_opts(car_id: 0),
-               {MqttPublisherMock, publisher_name}
-             )
-
-    messages = receive_configs()
-    assert {^device_topic, final_payload, [retain: true, qos: 1]} = List.last(messages)
-
-    assert Jason.decode!(final_payload)["components"]["display_name"]["enabled_by_default"] ==
+    assert Jason.decode!(payload)["components"]["display_name"]["enabled_by_default"] ==
              false
-
-    assert Enum.count(messages, fn {topic, _payload, _opts} -> topic == device_topic end) == 2
   end
 
   defp receive_device_config(timeout \\ 200) do

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -598,7 +598,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
   test "backs off failed discovery publishes and retries the latest metadata", %{test: name} do
     topic = "homeassistant/device/teslamate_0/config"
     error = {:error, :disconnected}
-    responses = %{topic => List.duplicate(error, 7) ++ [:ok, :ok, error]}
+    responses = %{topic => List.duplicate(error, 7) ++ [:ok, error]}
 
     log =
       ExUnit.CaptureLog.capture_log(fn ->

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -686,8 +686,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
     summary = %Summary{healthy: true, display_name: "Foo", model: "3", state: :online}
     send(pid, summary)
 
-    assert_receive {MqttPublisherMock,
-                    {:publish, ^legacy_topic, _migration_payload, [retain: true, qos: 1]}}
+    assert_receive {MqttPublisherMock, {:publish, ^legacy_topic, "", [retain: true, qos: 1]}}
 
     refute_receive {MqttPublisherMock,
                     {:publish, "homeassistant/device/teslamate_0/config", _, _}}

--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -45,11 +45,16 @@ broker do not collide on the same discovery topics. The device is grouped
 under the `teslamate_car_<car_id>` identifier (likewise namespace-scoped), and
 the entity IDs match those produced by the manual `mqtt_sensors.yaml` below.
 
-When upgrading from TeslaMate's former per-entity discovery format, TeslaMate
-uses Home Assistant's discovery migration protocol to preserve entity registry
-settings and customizations. It marks the former single-component topics for
-migration, publishes the device discovery payload, and then clears the old
-retained topics.
+On the first vehicle summary after each startup, TeslaMate clears every retained
+topic from its former per-entity discovery format, waits for Home Assistant to
+process the removals, and then publishes one complete device discovery payload.
+Repeating this sequence is safe for installations already using device
+discovery: the legacy topics are absent and the retained device payload is
+unchanged.
+
+This cleanup does not use Home Assistant's discovery migration protocol. As a
+result, entity registry settings and customizations from the former per-entity
+format are not preserved when upgrading directly from TeslaMate 4.1.x.
 
 :::note
 

--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -48,9 +48,13 @@ the entity IDs match those produced by the manual `mqtt_sensors.yaml` below.
 On the first vehicle summary after each startup, TeslaMate clears every retained
 topic from its former per-entity discovery format, waits for Home Assistant to
 process the removals, and then publishes one complete device discovery payload.
-Repeating this sequence is safe for installations already using device
-discovery: the legacy topics are absent and the retained device payload is
-unchanged.
+For installations already using device discovery, repeating this sequence is
+state-idempotent but not silent. MQTT forwards each zero-byte retained publish
+to Home Assistant even when the legacy retained topic is already absent, so
+Home Assistant logs one harmless "conflicting MQTT discovery message" warning
+for each of the 62 legacy topics per vehicle after every TeslaMate restart.
+These warnings do not change or remove any existing entity, and the retained
+device payload is unchanged.
 
 This cleanup does not use Home Assistant's discovery migration protocol. As a
 result, entity registry settings and customizations from the former per-entity


### PR DESCRIPTION
## Summary

- clear all 62 historical single-component discovery topics before publishing device discovery
- wait for Home Assistant to process cleanup, then publish one complete retained device payload
- remove migration markers and partial device payloads so repeated startups are idempotent
- document the compatibility tradeoff for direct upgrades from TeslaMate 4.1.x

## Testing

- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix test test/teslamate/mqtt/pubsub/home_assistant_test.exs test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs test/teslamate/mqtt/pubsub/pubsub_test.exs --warnings-as-errors` (51 tests)

Fixes #5667