### PR TITLE
refactor(vehicle): date timestamp-less state rows through the clock seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Under the hood, this release adds a self-verifying black-box characterization su
 - fix(vehicle): cancel an update with the logged update row instead of the API payload, which crashed the vehicle process and left the update open forever (#5664 - @JakobLichterfeld)
 - fix(web): remove stray brace from the direction arrow SVG path, which made Safari log a parse error on every position update (#5665 - @JakobLichterfeld)
 - refactor(vehicle): route the vehicle's view of time through a clock seam (#5688 - @JakobLichterfeld)
+- refactor(vehicle): date timestamp-less state rows through the clock seam (#5689 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -998,7 +998,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
     Logger.info("Start / :asleep", car_id: data.car.id)
 
     {:ok, %Log.State{start_date: last_state_change}} =
-      call(data.deps.log, :start_state, [data.car, :asleep, date_opts(vehicle)])
+      call(data.deps.log, :start_state, [data.car, :asleep, date_opts(vehicle, data)])
 
     :ok = disconnect_stream(data)
 
@@ -1011,7 +1011,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
     Logger.info("Start / :offline", car_id: data.car.id)
 
     {:ok, %Log.State{start_date: last_state_change}} =
-      call(data.deps.log, :start_state, [data.car, :offline, date_opts(vehicle)])
+      call(data.deps.log, :start_state, [data.car, :offline, date_opts(vehicle, data)])
 
     :ok = disconnect_stream(data)
 
@@ -1038,7 +1038,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         synchronize_updates(vehicle, data)
 
         {:ok, %Log.State{start_date: last_state_change}} =
-          call(data.deps.log, :start_state, [car, :online, date_opts(vehicle)])
+          call(data.deps.log, :start_state, [car, :online, date_opts(vehicle, data)])
 
         {:ok, pos} = call(data.deps.log, :insert_position, [car, create_position(vehicle, data)])
         geofence = call(data.deps.locations, :find_geofence, [pos])
@@ -2087,9 +2087,12 @@ defmodule TeslaMate.Vehicles.Vehicle do
     {{:timeout, :store_position}, :timer.minutes(5), :store_position}
   end
 
-  defp date_opts(%Vehicle{drive_state: %Drive{timestamp: nil}}), do: []
-  defp date_opts(%Vehicle{drive_state: %Drive{timestamp: ts}}), do: [date: parse_timestamp(ts)]
-  defp date_opts(%Vehicle{}), do: []
+  # A payload without a timestamp is dated by the vehicle's clock, so every
+  # state row carries the vehicle's view of time rather than Log's fallback.
+  defp date_opts(%Vehicle{drive_state: %Drive{timestamp: ts}}, _data) when is_integer(ts),
+    do: [date: parse_timestamp(ts)]
+
+  defp date_opts(%Vehicle{}, %Data{deps: deps}), do: [date: deps.clock.utc_now()]
 
   defp parse_timestamp(ts), do: DateTime.from_unix!(ts, :millisecond)
 

--- a/test/teslamate/vehicles/vehicle/charging_test.exs
+++ b/test/teslamate/vehicles/vehicle/charging_test.exs
@@ -278,7 +278,7 @@ defmodule TeslaMate.Vehicles.Vehicle.ChargingTest do
     assert_receive {:insert_charge, ^cproc, %{date: _, charge_energy_added: 0.2}}
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :charging}}}
     assert_receive {:complete_charging_process, ^cproc}
-    assert_receive {:start_state, ^car, :asleep, []}
+    assert_receive {:start_state, ^car, :asleep, [date: _]}
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :asleep}}}
 
     refute_receive _

--- a/test/teslamate/vehicles/vehicle/driving_test.exs
+++ b/test/teslamate/vehicles/vehicle/driving_test.exs
@@ -339,7 +339,7 @@ defmodule TeslaMate.Vehicles.Vehicle.DrivingTest do
       assert_receive {:close_drive, ^drive, lookup_address: true}, 1200
 
       # After drive timeout, vehicle stays offline → state machine must transition to :offline
