### PR TITLE
fix(vehicle): keep logging when the car reports an outdated timestamp after being offline or asleep — previously the vehicle process crashed on every poll and the state stayed stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Under the hood, this release adds a self-verifying black-box characterization su
 - fix(web): remove stray brace from the direction arrow SVG path, which made Safari log a parse error on every position update (#5665 - @JakobLichterfeld)
 - refactor(vehicle): route the vehicle's view of time through a clock seam (#5688 - @JakobLichterfeld)
 - refactor(vehicle): date timestamp-less state rows through the clock seam (#5689 - @JakobLichterfeld)
+- fix(vehicle): keep logging when the car reports an outdated timestamp after being offline or asleep — previously the vehicle process crashed on every poll and the state stayed stuck (#5692 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -19,6 +19,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
               last_used: nil,
               last_response: nil,
               last_state_change: nil,
+              state_row_started: nil,
               elevation: nil,
               geofence: nil,
               deps: %{},
@@ -248,6 +249,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
       car: car,
       last_used: deps.clock.utc_now(),
       last_state_change: last_state_change,
+      state_row_started: last_state_change,
       deps: deps,
       import?: Keyword.get(opts, :import?, false)
     }
@@ -1003,8 +1005,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
     :ok = disconnect_stream(data)
 
     {:next_state, {:asleep, asleep_interval()},
-     %{data | last_state_change: last_state_change, stream_pid: nil, pre_online_check: :idle},
-     [broadcast_summary(), schedule_fetch(data)]}
+     %{
+       data
+       | last_state_change: last_state_change,
+         state_row_started: last_state_change,
+         stream_pid: nil,
+         pre_online_check: :idle
+     }, [broadcast_summary(), schedule_fetch(data)]}
   end
 
   def handle_event(:internal, {:update, {:offline, vehicle}}, :start, %Data{} = data) do
@@ -1016,8 +1023,13 @@ defmodule TeslaMate.Vehicles.Vehicle do
     :ok = disconnect_stream(data)
 
     {:next_state, {:offline, asleep_interval()},
-     %{data | last_state_change: last_state_change, stream_pid: nil, pre_online_check: :idle},
-     [broadcast_summary(), schedule_fetch(data)]}
+     %{
+       data
+       | last_state_change: last_state_change,
+         state_row_started: last_state_change,
+         stream_pid: nil,
+         pre_online_check: :idle
+     }, [broadcast_summary(), schedule_fetch(data)]}
   end
 
   def handle_event(:internal, {:update, {:online, vehicle}} = evt, :start, %Data{} = data) do
@@ -1064,6 +1076,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
        data
        | car: car,
          last_state_change: last_state_change,
+         state_row_started: last_state_change,
          geofence: geofence,
          stream_pid: stream_pid
      }, [broadcast_summary(), {:next_event, :internal, evt}, schedule_position_storing()]}
@@ -2087,11 +2100,38 @@ defmodule TeslaMate.Vehicles.Vehicle do
     {{:timeout, :store_position}, :timer.minutes(5), :store_position}
   end
 
-  # A payload without a timestamp is dated by the vehicle's clock, so every
-  # state row carries the vehicle's view of time rather than Log's fallback.
+  # A payload whose timestamp lies before the open states row began is
+  # stale: the state change is real and observed now, only its timestamp is
+  # not trustworthy — dating the row with the payload would fail the
+  # positive_duration constraint (end_date >= start_date of that row) and
+  # crash the process (#5684). The comparison uses exactly the value the
+  # constraint compares: state_row_started, set only where start_state or
+  # get_current_state returns a row.
+  defp date_opts(
+         %Vehicle{drive_state: %Drive{timestamp: ts}},
+         %Data{state_row_started: %DateTime{} = started, deps: deps, car: car}
+       )
+       when is_integer(ts) do
+    date = parse_timestamp(ts)
+
+    if DateTime.compare(date, started) == :lt do
+      Logger.warning(
+        "Stale payload timestamp #{date} lies before the open state's start #{started} — " <>
+          "dating the state change now",
+        car_id: car.id
+      )
+
+      [date: deps.clock.utc_now()]
+    else
+      [date: date]
+    end
+  end
+
   defp date_opts(%Vehicle{drive_state: %Drive{timestamp: ts}}, _data) when is_integer(ts),
     do: [date: parse_timestamp(ts)]
 
