### PR TITLE
fix(web): return to the Grafana dashboard from Back buttons and detect the Grafana URL with origin-only referrers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Under the hood, this release adds a self-verifying black-box characterization suite: recorded API sequences replay through the real vehicle state machine, and everything that leaves the system — database rows, MQTT messages, and the vehicle's interactions with the streaming API and its supervisor — is pinned against goldens. All existing vehicle scenarios are converted (120 fixtures).
 The work already paid off three times: it exposed a crash in the update-cancel path (#5656), a crash loop after an offline period when the car reports an outdated timestamp (#5684), and the published state start time jumping backwards after charging, updating or driving (#5693) — all fixed in this release — and it pinned a data-quality quirk for a later fix (#5699: a charge sample without charger power is stored as 0 kW).
 
+The geo-fence links in the Grafana dashboards now open in the same tab, so the Back button returns to the dashboard and the Grafana URL is detected automatically again (#5709).
+
 **Note for Home Assistant MQTT discovery users:** TeslaMate no longer re-runs the discovery migration on every restart, which briefly removed and recreated entities (#5667). Instead it clears the former per-entity topics and republishes the device config; Home Assistant logs one harmless "conflicting MQTT discovery message" warning per legacy topic after each restart, entities are untouched.
 Upgrading directly from 4.1.x no longer preserves entity registry customizations — see the [docs](https://docs.teslamate.org/docs/integrations/home_assistant#mqtt-discovery-automatic-configuration) (#5685).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Upgrading directly from 4.1.x no longer preserves entity registry customizations
 - fix(vehicle): keep the published state start time from jumping backwards after charging, updating or driving (#5706 - @JakobLichterfeld)
 - fix(web): pin the size of Leaflet's SVG overlay so the vehicle arrow and geofence circle stay on the map at any Safari page zoom (#5666 - @JakobLichterfeld)
 - fix(grafana): open the TeslaMate header link in a new tab so it works when Grafana and TeslaMate share an origin (#5626 - @misenhower)
+- fix(web): make the Back button return to the Grafana dashboard and detect the Grafana URL despite origin-only referrers (#5709 - @JakobLichterfeld)
 
 #### Build, CI, internal
 

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -33,6 +33,20 @@ export const Dropdown = {
   },
 };
 
+// Navigates back in the browser history (e.g. to the Grafana dashboard the
+// page was opened from) and falls back to the link's href if there is no
+// history, e.g. when the page was opened in a new tab.
+export const HistoryBack = {
+  mounted() {
+    this.el.addEventListener("click", (e) => {
+      if (window.history.length > 1) {
+        e.preventDefault();
+        window.history.back();
+      }
+    });
+  },
+};
+
 export const LocalTime = {
   mounted() {
     this.el.innerText = toLocalTime(this.el.dataset.date);

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -35,10 +35,14 @@ export const Dropdown = {
 
 // Navigates back in the browser history (e.g. to the Grafana dashboard the
 // page was opened from) and falls back to the link's href if there is no
-// history, e.g. when the page was opened in a new tab.
+// history, e.g. when the page was opened in a new tab. Note that the history
+// entry is not necessarily where the href points to: it is plain browser
+// "Back" semantics, whatever the previous page in this tab was.
 export const HistoryBack = {
   mounted() {
     this.el.addEventListener("click", (e) => {
+      if (e.ctrlKey || e.shiftKey || e.metaKey || e.button === 1) return;
+
       if (window.history.length > 1) {
         e.preventDefault();
         window.history.back();

--- a/grafana/dashboards/charges.json
+++ b/grafana/dashboards/charges.json
@@ -730,7 +730,7 @@
                 "id": "links",
                 "value": [
                   {
-                    "targetBlank": true,
+                    "targetBlank": false,
                     "title": "Create or edit geo-fence",
                     "url": "${base_url:raw}/geo-fences/${__data.fields.path}"
                   }

--- a/grafana/dashboards/drives.json
+++ b/grafana/dashboards/drives.json
@@ -729,7 +729,7 @@
                 "id": "links",
                 "value": [
                   {
-                    "targetBlank": true,
+                    "targetBlank": false,
                     "title": "Create or edit geo-fence",
                     "url": "${base_url:raw}/geo-fences/${__data.fields.start_path}"
                   }
@@ -755,7 +755,7 @@
                 "id": "links",
                 "value": [
                   {
-                    "targetBlank": true,
+                    "targetBlank": false,
                     "title": "Create or edit geo-fence",
                     "url": "${base_url:raw}/geo-fences/${__data.fields.end_path}"
                   }

--- a/grafana/dashboards/locations.json
+++ b/grafana/dashboards/locations.json
@@ -763,7 +763,7 @@
                 "id": "links",
                 "value": [
                   {
-                    "targetBlank": true,
+                    "targetBlank": false,
                     "title": "",
                     "url": "${base_url:raw}/geo-fences/${__data.fields.path}"
                   }
@@ -1016,7 +1016,7 @@
                 "id": "links",
                 "value": [
                   {
-                    "targetBlank": true,
+                    "targetBlank": false,
                     "title": "",
                     "url": "${base_url:raw}/geo-fences/${__data.fields.id.numeric:raw}/edit"
                   }

--- a/grafana/dashboards/timeline.json
+++ b/grafana/dashboards/timeline.json
@@ -243,7 +243,7 @@
                 "id": "links",
                 "value": [
                   {
-                    "targetBlank": true,
+                    "targetBlank": false,
                     "title": "Create or edit geo-fence",
                     "url": "${base_url:raw}/geo-fences/${__data.fields.start_path:raw}"
                   }
@@ -269,7 +269,7 @@
                 "id": "links",
                 "value": [
                   {
-                    "targetBlank": true,
+                    "targetBlank": false,
                     "title": "Create or edit geo-fence",
                     "url": "${base_url:raw}/geo-fences/${__data.fields.end_path:raw}"
                   }

--- a/grafana/dashboards/trip.json
+++ b/grafana/dashboards/trip.json
@@ -1639,7 +1639,7 @@
                 "id": "links",
                 "value": [
                   {
-                    "targetBlank": true,
+                    "targetBlank": false,
                     "title": "Create or edit geo-fence",
                     "url": "${base_url:raw}/geo-fences/${__data.fields.start_path}"
                   }
@@ -1665,7 +1665,7 @@
                 "id": "links",
                 "value": [
                   {
-                    "targetBlank": true,
+                    "targetBlank": false,
                     "title": "Create or edit geo-fence",
                     "url": "${base_url:raw}/geo-fences/${__data.fields.end_path}"
                   }
@@ -2092,7 +2092,7 @@
                 "id": "links",
                 "value": [
                   {
-                    "targetBlank": true,
+                    "targetBlank": false,
                     "title": "Create or edit geo-fence",
                     "url": "${base_url:raw}/geo-fences/${__data.fields.path}"
                   }

--- a/lib/teslamate_web/live/charge_live/cost.html.heex
+++ b/lib/teslamate_web/live/charge_live/cost.html.heex
@@ -162,7 +162,9 @@
     <div class="field-body">
       <div class="field is-grouped">
         <div class="control">
-          {link(gettext("Back"), to: @redirect_to, class: "button")}
+          <a id="back-button" href={@redirect_to} class="button" phx-hook="HistoryBack">
+            {gettext("Back")}
+          </a>
         </div>
         <div class="control" style="min-width: 300px;">
           {submit(if(is_nil(@notification), do: gettext("Save"), else: @notification.message),

--- a/lib/teslamate_web/live/geofence_live/form.ex
+++ b/lib/teslamate_web/live/geofence_live/form.ex
@@ -183,18 +183,21 @@ defmodule TeslaMateWeb.GeoFenceLive.Form do
          {:ok, settings} <- Settings.update_global_settings(settings, %{grafana_url: url}) do
       {:ok, settings}
     else
-      {:error, reason} -> Logger.warning("Updating settings failed: #{inspect(reason)}")
-      _ -> {:ok, settings}
+      {:error, reason} ->
+        Logger.warning("Updating settings failed: #{inspect(reason)}")
+        {:ok, settings}
+
+      _ ->
+        {:ok, settings}
     end
   end
 
   defp grafana_base_path(path) when path in [nil, "", "/"], do: {:ok, nil}
 
   defp grafana_base_path(path) do
-    case path |> String.split("/") |> Enum.reverse() do
-      [_slug, _uid, "d" | base] -> {:ok, base |> Enum.reverse() |> Enum.join("/")}
-      [_uid, "d" | base] -> {:ok, base |> Enum.reverse() |> Enum.join("/")}
-      _ -> :error
+    case Regex.run(~r{^(.*)/d/[^/]+}, path) do
+      [_, base] -> {:ok, base}
+      nil -> :error
     end
   end
 

--- a/lib/teslamate_web/live/geofence_live/form.ex
+++ b/lib/teslamate_web/live/geofence_live/form.ex
@@ -167,17 +167,34 @@ defmodule TeslaMateWeb.GeoFenceLive.Form do
     end
   end
 
+  # Derives the Grafana URL from the referrer of the dashboard link. Browsers
+  # strip cross-origin referrers down to the origin by default
+  # (`strict-origin-when-cross-origin`), so the referrer is either the full
+  # dashboard URL (same-origin setups) or just the Grafana origin. In the
+  # latter case a Grafana sub-path cannot be detected and has to be set
+  # manually in the settings.
   defp set_grafana_url(settings, socket) do
     with nil <- settings.grafana_url,
          %{"referrer" => referrer} when is_binary(referrer) <- get_connect_params(socket),
-         %URI{path: path} = url when is_binary(path) <- URI.parse(referrer),
-         [_, _, _ | path] <- path |> String.split("/") |> Enum.reverse(),
-         url = %URI{url | path: Enum.join([nil | path], "/"), query: nil} |> URI.to_string(),
+         %URI{scheme: scheme, host: host} = uri
+         when is_binary(scheme) and is_binary(host) <- URI.parse(referrer),
+         {:ok, path} <- grafana_base_path(uri.path),
+         url = URI.to_string(%URI{uri | path: path, query: nil, fragment: nil}),
          {:ok, settings} <- Settings.update_global_settings(settings, %{grafana_url: url}) do
       {:ok, settings}
     else
       {:error, reason} -> Logger.warning("Updating settings failed: #{inspect(reason)}")
       _ -> {:ok, settings}
+    end
+  end
+
+  defp grafana_base_path(path) when path in [nil, "", "/"], do: {:ok, nil}
+
+  defp grafana_base_path(path) do
+    case path |> String.split("/") |> Enum.reverse() do
+      [_slug, _uid, "d" | base] -> {:ok, base |> Enum.reverse() |> Enum.join("/")}
+      [_uid, "d" | base] -> {:ok, base |> Enum.reverse() |> Enum.join("/")}
+      _ -> :error
     end
   end
 

--- a/lib/teslamate_web/live/geofence_live/form.html.heex
+++ b/lib/teslamate_web/live/geofence_live/form.html.heex
@@ -127,9 +127,14 @@
     <div class="field-body">
       <div class="field is-grouped">
         <div class="control">
-          <.link navigate={Routes.live_path(@socket, GeoFenceLive.Index)} class="button">
+          <a
+            id="back-button"
+            href={Routes.live_path(@socket, GeoFenceLive.Index)}
+            class="button"
+            phx-hook="HistoryBack"
+          >
             {gettext("Back")}
-          </.link>
+          </a>
         </div>
         <div class="control">
           {submit(gettext("Save"),

--- a/priv/gettext/ca/LC_MESSAGES/default.po
+++ b/priv/gettext/ca/LC_MESSAGES/default.po
@@ -132,7 +132,7 @@ msgstr "Unitats"
 msgid "Back"
 msgstr "Enrere"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "S'ha creat la geotanca \"%{name}\""
@@ -371,7 +371,7 @@ msgstr "Activat"
 msgid "Sleep Mode"
 msgstr "Mode de repòs"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "S'ha actualitzat la geotanca \"%{name}\""

--- a/priv/gettext/ca/LC_MESSAGES/default.po
+++ b/priv/gettext/ca/LC_MESSAGES/default.po
@@ -126,13 +126,13 @@ msgstr "Temperatura"
 msgid "Units"
 msgstr "Unitats"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Enrere"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "S'ha creat la geotanca \"%{name}\""
@@ -169,14 +169,14 @@ msgstr "Posició"
 msgid "Radius"
 msgstr "Radi"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Desa"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -371,7 +371,7 @@ msgstr "Activat"
 msgid "Sleep Mode"
 msgstr "Mode de repòs"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "S'ha actualitzat la geotanca \"%{name}\""
@@ -503,24 +503,24 @@ msgstr "Per kWh"
 msgid "Total"
 msgstr "Total"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "Hi ha <strong>%{n} sessió de càrrega</strong> en aquesta localització per la qual encara no s'ha establert un preu de cost."
 msgstr[1] "Hi ha <strong>%{n} sessions de càrrega</strong> en aquesta localització per les quals encara no s'ha establert un preu de cost."
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "Afegeix despeses retroactivament"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "Despeses de càrrega"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Continua"

--- a/priv/gettext/da/LC_MESSAGES/default.po
+++ b/priv/gettext/da/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "Temperatur"
 msgid "Units"
 msgstr "Enheder"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Tilbage"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Geografisk afgrænsning \"%{name}\" oprettet"
@@ -170,14 +170,14 @@ msgstr "Position"
 msgid "Radius"
 msgstr "Radius"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Gem"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "Aktiveret"
 msgid "Sleep Mode"
 msgstr "Dvaletilstand"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Geografisk afgrænsning \"%{name}\" opdateret"
@@ -502,24 +502,24 @@ msgstr "Per kWh"
 msgid "Total"
 msgstr "Total"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "Der er <strong>%{n} opladning</strong> på dette sted der ikke er angivet en pris for endnu."
 msgstr[1] "Der er <strong>%{n} opladninger</strong> på dette sted der ikke er angivet en pris for endnu."
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "Tilføj pris med tilbagevirkning"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "Udgifter til opladning"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Fortsæt"

--- a/priv/gettext/da/LC_MESSAGES/default.po
+++ b/priv/gettext/da/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "Enheder"
 msgid "Back"
 msgstr "Tilbage"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Geografisk afgrænsning \"%{name}\" oprettet"
@@ -370,7 +370,7 @@ msgstr "Aktiveret"
 msgid "Sleep Mode"
 msgstr "Dvaletilstand"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Geografisk afgrænsning \"%{name}\" opdateret"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "Einheiten"
 msgid "Back"
 msgstr "Zurück"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Geo-Fence \"%{name}\" erstellt"
@@ -370,7 +370,7 @@ msgstr "Aktiviert"
 msgid "Sleep Mode"
 msgstr "Schlafmodus"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Geo-Fence \"%{name}\" aktualisiert"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "Temperatur"
 msgid "Units"
 msgstr "Einheiten"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Zurück"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Geo-Fence \"%{name}\" erstellt"
@@ -170,14 +170,14 @@ msgstr ""
 msgid "Radius"
 msgstr ""
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Speichern"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "Aktiviert"
 msgid "Sleep Mode"
 msgstr "Schlafmodus"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Geo-Fence \"%{name}\" aktualisiert"
@@ -502,24 +502,24 @@ msgstr "Pro kWh"
 msgid "Total"
 msgstr "Gesamt"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "An diesem Standort gibt es <strong>%{n} Ladevorgang</strong>, für den noch keine Kosten hinzugefügt wurden."
 msgstr[1] "An diesem Standort gibt es <strong>%{n} Ladevorgänge</strong>, für die noch keine Kosten hinzugefügt wurden."
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "Kosten rückwirkend hinzufügen"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "Ladekosten"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Weiter"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -133,7 +133,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr ""
@@ -370,7 +370,7 @@ msgstr ""
 msgid "Sleep Mode"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -127,13 +127,13 @@ msgstr ""
 msgid "Units"
 msgstr ""
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr ""
@@ -170,14 +170,14 @@ msgstr ""
 msgid "Radius"
 msgstr ""
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr ""
 msgid "Sleep Mode"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr ""
@@ -502,24 +502,24 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr ""
@@ -370,7 +370,7 @@ msgstr ""
 msgid "Sleep Mode"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr ""
 msgid "Units"
 msgstr ""
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr ""
@@ -170,14 +170,14 @@ msgstr ""
 msgid "Radius"
 msgstr ""
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr ""
 msgid "Sleep Mode"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr ""
@@ -502,24 +502,24 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr ""
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "Temperatura"
 msgid "Units"
 msgstr "Unidades"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Atrás"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Creada la geovalla \"%{name}\""
@@ -170,14 +170,14 @@ msgstr "Posición"
 msgid "Radius"
 msgstr "Radio"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Guardar"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "Activado"
 msgid "Sleep Mode"
 msgstr "Modo de reposo"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Actualizada la geovalla \"%{name}\""
@@ -502,24 +502,24 @@ msgstr "Por kWh"
 msgid "Total"
 msgstr "Total"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "Hay <strong>%{n} sesión de carga</strong> en esta localización para la que aún no se ha añadido un coste."
 msgstr[1] "Hay <strong>%{n} sesiones de carga</strong> en esta localización para las que aún no se ha añadido un coste."
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "Añadir costes retroactivamente"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "Costes de Carga"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Continuar"

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "Unidades"
 msgid "Back"
 msgstr "Atrás"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Creada la geovalla \"%{name}\""
@@ -370,7 +370,7 @@ msgstr "Activado"
 msgid "Sleep Mode"
 msgstr "Modo de reposo"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Actualizada la geovalla \"%{name}\""

--- a/priv/gettext/fi/LC_MESSAGES/default.po
+++ b/priv/gettext/fi/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "Lämpötila"
 msgid "Units"
 msgstr "Mittayksiköt"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Takaisin"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Georajaus \"%{name}\" luotu"
@@ -170,14 +170,14 @@ msgstr "Sijainti"
 msgid "Radius"
 msgstr "Säde"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Tallenna"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "Käytössä"
 msgid "Sleep Mode"
 msgstr "Lepotila"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Georajaus \"%{name}\" päivitetty"
@@ -502,24 +502,24 @@ msgstr "Per kWh"
 msgid "Total"
 msgstr "Yhteensä"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "Lataustapahtumissa on <strong>yksi lataus</strong> johon ei ole lisätty kustannuksia."
 msgstr[1] "Lataustapahtumissa on <strong>%{n} latausta</strong> joihin ei ole lisätty kustannuksia."
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "Lisää kustannuksia jälkikäteen"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "Latauskustannukset"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Jatka"

--- a/priv/gettext/fi/LC_MESSAGES/default.po
+++ b/priv/gettext/fi/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "Mittayksiköt"
 msgid "Back"
 msgstr "Takaisin"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Georajaus \"%{name}\" luotu"
@@ -370,7 +370,7 @@ msgstr "Käytössä"
 msgid "Sleep Mode"
 msgstr "Lepotila"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Georajaus \"%{name}\" päivitetty"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "Unités"
 msgid "Back"
 msgstr "Retour"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Géorepérage \"%{name}\" créé"
@@ -370,7 +370,7 @@ msgstr "Activé"
 msgid "Sleep Mode"
 msgstr "Mode veille"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Géo-repérage \"%{name}\" mis à jour"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "Température"
 msgid "Units"
 msgstr "Unités"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Retour"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Géorepérage \"%{name}\" créé"
@@ -170,14 +170,14 @@ msgstr "Position"
 msgid "Radius"
 msgstr "Rayon"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Enregistrer"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "Activé"
 msgid "Sleep Mode"
 msgstr "Mode veille"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Géo-repérage \"%{name}\" mis à jour"
@@ -502,24 +502,24 @@ msgstr "Par kWh"
 msgid "Total"
 msgstr "Total"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "Il existe <strong>%{n} session de charge </strong> à cet endroit pour laquelle aucun coût n'a encore été ajouté."
 msgstr[1] "Il existe <strong>%{n} sessions de charge </strong> à cet endroit pour lesquelles aucun coût n'a encore été ajouté."
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "Ajouter les coûts rétroactivement"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "Coût de Charge"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Continuer"

--- a/priv/gettext/hu/LC_MESSAGES/default.po
+++ b/priv/gettext/hu/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "Hőmérséklet"
 msgid "Units"
 msgstr "Mértékegységek"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Vissza"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "A(z) \"%{name}\" geokerítés létrehozva"
@@ -170,14 +170,14 @@ msgstr "Pozíció"
 msgid "Radius"
 msgstr "Sugár"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Mentés"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "Engedélyezve"
 msgid "Sleep Mode"
 msgstr "Alvó mód"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "A(z) \"%{name}\" geokerítés frissítve"
@@ -502,24 +502,24 @@ msgstr "kWh-nként"
 msgid "Total"
 msgstr "Összesen"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "Ezen a helyen <strong>%{n} töltési munkamenet</strong> van, amelyhez még nincs költség megadva."
 msgstr[1] "Ezen a helyen <strong>%{n} töltési munkamenet</strong> van, amelyhez még nincs költség megadva."
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "Költségek utólagos hozzáadása"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "Töltési költségek"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Folytatás"

--- a/priv/gettext/hu/LC_MESSAGES/default.po
+++ b/priv/gettext/hu/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "Mértékegységek"
 msgid "Back"
 msgstr "Vissza"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "A(z) \"%{name}\" geokerítés létrehozva"
@@ -370,7 +370,7 @@ msgstr "Engedélyezve"
 msgid "Sleep Mode"
 msgstr "Alvó mód"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "A(z) \"%{name}\" geokerítés frissítve"

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "Temperatura"
 msgid "Units"
 msgstr "Unità"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Indietro"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Geo-Fence \"%{name}\" creata"
@@ -170,14 +170,14 @@ msgstr "Posizione"
 msgid "Radius"
 msgstr "Raggio"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Salva"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "Attivato"
 msgid "Sleep Mode"
 msgstr "Modalità sospensione"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Geo-fence \"%{name}\" aggiornata"
@@ -502,24 +502,24 @@ msgstr "Per kWh"
 msgid "Total"
 msgstr "Totale"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "C'è <strong>%{n} sessione di addebito</strong> in questa posizione per la quale non è stato ancora aggiunto alcun costo."
 msgstr[1] "Ci sono <strong>%{n} sessioni di addebito</strong> in questa posizione per le quali non è stato ancora aggiunto alcun costo."
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "Aggiungere i costi retroattivamente"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "Costo di ricarica"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Continuare"

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "Unità"
 msgid "Back"
 msgstr "Indietro"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Geo-Fence \"%{name}\" creata"
@@ -370,7 +370,7 @@ msgstr "Attivato"
 msgid "Sleep Mode"
 msgstr "Modalità sospensione"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Geo-fence \"%{name}\" aggiornata"

--- a/priv/gettext/ja/LC_MESSAGES/default.po
+++ b/priv/gettext/ja/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "温度"
 msgid "Units"
 msgstr "単位"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "戻る"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "ジオフェンス \"%{name}\" が作成されました"
@@ -170,14 +170,14 @@ msgstr "位置"
 msgid "Radius"
 msgstr "半径"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "保存"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "有効"
 msgid "Sleep Mode"
 msgstr "スリープモード"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "ジオフェンス \"%{name}\" がアップデートされました"
@@ -502,24 +502,24 @@ msgstr "kWh毎"
 msgid "Total"
 msgstr "合計"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "この場所には、<strong>まだ費用が追加されていない%{n}つの課金セッション</strong>があります。"
 msgstr[1] "この場所には、<strong>まだ費用が追加されていない%{n}つの課金セッション</strong>があります。"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "さかのぼってにコストを追加する"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "充電費用"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "続ける"

--- a/priv/gettext/ja/LC_MESSAGES/default.po
+++ b/priv/gettext/ja/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "単位"
 msgid "Back"
 msgstr "戻る"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "ジオフェンス \"%{name}\" が作成されました"
@@ -370,7 +370,7 @@ msgstr "有効"
 msgid "Sleep Mode"
 msgstr "スリープモード"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "ジオフェンス \"%{name}\" がアップデートされました"

--- a/priv/gettext/ko/LC_MESSAGES/default.po
+++ b/priv/gettext/ko/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "단위"
 msgid "Back"
 msgstr "뒤로"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "지오펜스 \"%{name}\" 가 생성되었습니다."
@@ -370,7 +370,7 @@ msgstr "활성화"
 msgid "Sleep Mode"
 msgstr "절전모드"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "지오펜스 \"%{name}\" 가 업데이트 되었습니다."

--- a/priv/gettext/ko/LC_MESSAGES/default.po
+++ b/priv/gettext/ko/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "온도"
 msgid "Units"
 msgstr "단위"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "뒤로"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "지오펜스 \"%{name}\" 가 생성되었습니다."
@@ -170,14 +170,14 @@ msgstr "위치"
 msgid "Radius"
 msgstr "반경"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "저장"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "활성화"
 msgid "Sleep Mode"
 msgstr "절전모드"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "지오펜스 \"%{name}\" 가 업데이트 되었습니다."
@@ -502,24 +502,24 @@ msgstr "kWh 당"
 msgid "Total"
 msgstr "총합"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "이 위치에는 아직 비용이 추가되지 않은 <strong>%{n} 충전 세션</strong>이 있습니다."
 msgstr[1] "이 위치에는 아직 비용이 추가되지 않은 <strong>%{n} 충전 세션들</strong>이 있습니다."
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "과거 요금 추가"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "충전요금"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "계속"

--- a/priv/gettext/nb/LC_MESSAGES/default.po
+++ b/priv/gettext/nb/LC_MESSAGES/default.po
@@ -134,7 +134,7 @@ msgstr "Enheter"
 msgid "Back"
 msgstr "Tilbake"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Geo-lokasjon \"%{name}\" opprettet"
@@ -371,7 +371,7 @@ msgstr "Aktivert"
 msgid "Sleep Mode"
 msgstr "Dvalemodus"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Geo-lokasjon \"%{name}\" oppdatert"

--- a/priv/gettext/nb/LC_MESSAGES/default.po
+++ b/priv/gettext/nb/LC_MESSAGES/default.po
@@ -128,13 +128,13 @@ msgstr "Temperatur"
 msgid "Units"
 msgstr "Enheter"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Tilbake"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Geo-lokasjon \"%{name}\" opprettet"
@@ -171,14 +171,14 @@ msgstr "Posisjon"
 msgid "Radius"
 msgstr "Radius"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Lagre"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -371,7 +371,7 @@ msgstr "Aktivert"
 msgid "Sleep Mode"
 msgstr "Dvalemodus"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Geo-lokasjon \"%{name}\" oppdatert"
@@ -503,24 +503,24 @@ msgstr "Pr kWh"
 msgid "Total"
 msgstr "Total"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "Det er <strong>%{n} ladeøkt</strong> på denne lokasjonen der pris ikke er definert."
 msgstr[1] "Det er <strong>%{n} ladeøkter</strong> på denne lokasjonen der priser ikke er definert."
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "Legg til pris med tilbakevirkende kraft"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "Pris på lading"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Fortsett"

--- a/priv/gettext/nl/LC_MESSAGES/default.po
+++ b/priv/gettext/nl/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "Eenheden"
 msgid "Back"
 msgstr "Terug"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Geo-hek \"%{name}\" aangemaakt"
@@ -370,7 +370,7 @@ msgstr "Ingeschakeld"
 msgid "Sleep Mode"
 msgstr "Slaapstand"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Geo-hek \"%{name}\" bijgewerkt"

--- a/priv/gettext/nl/LC_MESSAGES/default.po
+++ b/priv/gettext/nl/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "Temperatuur"
 msgid "Units"
 msgstr "Eenheden"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Terug"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Geo-hek \"%{name}\" aangemaakt"
@@ -170,14 +170,14 @@ msgstr "Positie"
 msgid "Radius"
 msgstr "Straal"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Opslaan"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "Ingeschakeld"
 msgid "Sleep Mode"
 msgstr "Slaapstand"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Geo-hek \"%{name}\" bijgewerkt"
@@ -502,24 +502,24 @@ msgstr "Per kWh"
 msgid "Total"
 msgstr "Totaal"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "Er is <strong>%{n} oplaadsessie</strong> op deze locatie waarvoor nog geen kosten zijn toegevoegd."
 msgstr[1] "Er zijn <strong>%{n} oplaadsessies</strong> op deze locatie waarvoor nog geen kosten zijn toegevoegd."
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "Kosten met terugwerkende kracht toevoegen"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "Laadkosten"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Ga verder"

--- a/priv/gettext/sv/LC_MESSAGES/default.po
+++ b/priv/gettext/sv/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "Temperatur"
 msgid "Units"
 msgstr "Enheter"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Tillbaka"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Geostaket \"%{name}\" skapat"
@@ -170,14 +170,14 @@ msgstr ""
 msgid "Radius"
 msgstr "Radie"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Spara"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "Aktiverad"
 msgid "Sleep Mode"
 msgstr "Viloläge"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Geostaket \"%{name}\" uppdaterad"
@@ -502,24 +502,24 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "Det finns <strong>%{n} laddningssession</strong> på denna position för vilken ingen kostnad har lagts till än."
 msgstr[1] "Det finns <strong>%{n} laddningssessioner</strong> på denna position för vilken inga kostnader har lagts till än."
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "Lägg till kostnader retroaktivt"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "Laddningskostnad"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Fortsätt"

--- a/priv/gettext/sv/LC_MESSAGES/default.po
+++ b/priv/gettext/sv/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "Enheter"
 msgid "Back"
 msgstr "Tillbaka"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Geostaket \"%{name}\" skapat"
@@ -370,7 +370,7 @@ msgstr "Aktiverad"
 msgid "Sleep Mode"
 msgstr "Viloläge"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Geostaket \"%{name}\" uppdaterad"

--- a/priv/gettext/th/LC_MESSAGES/default.po
+++ b/priv/gettext/th/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "อุณหภูมิ"
 msgid "Units"
 msgstr "หน่วย"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "ย้อนกลับ"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "สร้างขอบเขตทางภูมิศาสตร์ \"%{name}\" แล้ว"
@@ -170,14 +170,14 @@ msgstr "ตำแหน่ง"
 msgid "Radius"
 msgstr "รัศมี"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "บันทึก"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "เปิดใช้งานแล้ว"
 msgid "Sleep Mode"
 msgstr "โหมดหลับ"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "อัปเดตขอบเขตทางภูมิศาสตร์ \"%{name}\" แล้ว"
@@ -501,24 +501,24 @@ msgstr "ต่อกิโลวัตต์ชั่วโมง"
 msgid "Total"
 msgstr "ทั้งหมด"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "มีเซสชันการเรียกเก็บเงิน <strong>%{n} ครั้ง</strong> ณ ตำแหน่งนี้ ซึ่งยังไม่มีการเพิ่มค่าใช้จ่าย"
 msgstr[1] "มีเซสชันการเรียกเก็บเงิน <strong>%{n} ครั้ง</strong> ณ ตำแหน่งนี้ ซึ่งยังไม่มีการเพิ่มค่าใช้จ่าย"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "เพิ่มค่าใช้จ่ายย้อนหลัง"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "ค่าใช้จ่ายในการชาร์จ"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "ดำเนินการต่อ"

--- a/priv/gettext/th/LC_MESSAGES/default.po
+++ b/priv/gettext/th/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "หน่วย"
 msgid "Back"
 msgstr "ย้อนกลับ"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "สร้างขอบเขตทางภูมิศาสตร์ \"%{name}\" แล้ว"
@@ -370,7 +370,7 @@ msgstr "เปิดใช้งานแล้ว"
 msgid "Sleep Mode"
 msgstr "โหมดหลับ"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "อัปเดตขอบเขตทางภูมิศาสตร์ \"%{name}\" แล้ว"

--- a/priv/gettext/tr/LC_MESSAGES/default.po
+++ b/priv/gettext/tr/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "Sıcaklık"
 msgid "Units"
 msgstr "Birimler"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Geri"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Coğrafi-sınır \"%{name}\" oluşturuldu"
@@ -170,14 +170,14 @@ msgstr "Konum"
 msgid "Radius"
 msgstr "Yarıçap"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Kaydet"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "Devrede"
 msgid "Sleep Mode"
 msgstr "Uyku Modu"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Coğrafi-sınır \"%{name}\" güncellendi"
@@ -502,24 +502,24 @@ msgstr "kWh başına"
 msgid "Total"
 msgstr "Toplam"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "Bu konumdaki <strong>%{n} şarj işlemi</strong> için henüz bir ücret yansıtılmadı."
 msgstr[1] "Bu konumdaki <strong>%{n} şarj işlemi</strong> için henüz bir ücret yansıtılmadı."
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "Tutarları geçmişe dönük olarak ekle"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "Şarj Tutarları"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Devam Et"

--- a/priv/gettext/tr/LC_MESSAGES/default.po
+++ b/priv/gettext/tr/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "Birimler"
 msgid "Back"
 msgstr "Geri"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Coğrafi-sınır \"%{name}\" oluşturuldu"
@@ -370,7 +370,7 @@ msgstr "Devrede"
 msgid "Sleep Mode"
 msgstr "Uyku Modu"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Coğrafi-sınır \"%{name}\" güncellendi"

--- a/priv/gettext/uk/LC_MESSAGES/default.po
+++ b/priv/gettext/uk/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "Температура"
 msgid "Units"
 msgstr "Одиниці"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Назад"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Гео-позиція \"%{name}\" створена"
@@ -170,14 +170,14 @@ msgstr "Позиція"
 msgid "Radius"
 msgstr "Радіус"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Зберегти"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "Увімкнено"
 msgid "Sleep Mode"
 msgstr "Спить"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Гео-позиція \"%{name}\" оновлена"
@@ -503,7 +503,7 @@ msgstr "за кВт*Г"
 msgid "Total"
 msgstr "Усього"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
@@ -511,17 +511,17 @@ msgstr[0] "Зарядній сесії %{n} у данній гео-позиці�
 msgstr[1] "Зарядним сесіям %{n} у данній гео-позиції ще не задано вартість"
 msgstr[2] "Зарядним сесіям %{n} у данній гео-позиції ще не задано вартість"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "Додати вартість минулим сесіям?"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "Вартість зарядки"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Продовжити"

--- a/priv/gettext/uk/LC_MESSAGES/default.po
+++ b/priv/gettext/uk/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "Одиниці"
 msgid "Back"
 msgstr "Назад"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "Гео-позиція \"%{name}\" створена"
@@ -370,7 +370,7 @@ msgstr "Увімкнено"
 msgid "Sleep Mode"
 msgstr "Спить"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "Гео-позиція \"%{name}\" оновлена"

--- a/priv/gettext/zh_Hans/LC_MESSAGES/default.po
+++ b/priv/gettext/zh_Hans/LC_MESSAGES/default.po
@@ -134,7 +134,7 @@ msgstr "单位"
 msgid "Back"
 msgstr "后退"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "收藏点 \"%{name}\" 已创建"
@@ -371,7 +371,7 @@ msgstr "已启用"
 msgid "Sleep Mode"
 msgstr "休眠模式"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "收藏点 \"%{name}\" 已更新"

--- a/priv/gettext/zh_Hans/LC_MESSAGES/default.po
+++ b/priv/gettext/zh_Hans/LC_MESSAGES/default.po
@@ -128,13 +128,13 @@ msgstr "温度"
 msgid "Units"
 msgstr "单位"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "后退"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "收藏点 \"%{name}\" 已创建"
@@ -171,14 +171,14 @@ msgstr "位置"
 msgid "Radius"
 msgstr "半径"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "保存"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -371,7 +371,7 @@ msgstr "已启用"
 msgid "Sleep Mode"
 msgstr "休眠模式"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "收藏点 \"%{name}\" 已更新"
@@ -503,24 +503,24 @@ msgstr "每度电"
 msgid "Total"
 msgstr "总共"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "此位置有 <strong>%{n} 次</strong> 收费记录，尚未添加任何费用。"
 msgstr[1] "此位置有 <strong>%{n} 次</strong> 收费记录，尚未添加任何费用。"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "过期费用追加"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "充电费用"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "下一步"

--- a/priv/gettext/zh_Hant/LC_MESSAGES/default.po
+++ b/priv/gettext/zh_Hant/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr "單位"
 msgid "Back"
 msgstr "上一步"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:205
+#: lib/teslamate_web/live/geofence_live/form.ex:208
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "收藏地點 \"%{name}\" 已建立"
@@ -370,7 +370,7 @@ msgstr "已啟用"
 msgid "Sleep Mode"
 msgstr "休眠模式"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:206
+#: lib/teslamate_web/live/geofence_live/form.ex:209
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "收藏點 \"%{name}\" 已更新"

--- a/priv/gettext/zh_Hant/LC_MESSAGES/default.po
+++ b/priv/gettext/zh_Hant/LC_MESSAGES/default.po
@@ -127,13 +127,13 @@ msgstr "溫度"
 msgid "Units"
 msgstr "單位"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:165
-#: lib/teslamate_web/live/geofence_live/form.html.heex:131
+#: lib/teslamate_web/live/charge_live/cost.html.heex:166
+#: lib/teslamate_web/live/geofence_live/form.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "上一步"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:188
+#: lib/teslamate_web/live/geofence_live/form.ex:205
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" created"
 msgstr "收藏地點 \"%{name}\" 已建立"
@@ -170,14 +170,14 @@ msgstr "位置"
 msgid "Radius"
 msgstr "半徑"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:168
-#: lib/teslamate_web/live/geofence_live/form.html.heex:135
+#: lib/teslamate_web/live/charge_live/cost.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "儲存"
 
-#: lib/teslamate_web/live/charge_live/cost.html.heex:169
-#: lib/teslamate_web/live/geofence_live/form.html.heex:136
+#: lib/teslamate_web/live/charge_live/cost.html.heex:171
+#: lib/teslamate_web/live/geofence_live/form.html.heex:141
 #: lib/teslamate_web/live/signin_live/index.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -370,7 +370,7 @@ msgstr "已啟用"
 msgid "Sleep Mode"
 msgstr "休眠模式"
 
-#: lib/teslamate_web/live/geofence_live/form.ex:189
+#: lib/teslamate_web/live/geofence_live/form.ex:206
 #, elixir-autogen, elixir-format
 msgid "Geo-fence \"%{name}\" updated"
 msgstr "收藏點 \"%{name}\" 已更新"
@@ -501,23 +501,23 @@ msgstr "每度"
 msgid "Total"
 msgstr "總計"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:170
+#: lib/teslamate_web/live/geofence_live/form.html.heex:175
 #, elixir-format, elixir-autogen
 msgid "There is <strong>%{n} charging session</strong> at this location for which no costs have been added yet."
 msgid_plural "There are <strong>%{n} charging sessions</strong> at this location for which no costs have been added yet."
 msgstr[0] "此地點有 <strong>%{n} 次</strong> 充電紀錄尚未登錄費用。"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:184
+#: lib/teslamate_web/live/geofence_live/form.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Add costs retroactively"
 msgstr "補登費用"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:162
+#: lib/teslamate_web/live/geofence_live/form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Charging Costs"
 msgstr "充電費用"
 
-#: lib/teslamate_web/live/geofence_live/form.html.heex:181
+#: lib/teslamate_web/live/geofence_live/form.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "下一步"

--- a/test/teslamate_web/live/charge_cost_live_test.exs
+++ b/test/teslamate_web/live/charge_cost_live_test.exs
@@ -319,7 +319,7 @@ defmodule TeslaMateWeb.ChargeLive.CostTest do
   end
 
   describe "back button" do
-    test "redirects to the original referrer", %{conn: conn} do
+    test "falls back to the original referrer", %{conn: conn} do
       %ChargingProcess{id: id} = charging_process_fixture(car_fixture())
 
       assert {:ok, _view, html} =
@@ -327,14 +327,12 @@ defmodule TeslaMateWeb.ChargeLive.CostTest do
                |> put_connect_params(%{"referrer" => "http://grafana.example.com/d/xyz/12"})
                |> live("/charge-cost/#{id}")
 
-      assert ["http://grafana.example.com/d/xyz/12"] =
-               html
-               |> Floki.parse_document!()
-               |> Floki.find(".control a")
-               |> Floki.attribute("href")
+      assert [back] = html |> Floki.parse_document!() |> Floki.find("#back-button")
+      assert Floki.attribute(back, "href") == ["http://grafana.example.com/d/xyz/12"]
+      assert Floki.attribute(back, "phx-hook") == ["HistoryBack"]
     end
 
-    test "redirects to home page if there is no referrer", %{conn: conn} do
+    test "falls back to the home page if there is no referrer", %{conn: conn} do
       %ChargingProcess{id: id} = charging_process_fixture(car_fixture())
 
       assert {:ok, _view, html} =
@@ -345,7 +343,7 @@ defmodule TeslaMateWeb.ChargeLive.CostTest do
       assert ["/"] =
                html
                |> Floki.parse_document!()
-               |> Floki.find(".control a")
+               |> Floki.find("#back-button")
                |> Floki.attribute("href")
     end
   end

--- a/test/teslamate_web/live/geofence_live_test.exs
+++ b/test/teslamate_web/live/geofence_live_test.exs
@@ -427,7 +427,7 @@ defmodule TeslaMateWeb.GeoFenceLiveTest do
     test "handles weird referrers", %{conn: conn} do
       assert %GlobalSettings{grafana_url: nil} = Settings.get_global_settings!()
 
-      for referrer <- [nil, "", "example.com", "http://example.com", "http://example.com/"] do
+      for referrer <- [nil, "", "example.com", "http://example.com/foo", "/geo-fences"] do
         assert {:ok, _parent_view, _html} =
                  conn
                  |> put_connect_params(%{"referrer" => referrer})
@@ -435,6 +435,36 @@ defmodule TeslaMateWeb.GeoFenceLiveTest do
 
         assert %GlobalSettings{grafana_url: nil} = Settings.get_global_settings!()
       end
+    end
+
+    test "sets the origin if the browser stripped the referrer path", %{conn: conn} do
+      for {referrer, url} <- [
+            {"http://grafana.example.com", "http://grafana.example.com"},
+            {"http://grafana.example.com:3000/", "http://grafana.example.com:3000"}
+          ] do
+        assert {:ok, _} =
+                 Settings.get_global_settings!()
+                 |> Settings.update_global_settings(%{grafana_url: nil})
+
+        assert {:ok, _parent_view, _html} =
+                 conn
+                 |> put_connect_params(%{"referrer" => referrer})
+                 |> live("/geo-fences/new?lat=0.0&lng=0.0")
+
+        assert %GlobalSettings{grafana_url: ^url} = Settings.get_global_settings!()
+      end
+    end
+
+    test "keeps a nested path", %{conn: conn} do
+      assert %GlobalSettings{grafana_url: nil} = Settings.get_global_settings!()
+
+      assert {:ok, _parent_view, _html} =
+               conn
+               |> put_connect_params(%{"referrer" => "http://example.com/foo/bar/d/xyz?orgId=1"})
+               |> live("/geo-fences/new?lat=0.0&lng=0.0")
+
+      assert %GlobalSettings{grafana_url: "http://example.com/foo/bar"} =
+               Settings.get_global_settings!()
     end
 
     test "keeps the path", %{conn: conn} do

--- a/test/teslamate_web/live/geofence_live_test.exs
+++ b/test/teslamate_web/live/geofence_live_test.exs
@@ -427,7 +427,14 @@ defmodule TeslaMateWeb.GeoFenceLiveTest do
     test "handles weird referrers", %{conn: conn} do
       assert %GlobalSettings{grafana_url: nil} = Settings.get_global_settings!()
 
-      for referrer <- [nil, "", "example.com", "http://example.com/foo", "/geo-fences"] do
+      for referrer <- [
+            nil,
+            "",
+            "example.com",
+            "http://example.com/foo",
+            "/geo-fences",
+            "android-app://com.example.app"
+          ] do
         assert {:ok, _parent_view, _html} =
                  conn
                  |> put_connect_params(%{"referrer" => referrer})
@@ -438,21 +445,39 @@ defmodule TeslaMateWeb.GeoFenceLiveTest do
     end
 
     test "sets the origin if the browser stripped the referrer path", %{conn: conn} do
-      for {referrer, url} <- [
-            {"http://grafana.example.com", "http://grafana.example.com"},
-            {"http://grafana.example.com:3000/", "http://grafana.example.com:3000"}
-          ] do
-        assert {:ok, _} =
-                 Settings.get_global_settings!()
-                 |> Settings.update_global_settings(%{grafana_url: nil})
+      assert %GlobalSettings{grafana_url: nil} = Settings.get_global_settings!()
 
-        assert {:ok, _parent_view, _html} =
-                 conn
-                 |> put_connect_params(%{"referrer" => referrer})
-                 |> live("/geo-fences/new?lat=0.0&lng=0.0")
+      assert {:ok, _parent_view, _html} =
+               conn
+               |> put_connect_params(%{"referrer" => "http://grafana.example.com"})
+               |> live("/geo-fences/new?lat=0.0&lng=0.0")
 
-        assert %GlobalSettings{grafana_url: ^url} = Settings.get_global_settings!()
-      end
+      assert %GlobalSettings{grafana_url: "http://grafana.example.com"} =
+               Settings.get_global_settings!()
+    end
+
+    test "sets the origin if the referrer is the root path", %{conn: conn} do
+      assert %GlobalSettings{grafana_url: nil} = Settings.get_global_settings!()
+
+      assert {:ok, _parent_view, _html} =
+               conn
+               |> put_connect_params(%{"referrer" => "http://grafana.example.com:3000/"})
+               |> live("/geo-fences/new?lat=0.0&lng=0.0")
+
+      assert %GlobalSettings{grafana_url: "http://grafana.example.com:3000"} =
+               Settings.get_global_settings!()
+    end
+
+    test "tolerates a trailing slash", %{conn: conn} do
+      assert %GlobalSettings{grafana_url: nil} = Settings.get_global_settings!()
+
+      assert {:ok, _parent_view, _html} =
+               conn
+               |> put_connect_params(%{"referrer" => "http://example.com/grafana/d/xyz/slug/"})
+               |> live("/geo-fences/new?lat=0.0&lng=0.0")
+
+      assert %GlobalSettings{grafana_url: "http://example.com/grafana"} =
+               Settings.get_global_settings!()
     end
 
     test "keeps a nested path", %{conn: conn} do

--- a/test/teslamate_web/live/geofence_live_test.exs
+++ b/test/teslamate_web/live/geofence_live_test.exs
@@ -396,6 +396,19 @@ defmodule TeslaMateWeb.GeoFenceLiveTest do
     end
   end
 
+  describe "back button" do
+    test "navigates back in the browser history with the index as fallback", %{conn: conn} do
+      assert {:ok, _parent_view, html} =
+               conn
+               |> put_connect_params(%{"referrer" => "http://grafana.example.com/"})
+               |> live("/geo-fences/new?lat=0.0&lng=0.0")
+
+      assert [back] = html |> Floki.parse_document!() |> Floki.find("#back-button")
+      assert Floki.attribute(back, "href") == ["/geo-fences"]
+      assert Floki.attribute(back, "phx-hook") == ["HistoryBack"]
+    end
+  end
+
   describe "grafana URL" do
     alias TeslaMate.Settings.GlobalSettings
 


### PR DESCRIPTION
## Problem

Browsers send only the origin for cross-origin referrers (`strict-origin-when-cross-origin`). Grafana and TeslaMate usually run on different origins, so `document.referrer` is just `http://grafana:3000/`. Two features relied on the full referrer:

- The Back button on the charge cost page linked to the referrer and landed on the Grafana home dashboard with the default time range.
- The geo-fence form derives the Grafana URL setting from the referrer's dashboard path. With an origin-only referrer the match failed silently and the setting stayed empty.

The geo-fence data links additionally opened in a new tab. A new tab has no history, and where several links share a table cell Grafana's context menu adds `rel="noopener noreferrer"`, so no referrer arrived at all. Both the geo-fence Back button and the Grafana URL detection only work through the dashboard change below.

## Changes

- New `HistoryBack` JS hook: Back navigates in the browser history and falls back to the link's `href` when there is no history. Modifier clicks are left to the browser. Used by the charge cost and geo-fence forms.
- All geo-fence data links in the dashboards open in the same tab (`targetBlank: false`), like the charge cost link already did.
- Grafana URL detection accepts a bare origin, matches dashboard paths on the `/d/` segment (trailing slash tolerated) and keeps nested sub-paths in order (previously reversed).
- Fixes a pre-existing crash on mount: a referrer that fails URL validation (e.g. `android-app://…`) made `set_grafana_url` return `:ok` instead of the settings.
- Tests for both Back buttons, origin-only referrers, nested paths, trailing slash and the invalid-URL referrer.

## Workarounds & open questions

- With an origin-only referrer a Grafana sub-path on a different origin than TeslaMate (e.g. `https://other-host/grafana`) cannot be detected; the setting then holds the origin and the navbar dashboard links 404 until corrected manually in the settings. Same-origin sub-paths deliver the full referrer and work. Previously nothing was detected in either case.
- `history.back()` uses plain browser semantics: the previous entry in the tab, which is not necessarily where the fallback `href` points.
- The hook's behaviour itself is not covered by tests; the repo has no JS test setup. Tests verify the hook is attached and the fallback `href`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Fable 5.1 medium) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)