### PR TITLE
test(characterization): pin the stale-timestamp resume crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Under the hood, this release adds a self-verifying black-box characterization su
 - test(characterization): enforce the two-call-terminal limit (#5683 - @JakobLichterfeld)
 - test(characterization): convert suspend_logging scenarios to characterization fixtures (#5687 - @JakobLichterfeld)
 - test(characterization): run replays on a scenario clock, retire timebase (#5690 - @JakobLichterfeld)
+- test(characterization): pin the stale-timestamp resume crash (#5691 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/test/fixtures/characterization/goldens/stale_timestamp_offline_resume.json
+++ b/test/fixtures/characterization/goldens/stale_timestamp_offline_resume.json
@@ -1,0 +1,239 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "LR AWD",
+        "model": "3",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "74D",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 60,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:20.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.95",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 59
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:20.000000",
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.001000",
+        "state": "offline"
+      },
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:20.002000",
+        "id": "state_2",
+        "start_date": "2024-01-01T00:00:20.000000",
+        "state": "online"
+      },
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_3",
+        "start_date": "2024-01-01T00:00:20.002000",
+        "state": "asleep"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:20.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:20.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["60"],
+    "teslamate/cars/$car/charge_energy_added": [""],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["120"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["<volatile>", "<volatile>", "<volatile>"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["offline", "online", "asleep"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["", "74D"],
+    "teslamate/cars/$car/usable_battery_level": ["59"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/scenarios/stale_timestamp_offline_resume.json
+++ b/test/fixtures/characterization/scenarios/stale_timestamp_offline_resume.json
@@ -1,0 +1,181 @@
+{
+  "description": "PINNED BUG #5684: after an offline period, an online payload whose drive_state.timestamp lies before the offline row's date (here five minutes before the last position) cannot close that row — the states.positive_duration check rejects the update, the {:ok, _} match in the vehicle raises and the vehicle process crashes; expect_restart pins the crash. Both resume payloads are snapshot events: in :offline the vehicle probes first, and a plain event would be consumed by that probe without effect — the snapshot serves probe and data fetch from one payload. The stale snapshot is served exactly once and crashes; after the restart the fresh snapshot closes the offline row with t0 + 20 s, opens the online row and inserts one position. The asleep tail is the convergence gate: reached from :online through :start one cycle after the barrier, so the await is not vacuous. The golden pins the offline row closed by the fresh payload (not the stale one), no row from the stale payload, and the single restart position. Whether the API delivers such payloads is open (#5558 clock measurements); the fix follows against this pin in its own commit.",
+  "car": {
+    "eid": 42,
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001",
+    "model": "3",
+    "name": "blue",
+    "efficiency": 0.153
+  },
+  "settings": {
+    "use_streaming_api": false,
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000
+  },
+  "expect_restart": true,
+  "events": [
+    {
+      "vehicle": {
+        "id": 42,
+        "vehicle_id": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "state": "online",
+        "display_name": "blue",
+        "charge_state": {
+          "timestamp": 1704067200000,
+          "battery_level": 60,
+          "usable_battery_level": 59,
+          "ideal_battery_range": 250.0,
+          "battery_range": 240.0,
+          "est_battery_range": 230.5,
+          "charging_state": "Disconnected"
+        },
+        "drive_state": {
+          "timestamp": 1704067200000,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "heading": 120,
+          "power": 0,
+          "shift_state": null,
+          "speed": null
+        },
+        "climate_state": {
+          "timestamp": 1704067200000,
+          "outside_temp": 12.5,
+          "inside_temp": 18.0,
+          "is_climate_on": false
+        },
+        "vehicle_state": {
+          "timestamp": 1704067200000,
+          "car_version": "2026.20.1 abc123",
+          "odometer": 10000.0,
+          "locked": true,
+          "sentry_mode": false,
+          "is_user_present": false
+        },
+        "vehicle_config": {
+          "timestamp": 1704067200000,
+          "car_type": "model3",
+          "trim_badging": "74d",
+          "exterior_color": "DeepBlue",
+          "wheel_type": "Pinwheel18",
+          "spoiler_type": "None"
+        }
+      }
+    },
+    {
+      "vehicle": {
+        "state": "offline"
+      }
+    },
+    {
+      "vehicle": {
+        "id": 42,
+        "vehicle_id": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "state": "online",
+        "display_name": "blue",
+        "charge_state": {
+          "timestamp": 1704066900000,
+          "battery_level": 60,
+          "usable_battery_level": 59,
+          "ideal_battery_range": 250.0,
+          "battery_range": 240.0,
+          "est_battery_range": 230.5,
+          "charging_state": "Disconnected"
+        },
+        "drive_state": {
+          "timestamp": 1704066900000,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "heading": 120,
+          "power": 0,
+          "shift_state": null,
+          "speed": null
+        },
+        "climate_state": {
+          "timestamp": 1704066900000,
+          "outside_temp": 12.5,
+          "inside_temp": 18.0,
+          "is_climate_on": false
+        },
+        "vehicle_state": {
+          "timestamp": 1704066900000,
+          "car_version": "2026.20.1 abc123",
+          "odometer": 10000.0,
+          "locked": true,
+          "sentry_mode": false,
+          "is_user_present": false
+        },
+        "vehicle_config": {
+          "timestamp": 1704066900000,
+          "car_type": "model3",
+          "trim_badging": "74d",
+          "exterior_color": "DeepBlue",
+          "wheel_type": "Pinwheel18",
+          "spoiler_type": "None"
+        }
+      },
+      "snapshot": true
+    },
+    {
+      "vehicle": {
+        "id": 42,
+        "vehicle_id": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "state": "online",
+        "display_name": "blue",
+        "charge_state": {
+          "timestamp": 1704067220000,
+          "battery_level": 60,
+          "usable_battery_level": 59,
+          "ideal_battery_range": 250.0,
+          "battery_range": 240.0,
+          "est_battery_range": 230.5,
+          "charging_state": "Disconnected"
+        },
+        "drive_state": {
+          "timestamp": 1704067220000,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "heading": 120,
+          "power": 0,
+          "shift_state": null,
+          "speed": null
+        },
+        "climate_state": {
+          "timestamp": 1704067220000,
+          "outside_temp": 12.5,
+          "inside_temp": 18.0,
+          "is_climate_on": false
+        },
+        "vehicle_state": {
+          "timestamp": 1704067220000,
+          "car_version": "2026.20.1 abc123",
+          "odometer": 10000.0,
+          "locked": true,
+          "sentry_mode": false,
+          "is_user_present": false
+        },
+        "vehicle_config": {
+          "timestamp": 1704067220000,
+          "car_type": "model3",
+          "trim_badging": "74d",
+          "exterior_color": "DeepBlue",
+          "wheel_type": "Pinwheel18",
+          "spoiler_type": "None"
+        }
+      },
+      "snapshot": true
+    },
+    {
+      "vehicle": {
+        "state": "asleep"
+      }
+    }
+  ],
+  "await": {
+    "state": "asleep"
+  }
+}


### PR DESCRIPTION
Pins #5684 as current behaviour — not a fix. One fixture, no `lib/` change.

## Mechanism

When the vehicle goes offline, the payload carries no `drive_state.timestamp`, so the offline states row is dated by the vehicle's clock. When it comes back, `start_state` closes that row with the resume payload's timestamp as `end_date`. If that timestamp lies before the row's date, the `states.positive_duration` check rejects the update, `Repo.update` returns `{:error, changeset}`, and the `{:ok, %Log.State{}} =` match in `vehicle.ex` raises — the vehicle process crashes and is restarted by its supervisor.

## The fixture

`stale_timestamp_offline_resume`: `[online(t0), offline, snapshot online(t0 − 5 min), snapshot online(t0 + 20 s), asleep]`, streaming off, `expect_restart: true`, `await: {"state": "asleep"}`.

- Both resume payloads are **snapshot events**: in `:offline` the vehicle probes first (`get_vehicle`), and a plain event would be consumed by that probe without effect — the snapshot serves the probe and the data fetch from one payload.
- The stale snapshot is served exactly once and crashes (`MatchError`, `constraint_name: "positive_duration"`); after the restart the fresh snapshot closes the offline row with `t0 + 20 s`, opens the online row and inserts one position — recovery before the barrier.
- The asleep tail is the convergence gate: reached from `:online` through `:start` one cycle after the barrier, so the await gates a real transition (the vacuity probe stays silent), the barrier pair is strict → probe (no two-call cycle), and the DOWN precedes teardown.

## What the golden pins

- offline row `00:00:00.001 → 00:00:20.000` — closed by the fresh payload, not the stale one
- online row `00:00:20.000 → 00:00:20.002`, asleep row open
- exactly one position (`00:00:20.000`, from the restart); no row from the stale payload

## Open

Whether a real vehicle delivers such a payload — cached data right after wake-up, clock skew, a delayed first sample — is unanswered (#5558 clock measurements). If yes, the consequence in production is a crash loop on every fetch until the payload changes; the fix belongs in `start_state` and follows against this pin in its own commit.

## Verification

Characterization + harness suites: 101 passed. Full suite: 627 passed.

## Workarounds & open questions

None beyond the production question above.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Fable 5.1 low) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)