+  # A payload without a timestamp is dated by the vehicle's clock, so every
+  # state row carries the vehicle's view of time rather than Log's fallback.
   defp date_opts(%Vehicle{}, %Data{deps: deps}), do: [date: deps.clock.utc_now()]
 
   defp parse_timestamp(ts), do: DateTime.from_unix!(ts, :millisecond)

--- a/test/fixtures/characterization/goldens/stale_timestamp_offline_resume.json
+++ b/test/fixtures/characterization/goldens/stale_timestamp_offline_resume.json
@@ -44,7 +44,7 @@
         "battery_heater_on": null,
         "battery_level": 60,
         "car_id": "$car",
-        "date": "2024-01-01T00:00:20.000000",
+        "date": "2023-12-31T23:55:00.000000",
         "drive_id": null,
         "driver_temp_setting": null,
         "elevation": null,
@@ -74,7 +74,7 @@
     "states": [
       {
         "car_id": "$car",
-        "end_date": "2024-01-01T00:00:20.000000",
+        "end_date": "2024-01-01T00:00:00.002000",
         "id": "state_1",
         "start_date": "2024-01-01T00:00:00.001000",
         "state": "offline"
@@ -83,7 +83,7 @@
         "car_id": "$car",
         "end_date": "2024-01-01T00:00:20.002000",
         "id": "state_2",
-        "start_date": "2024-01-01T00:00:20.000000",
+        "start_date": "2024-01-01T00:00:00.002000",
         "state": "online"
       },
       {
@@ -97,9 +97,9 @@
     "updates": [
       {
         "car_id": "$car",
-        "end_date": "2024-01-01T00:00:20.000000",
+        "end_date": "2023-12-31T23:55:00.000000",
         "id": "update_1",
-        "start_date": "2024-01-01T00:00:20.000000",
+        "start_date": "2023-12-31T23:55:00.000000",
         "version": "2026.20.1 abc123"
       }
     ]

--- a/test/fixtures/characterization/scenarios/stale_timestamp_offline_resume.json
+++ b/test/fixtures/characterization/scenarios/stale_timestamp_offline_resume.json
@@ -1,5 +1,5 @@
 {
-  "description": "PINNED BUG #5684: after an offline period, an online payload whose drive_state.timestamp lies before the offline row's date (here five minutes before the last position) cannot close that row — the states.positive_duration check rejects the update, the {:ok, _} match in the vehicle raises and the vehicle process crashes; expect_restart pins the crash. Both resume payloads are snapshot events: in :offline the vehicle probes first, and a plain event would be consumed by that probe without effect — the snapshot serves probe and data fetch from one payload. The stale snapshot is served exactly once and crashes; after the restart the fresh snapshot closes the offline row with t0 + 20 s, opens the online row and inserts one position. The asleep tail is the convergence gate: reached from :online through :start one cycle after the barrier, so the await is not vacuous. The golden pins the offline row closed by the fresh payload (not the stale one), no row from the stale payload, and the single restart position. Whether the API delivers such payloads is open (#5558 clock measurements); the fix follows against this pin in its own commit.",
+  "description": "Fix for #5684: after an offline period, an online payload whose drive_state.timestamp lies before the offline row's date (here five minutes before the last position) used to crash the vehicle — states.positive_duration rejected the update and the {:ok, _} match raised. The vehicle now recognises the stale timestamp (older than the open states row's start), dates the state change with its clock and logs a warning; no crash, no restart. Both resume payloads are snapshot events: in :offline the vehicle probes first, and a plain event would be consumed by that probe without effect. The asleep tail is the convergence gate (reached from :online through :start one cycle after the barrier). The golden pins the offline row closed at the clock time of the stale payload — not at its timestamp — the online row from there, and the positions. Whether the API delivers such payloads is still open (#5558 clock measurements).",
   "car": {
     "eid": 42,
     "vid": 1000,
@@ -13,7 +13,6 @@
     "suspend_after_idle_min": 100000,
     "suspend_min": 100000
   },
-  "expect_restart": true,
   "events": [
     {
       "vehicle": {

--- a/test/support/mocks/log.ex
+++ b/test/support/mocks/log.ex
@@ -78,9 +78,11 @@ defmodule LogMock do
   end
 
   @impl true
-  def handle_call({:start_state, _car, s, _} = action, _from, %State{pid: pid} = state) do
+  def handle_call({:start_state, _car, s, opts} = action, _from, %State{pid: pid} = state) do
     send(pid, action)
-    {:reply, {:ok, %Log.State{state: s, start_date: DateTime.utc_now()}}, state}
+    # Mirrors the production contract: the row is dated with the given date.
+    start_date = Keyword.get(opts, :date) || DateTime.utc_now()
+    {:reply, {:ok, %Log.State{state: s, start_date: start_date}}, state}
   end
 
   def handle_call({:get_current_state, _}, _from, state) do

--- a/test/teslamate/vehicles/vehicle/charging_test.exs
+++ b/test/teslamate/vehicles/vehicle/charging_test.exs
@@ -91,7 +91,7 @@ defmodule TeslaMate.Vehicles.Vehicle.ChargingTest do
     assert_receive {ApiMock, {:stream, 1000, _}}
     assert_receive {:insert_position, ^car, %{}}
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online, since: s2}}}
-    assert DateTime.diff(s1, s2, :nanosecond) < 0
+    assert s2 == start_date
 
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online, since: ^s2}}}
 