-      assert_receive {:start_state, ^car, :offline, []}
+      assert_receive {:start_state, ^car, :offline, [date: _]}
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :offline}}}
     end
 
@@ -373,7 +373,7 @@ defmodule TeslaMate.Vehicles.Vehicle.DrivingTest do
       assert_receive {:close_drive, ^drive, lookup_address: true}, 1200
 
       # Regression: state must transition to :offline, not stay stuck in :driving state
-      assert_receive {:start_state, ^car, :offline, []}
+      assert_receive {:start_state, ^car, :offline, [date: _]}
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :offline}}}
     end
 
@@ -401,7 +401,7 @@ defmodule TeslaMate.Vehicles.Vehicle.DrivingTest do
 
       # Timeout
       assert_receive {:close_drive, ^drive, lookup_address: true}, 1200
-      assert_receive {:start_state, _car, :asleep, []}
+      assert_receive {:start_state, _car, :asleep, [date: _]}
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :asleep}}}
 
       refute_receive _

--- a/test/teslamate/vehicles/vehicle/streaming_test.exs
+++ b/test/teslamate/vehicles/vehicle/streaming_test.exs
@@ -470,7 +470,7 @@ defmodule TeslaMate.Vehicles.Vehicle.StreamingTest do
       assert_receive :continue?
       send(:"api_#{name}", :continue)
 
-      assert_receive {:start_state, ^car, :asleep, []}
+      assert_receive {:start_state, ^car, :asleep, [date: _]}
       assert_receive {:"$websockex_cast", :disconnect}
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :asleep}}}
 

--- a/test/teslamate/vehicles/vehicle/suspend_logging_test.exs
+++ b/test/teslamate/vehicles/vehicle/suspend_logging_test.exs
@@ -10,7 +10,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
     ]
 
     :ok = start_vehicle(name, events)
-    assert_receive {:start_state, _, :asleep, []}
+    assert_receive {:start_state, _, :asleep, [date: _]}
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :asleep}}}
 
     assert :ok = Vehicle.suspend_logging(name)
@@ -23,7 +23,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
     ]
 
     :ok = start_vehicle(name, events)
-    assert_receive {:start_state, _, :offline, []}
+    assert_receive {:start_state, _, :offline, [date: _]}
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :offline}}}
 
     assert :ok = Vehicle.suspend_logging(name)

--- a/test/teslamate/vehicles/vehicle/suspend_test.exs
+++ b/test/teslamate/vehicles/vehicle/suspend_test.exs
@@ -38,7 +38,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
     assert DateTime.diff(s0, s1, :nanosecond) < 0
     assert_receive {:insert_position, ^car, %{}}
 
-    assert_receive {:start_state, ^car, :asleep, []}
+    assert_receive {:start_state, ^car, :asleep, [date: _]}
     assert_receive {:"$websockex_cast", :disconnect}
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :asleep, since: s2}}}
     assert DateTime.diff(s1, s2, :nanosecond) < 0
@@ -426,7 +426,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
 
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :suspended}}}
     assert_receive {:insert_position, ^car, %{}}
-    assert_receive {:start_state, ^car, :asleep, []}, 50
+    assert_receive {:start_state, ^car, :asleep, [date: _]}, 50
     assert_receive {:"$websockex_cast", :disconnect}
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :asleep}}}
 

--- a/test/teslamate/vehicles/vehicle_test.exs
+++ b/test/teslamate/vehicles/vehicle_test.exs
@@ -61,7 +61,7 @@ defmodule TeslaMate.Vehicles.VehicleTest do
 
       :ok = start_vehicle(name, events)
 
-      assert_receive {:start_state, _car, :offline, []}
+      assert_receive {:start_state, _car, :offline, [date: _]}
       assert_receive {:pubsub, {:broadcast, _server, _topic, %Summary{state: :offline}}}
 
       refute_receive _
