### PR TITLE
test(characterization): name the scenario event behind a mismatch on a dated row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Under the hood, this release adds a self-verifying black-box characterization su
 - test(characterization): convert the remaining vehicle scenarios — resume_logging and summary calls, expect_halt, seed positions, Vehicles stand-in (#5698 - @JakobLichterfeld)
 - test(characterization): pin charge samples without charger_power (#5700 - @JakobLichterfeld)
 - test(characterization): pin stream connect/disconnect and the supervisor kill as golden interactions (#5704 - @JakobLichterfeld)
+- test(characterization): name the scenario event behind a mismatch on a dated row (#5705 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/test/support/characterization.ex
+++ b/test/support/characterization.ex
@@ -256,6 +256,12 @@ defmodule TeslaMate.Characterization do
       vehicle process is monitored and the replay fails before teardown
       unless it actually went down; a declaration without an `await`
       convergence outcome raises (`replay/2`, `expect_restart?/1`).
+    * A mismatch on a dated row names the scenario event whose cycle created
+      it — the last timed event (payload timestamp, clock value or stream
+      time) at or before the row's date, with the distance in milliseconds
+      when the date lies between events; an `end_date` divergence names the
+      closing event as well, rows dated before the first event are called
+      out as seed or clock-dated (`mismatch_message/4`, `attribute_date/2`).
     * Interactions are captured, not flushed: stream connect and disconnect
       and the supervisor kill land in the golden with their serve index
       (`ApiMock.record_interaction/2`, `ApiMock.interactions/1`,
@@ -498,9 +504,10 @@ defmodule TeslaMate.Characterization do
            "missing golden for #{pair.name} — " <>
              "record it with CHARACTERIZATION_RECORD=#{only_target(pair)} mix test"
 
+    input = read_scenario(pair)
     expected = pair.golden_path |> File.read!() |> Jason.decode!()
-    actual = replay(read_scenario(pair), :compare)
-    assert_equivalent(expected, actual, pair.name)
+    actual = replay(input, :compare)
+    assert_equivalent(expected, actual, pair.name, input)
   end
 
   def only_target(%Pair{selftest?: true, name: name}), do: "only:selftest/#{name}"
@@ -1456,19 +1463,155 @@ defmodule TeslaMate.Characterization do
   def mask_volatile(value, value), do: value
   def mask_volatile(_first, _second), do: @volatile
 
-  defp assert_equivalent(expected, actual, name) do
+  defp assert_equivalent(expected, actual, name, input) do
+    case mismatch_message(name, expected, actual, input) do
+      nil -> :ok
+      message -> flunk(message)
+    end
+  end
+
+  # The comparison message: the first divergence, and — when it lies in a
+  # dated row — the scenario event whose cycle created that row, so the
+  # reader lands on the event instead of hunting the row's date.
+  @doc false
+  def mismatch_message(name, expected, actual, input) do
     case diff(expected, actual) do
       nil ->
-        :ok
+        nil
 
       {path, exp, act} ->
-        flunk("""
+        """
         characterization mismatch in #{name}
         first divergence at #{Enum.join(path, ".")}
         expected: #{inspect(exp)}
         actual:   #{inspect(act)}
-        """)
+        """ <> attribution_lines(path, expected, actual, input)
     end
+  end
+
+  defp attribution_lines(
+         ["database", table, "[" <> _ = position, column],
+         expected,
+         actual,
+         input
+       ) do
+    index =
+      position |> String.trim_leading("[") |> String.trim_trailing("]") |> String.to_integer()
+
+    expected_row = row_at(expected, table, index)
+    actual_row = row_at(actual, table, index)
+
+    created =
+      case row_date(expected_row, actual_row, ["date", "start_date"]) do
+        nil -> ""
+        date -> "row dated #{date} — created #{attribute_date(date, input)}\n"
+      end
+
+    closed =
+      case column == "end_date" && row_date(expected_row, actual_row, ["end_date"]) do
+        date when is_binary(date) ->
+          "row closed #{date} — closed #{attribute_date(date, input)}\n"
+
+        _ ->
+          ""
+      end
+
+    created <> closed
+  end
+
+  defp attribution_lines(_path, _expected, _actual, _input), do: ""
+
+  defp row_at(capture, table, index) do
+    case get_in(capture, ["database", table]) do
+      rows when is_list(rows) -> Enum.at(rows, index, :__missing__)
+      _ -> :__missing__
+    end
+  end
+
+  # The row's date: from the golden, from the capture when the golden's is
+  # masked or the row exists only there.
+  defp row_date(expected_row, actual_row, columns) do
+    Enum.find_value(columns, fn column ->
+      Enum.find_value([expected_row, actual_row], fn
+        %{} = row ->
+          case Map.get(row, column) do
+            value when is_binary(value) and value != @volatile -> value
+            _ -> nil
+          end
+
+        _ ->
+          nil
+      end)
+    end)
+  end
+
+  # Attribution rule, derived from the replay clock: every serve raises the
+  # clock to at least its payload time and clock events set it explicitly,
+  # so a row dated d was created in the cycle of the last event whose time
+  # is <= d. Ticks between timed events do not identify an event
+  # (Clock.serve/1 runs per closure execution — snapshot twice, terminal
+  # repeats, error fallback), so the distance is reported instead.
+  @doc false
+  def attribute_date(date, input) do
+    with {:ok, naive} <- NaiveDateTime.from_iso8601(date),
+         ms = naive |> DateTime.from_naive!("Etc/UTC") |> DateTime.to_unix(:millisecond),
+         {position, kind, time, serve} <- last_event_at_or_before(timeline(input), ms) do
+      label =
+        "event #{position} (#{kind}#{if serve, do: ", serve #{serve}", else: ""}, #{time_label(kind)} #{time})"
+
+      case ms - time do
+        0 -> "in the cycle of #{label}"
+        gap -> "#{gap} ms after #{label}"
+      end
+    else
+      :before_first_event -> "before the first event (seed or clock-dated)"
+      _ -> "at a date that is not attributable"
+    end
+  end
+
+  defp time_label("clock"), do: "value"
+  defp time_label("stream"), do: "time"
+  defp time_label(_kind), do: "timestamp"
+
+  defp last_event_at_or_before(timeline, ms) do
+    timeline
+    |> Enum.filter(fn {_position, _kind, time, _serve} -> time <= ms end)
+    |> List.last() || :before_first_event
+  end
+
+  # Timed events of the scenario in list order: {position, kind, time,
+  # serve index}. API events carry their index from index_events/1;
+  # asleep, offline, error, call and control events have no time.
+  defp timeline(%{"events" => raw_events}) do
+    {_serve, entries} =
+      raw_events
+      |> Enum.with_index(1)
+      |> Enum.reduce({0, []}, fn {event, position}, {serve, acc} ->
+        case event do
+          %{"vehicle" => raw} ->
+            serve = serve + 1
+
+            case get_in(raw, ["drive_state", "timestamp"]) do
+              ts when is_integer(ts) -> {serve, [{position, "vehicle", ts, serve} | acc]}
+              _ -> {serve, acc}
+            end
+
+          %{"error" => _} ->
+            {serve + 1, acc}
+
+          %{"clock" => ms} when is_integer(ms) ->
+            {serve, [{position, "clock", ms, nil} | acc]}
+
+          %{"stream" => value} when is_binary(value) ->
+            %TeslaApi.Stream.Data{time: %DateTime{} = time} = TeslaApi.Stream.decode_frame!(value)
+            {serve, [{position, "stream", DateTime.to_unix(time, :millisecond), nil} | acc]}
+
+          _ ->
+            {serve, acc}
+        end
+      end)
+
+    Enum.reverse(entries)
   end
 
   def diff(expected, actual) do

--- a/test/support/mocks/api.ex
+++ b/test/support/mocks/api.ex
@@ -106,7 +106,7 @@ defmodule ApiMock do
   def handle_call({action, id}, _from, %State{events: [event | _events]} = state)
       when action in [:get_vehicle, :get_vehicle_with_state] do
     result = exec(event, action)
-    state = mark_served(state, event)
+    %State{} = state = mark_served(state, event)
 
     case {action, snapshot?(event), result} do
       {:get_vehicle, true, {:ok, %TeslaApi.Vehicle{state: "online"}}} ->
@@ -157,9 +157,12 @@ defmodule ApiMock do
   # Characterization events arrive as {:indexed, index, closure}: the index
   # is the collector's serve index, so a snapshot's probe and strict serve
   # carry the same one.
-  defp mark_served(state, {:snapshot, event}), do: mark_served(state, event)
-  defp mark_served(state, {:indexed, index, _fun}), do: %State{state | last_served: index}
-  defp mark_served(state, _event), do: state
+  defp mark_served(%State{} = state, {:snapshot, event}), do: mark_served(state, event)
+
+  defp mark_served(%State{} = state, {:indexed, index, _fun}),
+    do: %State{state | last_served: index}
+
+  defp mark_served(%State{} = state, _event), do: state
 
   defp deliver_stream(_payload, %State{vehicle: nil}) do
     raise "stream deliveries require the :vehicle option on ApiMock — " <>
@@ -238,7 +241,7 @@ defmodule ApiMock do
         # counts like any other (index, barrier, vacuity).
         result = exec(event, action)
         GenServer.reply(from, result)
-        state = mark_served(state, event)
+        %State{} = state = mark_served(state, event)
         await_call_outcome(proxy, call, advance_event(state), result)
 
       {^ref, :ok} ->

--- a/test/teslamate/characterization_test.exs
+++ b/test/teslamate/characterization_test.exs
@@ -432,6 +432,65 @@ defmodule TeslaMate.CharacterizationTest do
              Characterization.diff(Map.delete(golden, "interactions"), golden)
   end
 
+  @tag :tmp_dir
+  test "a mismatch on a dated row names the event whose cycle created it", %{tmp_dir: tmp} do
+    t0 = 1_704_067_200_000
+
+    scenario =
+      base_scenario("attribution probe", [
+        Map.put(park_event(t0), "snapshot", true),
+        drive_event(t0 + 10_000, 52.516, 10_000.2),
+        drive_event(t0 + 20_000, 52.52, 10_001.5),
+        put_in(park_event(t0 + 30_000), ["vehicle", "vehicle_state", "odometer"], 10_001.6),
+        %{"clock" => t0 + 60_000},
+        %{"vehicle" => %{"state" => "asleep"}}
+      ])
+      |> Map.put("await", %{"state" => "asleep"})
+
+    pair = tmp_pair(tmp, "attribution", scenario)
+    Characterization.record_pair(pair)
+    golden = pair.golden_path |> File.read!() |> Jason.decode!()
+    [_park, first_drive_position | _] = golden["database"]["positions"]
+    assert first_drive_position["date"] == "2024-01-01T00:00:10.000000"
+
+    # A non-date column of the row dated by the second payload: named exactly.
+    tampered = put_in(golden, ["database", "positions", Access.at(1), "speed"], 999)
+    message = Characterization.mismatch_message("attribution", tampered, golden, scenario)
+    assert message =~ "first divergence at database.positions.[1].speed"
+
+    assert message =~
+             "created in the cycle of event 2 (vehicle, serve 2, timestamp 1704067210000)"
+
+    # An end_date divergence names the closing event as well as the creating one.
+    tampered =
+      put_in(
+        golden,
+        ["database", "drives", Access.at(0), "end_date"],
+        "1999-01-01T00:00:00.000000"
+      )
+
+    message = Characterization.mismatch_message("attribution", tampered, golden, scenario)
+    assert message =~ "row dated 2024-01-01T00:00:10.000000 — created in the cycle of event 2"
+
+    assert message =~
+             "row closed 1999-01-01T00:00:00.000000 — closed before the first event (seed or clock-dated)"
+
+    # With the golden's end_date masked, the capture's date is attributed.
+    tampered = put_in(golden, ["database", "drives", Access.at(0), "end_date"], "<volatile>")
+    tampered = put_in(tampered, ["database", "drives", Access.at(0), "distance"], 0)
+    message = Characterization.mismatch_message("attribution", tampered, golden, scenario)
+    assert message =~ "row dated 2024-01-01T00:00:10.000000 — created in the cycle of event 2"
+
+    # The asleep row is clock-dated after the clock event: the distance, not a tick count.
+    [_online, asleep] = golden["database"]["states"]
+
+    assert Characterization.attribute_date(asleep["start_date"], scenario) ==
+             "2 ms after event 5 (clock, value 1704067260000)"
+
+    assert Characterization.attribute_date("2000-01-01T00:00:00.000000", scenario) ==
+             "before the first event (seed or clock-dated)"
+  end
+
   defp base_scenario(description, events) do
     %{
       "description" => description,
@@ -515,6 +574,19 @@ defmodule TeslaMate.CharacterizationTest do
         }
       }
     }
+  end
+
+  defp drive_event(ts, latitude, odometer) do
+    park_event(ts)
+    |> update_in(["vehicle", "drive_state"], fn drive ->
+      Map.merge(drive, %{
+        "latitude" => latitude,
+        "shift_state" => "D",
+        "speed" => 60,
+        "power" => 15
+      })
+    end)
+    |> put_in(["vehicle", "vehicle_state", "odometer"], odometer)
   end
 
   for pair <- Characterization.pairs() do


### PR DESCRIPTION
## What this adds

When a comparison fails on a row that carries a date, the mismatch message now names the scenario event whose cycle created that row. Nothing else changes: undated paths (MQTT lists, counters, calls) read as before, interactions carry their serve index since #5704, goldens are untouched.

`compare/1` hands the scenario to `assert_equivalent/4`; `mismatch_message/4` builds the message and, for paths of the form `database.<table>.[i].<column>`, appends the attribution of the row's `date` / `start_date` — the golden's value, or the capture's when the golden's is masked or the row exists only there. An `end_date` divergence adds a second line for the closing date.

Attribution rule (`attribute_date/2`), derived from the replay clock: every serve raises the clock to at least its payload time and clock events set it explicitly, so a row dated `d` was created in the cycle of the last timed event at or before `d`. The timeline holds `vehicle` events with a `drive_state.timestamp` (with their serve index from `index_events/1`), `clock` values and `stream` frame times, in list order. An exact match reads `created in the cycle of event 4 (vehicle, serve 4, timestamp …)`; a clock-dated row reads `2 ms after event 5 (clock, value …)` — the distance, not a tick count, because `Clock.serve/1` runs per closure execution (snapshot twice, terminal repeats, error fallback) and ticks identify no event. Dates before the first timed event read `before the first event (seed or clock-dated)`.

```
characterization mismatch in attribution
first divergence at database.drives.[0].end_date
expected: "1999-01-01T00:00:00.000000"
actual:   "2024-01-01T00:00:30.000000"
row dated 2024-01-01T00:00:10.000000 — created in the cycle of event 2 (vehicle, serve 2, timestamp 1704067210000)
row closed 1999-01-01T00:00:00.000000 — closed before the first event (seed or clock-dated)
```

## Enforced invariants

- A mismatch on a dated row names the scenario event whose cycle created it — last timed event at or before the row's date, distance in milliseconds between events, closing event on an `end_date` divergence, seed or clock-dated rows before the first event called out (`mismatch_message/4`, `attribute_date/2`).
- Probe (`characterization_test.exs`): a recorded drive scenario with tampered golden rows — exact attribution to event 2, `end_date` attribution with the golden's date and with the capture's date when the golden's is masked, the clock-dated asleep row as a distance after the clock event, a date before the scenario.

## Verification

- Probe: 1 passed. `mix test test/teslamate/characterization_test.exs test/teslamate/characterization_harness_test.exs` without record mode: 168 passed.
- Full suite without record mode: 694 passed.
- `mix format --check-formatted` on the two changed test files: clean.
- No golden changed.

## Workarounds, deviations & open questions

- **Golden date first.** When the diverging column is the date itself, the golden's date is attributed (as specified); the probe shows the alternative path through a masked golden date.
- **Asleep row two ticks after the clock event.** From `:online` the asleep terminal routes through `:start`, so the row is written on its second serve: the message reads `2 ms after event 5`, the case the distance wording exists for.
- Also fixes the two struct-update warnings from #5704 in `mark_served/2`: the clauses match `%State{}`, and both call sites bind the result as `%State{} = state`, since the type checker loses the struct through the return value.
- Open questions: none.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Fable 5.1 low) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)