--- a/test/teslamate/vehicles/vehicle/suspend_logging_test.exs
+++ b/test/teslamate/vehicles/vehicle/suspend_logging_test.exs
@@ -373,7 +373,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
     assert_receive {ApiMock, {:stream, 1000, _}}
     assert_receive {:insert_position, ^car, %{}}
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :online, since: s2}}}
-    assert DateTime.diff(s1, s2, :nanosecond) < 0
+    assert s2 == d1
 
     assert :ok = Vehicle.suspend_logging(name)
     assert_receive {:pubsub, {:broadcast, _, _, %Summary{state: :suspended, since: s3}}}

--- a/test/teslamate/vehicles/vehicle/updating_test.exs
+++ b/test/teslamate/vehicles/vehicle/updating_test.exs
@@ -57,7 +57,7 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
                     {:broadcast, _server, _topic,
                      %Summary{state: :online, since: s2, version: "2019.8.5"}}}
 
-    assert DateTime.diff(s1, s2, :nanosecond) < 0
+    assert s2 == d1
 
     refute_receive _
   end
@@ -102,7 +102,7 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
     assert_receive {:start_state, ^car_id, :online, date: ^d1}
     assert_receive {:insert_position, ^car_id, %{}}
     assert_receive {:pubsub, {:broadcast, _server, _topic, %Summary{state: :online, since: s2}}}
-    assert DateTime.diff(s1, s2, :nanosecond) < 0
+    assert s2 == d1
 
     refute_receive _
   end


### PR DESCRIPTION
Fixes #5684 (the crash); the measurement question stays open there.

## Mechanism

When the vehicle goes offline or asleep, the states row is dated by the vehicle's clock. A resume payload whose `drive_state.timestamp` lies before that row's start could not close it: `states.positive_duration` (`end_date >= start_date`) rejected the update, the `{:ok, %Log.State{}} =` match raised, the vehicle process crashed and was restarted into the same payload — a crash loop until the payload changed. Pinned by `stale_timestamp_offline_resume` (#5691).

## The fix

`date_opts/2` compares the payload date with exactly the value the constraint compares — the open row's start, carried in a new `state_row_started` field set only where `start_state`/`get_current_state` return a row (`last_state_change` also marks server-dated transient states such as charging or updating, so ordinary car/server clock skew would have flagged the next payload). A stale payload dates the state change with the vehicle's clock and logs a warning with both times: the change is real and observed now, only its timestamp is not trustworthy. No clamp to zero length, no new setting, `log.ex` untouched.

## Mock fidelity and four sharpened assertions

`LogMock.start_state` ignored `date:` and returned `DateTime.utc_now()`; production dates the row with the given date. The mock now mirrors that contract. Four assertions (`charging_test`, `suspend_logging_test`, `updating_test` ×2) asserted only the *ordering* of the `since` topic across a transient state — they held by the mock's invented time. They now assert the exact payload date of the following online row. Observation from the faithful mock, not changed here: a transient state's `since` is server-dated while the following row is payload-dated, so `since` can step backwards by the car/server skew.

## The pin's golden diff — documented behavior change

Before: crash, restart, offline row closed by the *fresh* payload at `00:00:20`, one position from the fresh payload. After: no crash; offline row closed at the clock time of the stale serve (`00:00:00.002`), online row from there to the asleep tail, and the position the stale payload inserts with its own five-minutes-earlier date. Positions are payload-dated and outside this fix (finding for #5684).

## Verification

Vehicle mock tests: 125 passed. Full suite: 627 passed.

## Workarounds & open questions

- Positions, charges and updates stay payload-dated; a stale resume payload now leaves a backdated position row instead of crashing.
- `since` stepping backwards across transient states (see above).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Fable 5.1 low) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)