@@ -74,7 +74,7 @@ defmodule TeslaMate.Vehicles.VehicleTest do
 
       :ok = start_vehicle(name, events)
 
-      assert_receive {:start_state, _car, :asleep, []}
+      assert_receive {:start_state, _car, :asleep, [date: _]}
       assert_receive {:pubsub, {:broadcast, _server, _topic, %Summary{state: :asleep}}}
 
       refute_receive _
@@ -119,7 +119,7 @@ defmodule TeslaMate.Vehicles.VehicleTest do
 
       :ok = start_vehicle(name, events)
 
-      assert_receive {:start_state, car, :asleep, []}
+      assert_receive {:start_state, car, :asleep, [date: _]}
       assert_receive {:pubsub, {:broadcast, _server, _topic, %Summary{state: :asleep}}}
 
       assert :ok = Vehicle.resume_logging(name)
@@ -148,7 +148,7 @@ defmodule TeslaMate.Vehicles.VehicleTest do
 
       :ok = start_vehicle(name, events)
 
-      assert_receive {:start_state, car, :offline, []}
+      assert_receive {:start_state, car, :offline, [date: _]}
       assert_receive {:pubsub, {:broadcast, _server, _topic, %Summary{state: :offline}}}
 
       assert :ok = Vehicle.resume_logging(name)
@@ -275,7 +275,7 @@ defmodule TeslaMate.Vehicles.VehicleTest do
       assert_receive {:insert_position, ^car, %{}}
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
 
-      assert_receive {:start_state, ^car, :asleep, []}
+      assert_receive {:start_state, ^car, :asleep, [date: _]}
       assert_receive {:"$websockex_cast", :disconnect}
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :asleep}}}
 
@@ -413,7 +413,7 @@ defmodule TeslaMate.Vehicles.VehicleTest do
           delay: 10
         )
 
-      assert_receive {:start_state, _car, :asleep, []}
+      assert_receive {:start_state, _car, :asleep, [date: _]}
       assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :asleep, healthy: true}}}
 
       :ok = :fuse.circuit_disable(fuse_name)
@@ -545,7 +545,7 @@ defmodule TeslaMate.Vehicles.VehicleTest do
         assert_receive {:start_state, car, :online, date: _}
         assert_receive {:insert_position, ^car, %{}}
         assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online}}}
-        assert_receive {:start_state, ^car, :asleep, []}
+        assert_receive {:start_state, ^car, :asleep, [date: _]}
         assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :asleep}}}
       end
 


### PR DESCRIPTION
Completes the clock seam from #5688; after this, `lib/` is untouched by the harness-clock work.

## What this adds

`date_opts/1` returned `[]` for payloads without a `drive_state` timestamp (asleep, offline, bare online), which sent those state rows into `Log.start_state`'s own `DateTime.utc_now()` fallback — #5688 misreported those clauses as "no fallback case". `date_opts/2` now dates them with `deps.clock.utc_now()`, so every state row carries the vehicle's view of time; the timestamp clause is unchanged and `log.ex` keeps its fallback for other callers. No interval, threshold or ordering changes.

## Behaviour-neutrality evidence

- Production: `Clock.Real.utc_now/0` is the same instant the fallback produced.
- Characterization suite green with **byte-identical goldens** (the wall-dated rows are volatile-masked in every scenario): full suite 624 passed, `git status` shows no golden.
- Vehicle mock tests green: 125 passed. The **only** test change is the call form of 16 assertions in `vehicle_test`, `driving_test`, `suspend_test`, `charging_test`, `suspend_logging_test`, `streaming_test` — `{:start_state, _, _, []}` → `[date: _]` — because those mocks couple to the call shape, not to behaviour.

## Workarounds & open questions

None.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Fable 5.1 low) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)