### PR TITLE
test(characterization): pin vehicle identification from vehicle_config and VIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-Under the hood, this release adds a self-verifying black-box characterization suite: recorded API sequences replay through the real vehicle state machine, and everything that leaves the system — database rows, MQTT messages, and the vehicle's interactions with the streaming API and its supervisor — is pinned against goldens. All existing vehicle scenarios are converted (120 fixtures).
+Under the hood, this release adds a self-verifying black-box characterization suite: recorded API sequences replay through the real vehicle state machine, and everything that leaves the system — database rows, MQTT messages, and the vehicle's interactions with the streaming API and its supervisor — is pinned against goldens. All existing vehicle scenarios are converted (137 fixtures).
 The work already paid off three times: it exposed a crash in the update-cancel path (#5656), a crash loop after an offline period when the car reports an outdated timestamp (#5684), and the published state start time jumping backwards after charging, updating or driving (#5693) — all fixed in this release — and it surfaced two quirks for a later fix: a charge sample without charger power is stored as 0 kW (#5699),
 and a stream going inactive while logging is suspended can start a second fetch alongside the running poll (#5714).
 
@@ -61,6 +61,7 @@ Upgrading directly from 4.1.x no longer preserves entity registry customizations
 - build(deps): bump phoenix_live_view from 1.2.8 to 1.2.11 (#5678)
 - test(characterization): pin the pre-online check of the streaming API (#5712 - @JakobLichterfeld)
 - test(characterization): pin the suspended state's resume, usage and inactive-stream paths (#5713 - @JakobLichterfeld)
+- test(characterization): pin vehicle identification — model, trim and marketing name from vehicle_config and VIN (#5715 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/test/fixtures/characterization/goldens/identity_car_type_nil.json
+++ b/test/fixtures/characterization/goldens/identity_car_type_nil.json
@@ -1,0 +1,224 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": null,
+        "model": null,
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "100D",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["100D"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_cybertruck.json
+++ b/test/fixtures/characterization/goldens/identity_cybertruck.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": null,
+        "model": "Cybertruck",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "AWD",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["Cybertruck"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["AWD"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_lychee_100d.json
+++ b/test/fixtures/characterization/goldens/identity_lychee_100d.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "LR",
+        "model": "S",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "100D",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["S"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["100D"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_lychee_p100d.json
+++ b/test/fixtures/characterization/goldens/identity_lychee_p100d.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "Plaid",
+        "model": "S",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "P100D",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["S"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["P100D"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_model3_50_invalid_vin.json
+++ b/test/fixtures/characterization/goldens/identity_model3_50_invalid_vin.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "SR+",
+        "model": "3",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "50",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["50"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_model3_50_my2019.json
+++ b/test/fixtures/characterization/goldens/identity_model3_50_my2019.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "SR+",
+        "model": "3",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "50",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["50"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_model3_50_my2022.json
+++ b/test/fixtures/characterization/goldens/identity_model3_50_my2022.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "RWD",
+        "model": "3",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "50",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["50"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_model3_62.json
+++ b/test/fixtures/characterization/goldens/identity_model3_62.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "MR",
+        "model": "3",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "62",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["62"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_model3_74.json
+++ b/test/fixtures/characterization/goldens/identity_model3_74.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "LR",
+        "model": "3",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "74",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["74"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_model3_p74d.json
+++ b/test/fixtures/characterization/goldens/identity_model3_p74d.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "LR AWD Performance",
+        "model": "3",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "P74D",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["P74D"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_models2_100d.json
+++ b/test/fixtures/characterization/goldens/identity_models2_100d.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "LR+",
+        "model": "S",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "100D",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["S"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["100D"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_models_100d.json
+++ b/test/fixtures/characterization/goldens/identity_models_100d.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": null,
+        "model": "S",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "100D",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["S"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["100D"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_modelx_100d.json
+++ b/test/fixtures/characterization/goldens/identity_modelx_100d.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": null,
+        "model": "X",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "100D",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["X"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["100D"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_modely_50.json
+++ b/test/fixtures/characterization/goldens/identity_modely_50.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "SR",
+        "model": "Y",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "50",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["Y"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["50"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_modely_74.json
+++ b/test/fixtures/characterization/goldens/identity_modely_74.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "LR",
+        "model": "Y",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "74",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["Y"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["74"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_modely_74d.json
+++ b/test/fixtures/characterization/goldens/identity_modely_74d.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "LR AWD",
+        "model": "Y",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "74D",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["Y"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["74D"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_modely_p74d.json
+++ b/test/fixtures/characterization/goldens/identity_modely_p74d.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "LR AWD Performance",
+        "model": "Y",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "P74D",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["Y"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["P74D"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_tamarind_100d.json
+++ b/test/fixtures/characterization/goldens/identity_tamarind_100d.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "LR",
+        "model": "X",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "100D",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["X"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["100D"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_tamarind_p100d.json
+++ b/test/fixtures/characterization/goldens/identity_tamarind_p100d.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": "Plaid",
+        "model": "X",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "P100D",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["X"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["P100D"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_trim_nil.json
+++ b/test/fixtures/characterization/goldens/identity_trim_nil.json
@@ -1,0 +1,225 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": null,
+        "model": "3",
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": null,
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": [""],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/goldens/identity_unknown_car_type.json
+++ b/test/fixtures/characterization/goldens/identity_unknown_car_type.json
@@ -1,0 +1,224 @@
+{
+  "database": {
+    "addresses": [],
+    "car_settings": [
+      {
+        "enabled": true,
+        "free_supercharging": false,
+        "id": "car_setting_1",
+        "lfp_battery": false,
+        "req_not_unlocked": false,
+        "suspend_after_idle_min": 100000,
+        "suspend_min": 100000,
+        "use_streaming_api": false
+      }
+    ],
+    "cars": [
+      {
+        "display_priority": 1,
+        "efficiency": 0.153,
+        "eid": 42,
+        "exterior_color": "DeepBlue",
+        "id": "$car",
+        "inserted_at": "<volatile>",
+        "marketing_name": null,
+        "model": null,
+        "name": "blue",
+        "settings_id": "car_setting_1",
+        "spoiler_type": "None",
+        "trim_badging": "100D",
+        "updated_at": "<volatile>",
+        "vid": 1000,
+        "vin": "5YJ3E1EA1KF000001",
+        "wheel_type": "Pinwheel18"
+      }
+    ],
+    "charges": [],
+    "charging_processes": [],
+    "drives": [],
+    "geofences": [],
+    "positions": [
+      {
+        "battery_heater": null,
+        "battery_heater_no_power": null,
+        "battery_heater_on": null,
+        "battery_level": 80,
+        "car_id": "$car",
+        "date": "2024-01-01T00:00:00.000000",
+        "drive_id": null,
+        "driver_temp_setting": null,
+        "elevation": null,
+        "est_battery_range_km": "370.15",
+        "fan_status": null,
+        "id": "position_1",
+        "ideal_battery_range_km": "402.34",
+        "inside_temp": "18.0",
+        "is_climate_on": false,
+        "is_front_defroster_on": null,
+        "is_rear_defroster_on": null,
+        "latitude": "52.514521",
+        "longitude": "13.350144",
+        "odometer": 16093.44,
+        "outside_temp": "12.5",
+        "passenger_temp_setting": null,
+        "power": 0,
+        "rated_battery_range_km": "386.24",
+        "speed": null,
+        "tpms_pressure_fl": null,
+        "tpms_pressure_fr": null,
+        "tpms_pressure_rl": null,
+        "tpms_pressure_rr": null,
+        "usable_battery_level": 79
+      }
+    ],
+    "states": [
+      {
+        "car_id": "$car",
+        "end_date": null,
+        "id": "state_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "state": "online"
+      }
+    ],
+    "updates": [
+      {
+        "car_id": "$car",
+        "end_date": "2024-01-01T00:00:00.000000",
+        "id": "update_1",
+        "start_date": "2024-01-01T00:00:00.000000",
+        "version": "2026.20.1 abc123"
+      }
+    ]
+  },
+  "mqtt": {
+    "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
+    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
+      ""
+    ],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_energy_at_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_minutes_to_arrival/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
+    "homeassistant/sensor/teslamate_$car/heading/config": [""],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/model/config": [""],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
+    "homeassistant/sensor/teslamate_$car/power/config": [""],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
+    "homeassistant/sensor/teslamate_$car/since/config": [""],
+    "homeassistant/sensor/teslamate_$car/speed/config": [""],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/state/config": [""],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
+    "homeassistant/sensor/teslamate_$car/version/config": [""],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "teslamate/cars/$car/active_route": [
+      {
+        "error": "No active route available"
+      }
+    ],
+    "teslamate/cars/$car/active_route_destination": ["nil"],
+    "teslamate/cars/$car/active_route_latitude": ["nil"],
+    "teslamate/cars/$car/active_route_longitude": ["nil"],
+    "teslamate/cars/$car/battery_level": ["80"],
+    "teslamate/cars/$car/charge_energy_added": ["0.0"],
+    "teslamate/cars/$car/charger_actual_current": [""],
+    "teslamate/cars/$car/charger_phases": [""],
+    "teslamate/cars/$car/charger_power": [""],
+    "teslamate/cars/$car/charger_voltage": [""],
+    "teslamate/cars/$car/charging_state": ["Disconnected"],
+    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
+    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
+    "teslamate/cars/$car/geofence": [""],
+    "teslamate/cars/$car/heading": ["42"],
+    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
+    "teslamate/cars/$car/inside_temp": ["18.0"],
+    "teslamate/cars/$car/is_climate_on": ["false"],
+    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/location": [
+      {
+        "latitude": 52.514521,
+        "longitude": 13.350144
+      }
+    ],
+    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/longitude": ["13.350144"],
+    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/outside_temp": ["12.5"],
+    "teslamate/cars/$car/plugged_in": ["false"],
+    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
+    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/sentry_mode": ["false"],
+    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/state": ["online"],
+    "teslamate/cars/$car/time_to_full_charge": [""],
+    "teslamate/cars/$car/trim_badging": ["100D"],
+    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/version": ["2026.20.1"],
+    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_car_type_nil.json
+++ b/test/fixtures/characterization/scenarios/identity_car_type_nil.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries no vehicle_config.car_type (null) with trim_badging '100d'. Branch: a missing car_type maps to no model without any table lookup, marketing_name stays nil. identify/1 writes the cars row: model nil, trim_badging 100D (upcased from the payload), marketing_name nil; the model and trim_badging topics carry the same values; the model topic is absent because nil is never published. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": null,
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": null,
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_cybertruck.json
+++ b/test/fixtures/characterization/scenarios/identity_cybertruck.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'cybertruck' with trim_badging 'awd'. Branch: car_type 'cybertruck' maps to Cybertruck; no table row, marketing_name stays nil. identify/1 writes the cars row: model Cybertruck, trim_badging AWD (upcased from the payload), marketing_name nil; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "cybertruck",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "awd",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "cybertruck",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "awd",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_lychee_100d.json
+++ b/test/fixtures/characterization/scenarios/identity_lychee_100d.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'lychee' with trim_badging '100d'. Branch: car_type 'lychee' maps to S, table row S/100D/lychee gives LR. identify/1 writes the cars row: model S, trim_badging 100D (upcased from the payload), marketing_name LR; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "lychee",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "lychee",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_lychee_p100d.json
+++ b/test/fixtures/characterization/scenarios/identity_lychee_p100d.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'lychee' with trim_badging 'p100d'. Branch: car_type 'lychee' maps to S, table row S/P100D/lychee gives Plaid. identify/1 writes the cars row: model S, trim_badging P100D (upcased from the payload), marketing_name Plaid; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "lychee",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "p100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "lychee",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "p100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_model3_50_invalid_vin.json
+++ b/test/fixtures/characterization/scenarios/identity_model3_50_invalid_vin.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'model3' with trim_badging '50' and VIN INVALID. Branch: table row 3/50 with a VIN that is not 17 characters: no model year, base trim falls back to SR+. identify/1 writes the cars row: model 3, trim_badging 50 (upcased from the payload), marketing_name SR+; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "50",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "INVALID"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "50",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "INVALID"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_model3_50_my2019.json
+++ b/test/fixtures/characterization/scenarios/identity_model3_50_my2019.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'model3' with trim_badging '50'. Branch: table row 3/50 resolves the base trim from the VIN's tenth character K (model year 2019, before 2022) to SR+. identify/1 writes the cars row: model 3, trim_badging 50 (upcased from the payload), marketing_name SR+; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "50",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "50",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_model3_50_my2022.json
+++ b/test/fixtures/characterization/scenarios/identity_model3_50_my2022.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'model3' with trim_badging '50' and VIN 5YJ3E1EA1NF000001. Branch: table row 3/50 resolves the base trim from the VIN's tenth character N (model year 2022) to RWD. identify/1 writes the cars row: model 3, trim_badging 50 (upcased from the payload), marketing_name RWD; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "50",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1NF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "50",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1NF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_model3_62.json
+++ b/test/fixtures/characterization/scenarios/identity_model3_62.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'model3' with trim_badging '62'. Branch: table row 3/62. identify/1 writes the cars row: model 3, trim_badging 62 (upcased from the payload), marketing_name MR; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "62",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "62",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_model3_74.json
+++ b/test/fixtures/characterization/scenarios/identity_model3_74.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'model3' with trim_badging '74'. Branch: table row 3/74. identify/1 writes the cars row: model 3, trim_badging 74 (upcased from the payload), marketing_name LR; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "74",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "74",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_model3_p74d.json
+++ b/test/fixtures/characterization/scenarios/identity_model3_p74d.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'model3' with trim_badging 'p74d'. Branch: table row 3/P74D. identify/1 writes the cars row: model 3, trim_badging P74D (upcased from the payload), marketing_name LR AWD Performance; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "p74d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "p74d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_models2_100d.json
+++ b/test/fixtures/characterization/scenarios/identity_models2_100d.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'models2' with trim_badging '100d'. Branch: car_type 'models2' maps to S through the 'models' prefix clause (the dedicated 'models2' clause is shadowed by it), and the table row S/100D/models2 gives LR+. identify/1 writes the cars row: model S, trim_badging 100D (upcased from the payload), marketing_name LR+; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "models2",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "models2",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_models_100d.json
+++ b/test/fixtures/characterization/scenarios/identity_models_100d.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'models' with trim_badging '100d'. Branch: car_type 'models' maps to S; the marketing table has no row for S/100D without lychee or models2, so marketing_name stays nil. identify/1 writes the cars row: model S, trim_badging 100D (upcased from the payload), marketing_name nil; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "models",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "models",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_modelx_100d.json
+++ b/test/fixtures/characterization/scenarios/identity_modelx_100d.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'modelx' with trim_badging '100d'. Branch: car_type 'modelx' maps to X; the table has no row for X/100D without tamarind, marketing_name stays nil. identify/1 writes the cars row: model X, trim_badging 100D (upcased from the payload), marketing_name nil; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "modelx",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "modelx",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_modely_50.json
+++ b/test/fixtures/characterization/scenarios/identity_modely_50.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'modely' with trim_badging '50'. Branch: table row Y/50. identify/1 writes the cars row: model Y, trim_badging 50 (upcased from the payload), marketing_name SR; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "modely",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "50",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "modely",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "50",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_modely_74.json
+++ b/test/fixtures/characterization/scenarios/identity_modely_74.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'modely' with trim_badging '74'. Branch: table row Y/74. identify/1 writes the cars row: model Y, trim_badging 74 (upcased from the payload), marketing_name LR; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "modely",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "74",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "modely",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "74",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_modely_74d.json
+++ b/test/fixtures/characterization/scenarios/identity_modely_74d.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'modely' with trim_badging '74d'. Branch: table row Y/74D. identify/1 writes the cars row: model Y, trim_badging 74D (upcased from the payload), marketing_name LR AWD; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "modely",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "74d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "modely",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "74d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_modely_p74d.json
+++ b/test/fixtures/characterization/scenarios/identity_modely_p74d.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'modely' with trim_badging 'p74d'. Branch: car_type 'modely' maps to Y, table row Y/P74D. identify/1 writes the cars row: model Y, trim_badging P74D (upcased from the payload), marketing_name LR AWD Performance; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "modely",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "p74d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "modely",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "p74d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_tamarind_100d.json
+++ b/test/fixtures/characterization/scenarios/identity_tamarind_100d.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'tamarind' with trim_badging '100d'. Branch: car_type 'tamarind' maps to X, table row X/100D/tamarind gives LR. identify/1 writes the cars row: model X, trim_badging 100D (upcased from the payload), marketing_name LR; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "tamarind",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "tamarind",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_tamarind_p100d.json
+++ b/test/fixtures/characterization/scenarios/identity_tamarind_p100d.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'tamarind' with trim_badging 'p100d'. Branch: car_type 'tamarind' maps to X, table row X/P100D/tamarind gives Plaid. identify/1 writes the cars row: model X, trim_badging P100D (upcased from the payload), marketing_name Plaid; the model and trim_badging topics carry the same values. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "tamarind",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "p100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "tamarind",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "p100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_trim_nil.json
+++ b/test/fixtures/characterization/scenarios/identity_trim_nil.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'model3' with no trim_badging. Branch: a missing trim_badging stays nil and no table row matches. identify/1 writes the cars row: model 3, trim_badging nil (upcased from the payload), marketing_name nil; the model and trim_badging topics carry the same values; the trim_badging topic publishes an empty string, as it is in the publish-if-nil set. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": null,
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "model3",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": null,
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}

--- a/test/fixtures/characterization/scenarios/identity_unknown_car_type.json
+++ b/test/fixtures/characterization/scenarios/identity_unknown_car_type.json
@@ -1,0 +1,119 @@
+{
+  "car": {
+    "efficiency": 0.153,
+    "eid": 42,
+    "model": "3",
+    "name": "blue",
+    "vid": 1000,
+    "vin": "5YJ3E1EA1KF000001"
+  },
+  "description": "Identity (polling): the first full payload carries vehicle_config.car_type 'roadster' with trim_badging '100d'. Branch: an unknown car_type maps to no model, marketing_name stays nil. identify/1 writes the cars row: model nil, trim_badging 100D (upcased from the payload), marketing_name nil; the model and trim_badging topics carry the same values; the model topic is absent because nil is never published. The online terminal stays online and writes nothing.",
+  "events": [
+    {
+      "snapshot": true,
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067200000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067200000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067200000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "roadster",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067200000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067200000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    },
+    {
+      "vehicle": {
+        "charge_state": {
+          "battery_level": 80,
+          "battery_range": 240.0,
+          "charge_energy_added": 0.0,
+          "charging_state": "Disconnected",
+          "est_battery_range": 230.0,
+          "ideal_battery_range": 250.0,
+          "timestamp": 1704067210000,
+          "usable_battery_level": 79
+        },
+        "climate_state": {
+          "inside_temp": 18.0,
+          "is_climate_on": false,
+          "outside_temp": 12.5,
+          "timestamp": 1704067210000
+        },
+        "display_name": "blue",
+        "drive_state": {
+          "heading": 42,
+          "latitude": 52.514521,
+          "longitude": 13.350144,
+          "power": 0,
+          "shift_state": null,
+          "speed": null,
+          "timestamp": 1704067210000
+        },
+        "id": 42,
+        "state": "online",
+        "vehicle_config": {
+          "car_type": "roadster",
+          "exterior_color": "DeepBlue",
+          "spoiler_type": "None",
+          "timestamp": 1704067210000,
+          "trim_badging": "100d",
+          "wheel_type": "Pinwheel18"
+        },
+        "vehicle_id": 1000,
+        "vehicle_state": {
+          "car_version": "2026.20.1 abc123",
+          "is_user_present": false,
+          "locked": true,
+          "odometer": 10000.0,
+          "sentry_mode": false,
+          "timestamp": 1704067210000
+        },
+        "vin": "5YJ3E1EA1KF000001"
+      }
+    }
+  ],
+  "settings": {
+    "suspend_after_idle_min": 100000,
+    "suspend_min": 100000,
+    "use_streaming_api": false
+  }
+}


### PR DESCRIPTION
## What this adds

Twenty-one scenario/golden pairs for `identify/1` and its helpers: model from `vehicle_config.car_type`, trim from `trim_badging` (upcased — the payloads carry it lowercase so the upcase is visible in every row), `marketing_name` from the (model, trim, car_type) table, and for Model 3 "50" the base trim from the VIN's tenth character (model year ≥ 2022 → RWD, earlier → SR+, no 17-character VIN → SR+). Each fixture is one full online snapshot with the varied `vehicle_config` (and payload VIN where the branch needs it) plus an online terminal; the pin is the `cars` row (`model`, `trim_badging`, `marketing_name`) and the `model` / `trim_badging` topics.

| Fixture | car_type / trim / VIN | cars row |
|---|---|---|
| `identity_models_100d` | models / 100d | S, 100D, nil (no table row without lychee/models2) |
| `identity_models2_100d` | models2 / 100d | S, 100D, LR+ |
| `identity_lychee_100d`, `_p100d` | lychee / 100d, p100d | S, LR / Plaid |
| `identity_model3_p74d`, `_74`, `_62` | model3 | 3, LR AWD Performance / LR / MR |
| `identity_model3_50_my2019` | model3 / 50, VIN …K… | 3, 50, SR+ |
| `identity_model3_50_my2022` | model3 / 50, VIN …N… | 3, 50, RWD |
| `identity_model3_50_invalid_vin` | model3 / 50, VIN `INVALID` | 3, 50, SR+ |
| `identity_modelx_100d` | modelx / 100d | X, 100D, nil |
| `identity_tamarind_100d`, `_p100d` | tamarind | X, LR / Plaid |
| `identity_modely_p74d`, `_74d`, `_74`, `_50` | modely | Y, LR AWD Performance / LR AWD / LR / SR |
| `identity_cybertruck` | cybertruck / awd | Cybertruck, AWD, nil |
| `identity_unknown_car_type` | roadster / 100d | nil, 100D, nil — no `model` topic (nil is never published) |
| `identity_car_type_nil` | null / 100d | nil, 100D, nil — no `model` topic |
| `identity_trim_nil` | model3 / null | 3, nil, nil — `trim_badging` topic `""` (publish-if-nil) |

`3/74D → LR AWD` is already pinned by every existing fixture (`driving_full_drive` config).

## Enforced invariants

- Terminal repeat-neutrality via the double record run (`record/1`, `mask_volatile/2`): the online terminal writes nothing.
- Absence pinned: a missing `model` topic and an empty `trim_badging` publish are divergences like any other key (`diff/2`).

## Verification

- Full suite without record mode: 729 passed (seed 535108).
- Coverage of `lib/teslamate/vehicles/vehicle.ex` by the characterization suite alone (same command as the baseline): **89.3 %**, 81 missed lines — baseline 80.6 % / 148, previous family 85.9 % / 107.
- Baseline lines now hit: 117, 119, 122–127 except 120, 133–146 (the marketing table), 169, 171, 176–178 (VIN year and Model 3 base trim).

## Workarounds, deviations & open questions

- Baseline line 161 (`vehicle_config: nil`) is classified as not reachable at the boundary in #5652: the fetch-result handler only dispatches full payloads. Line 120 (`"models2" <> _`) is dead code, tracked in #5716. Lines 105/106 (`format_model/1`) belong to the Home Assistant device name, observable only with discovery enabled (production default off); the discovery declaration is the next harness step and `format_model` its first user, listed in #5652.
- Observation: `identify/1` reads the VIN from the payload, the `cars.vin` column keeps the car's own VIN; `identity_model3_50_my2022` shows RWD from the payload VIN with the row VIN unchanged.
- Open questions: none.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Fable 5.1 low) — sponsored by [Claude for Open Source](https://www.anthropic.com/claude-for-open-source)