### PR TITLE
feat(vehicle): expose is_auto_conditioning_on via Position, MQTT and HA discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Upgrading directly from 4.1.x no longer preserves entity registry customizations
 
 ### New features
 
+- feat(vehicle): expose `is_auto_conditioning_on` (distinguishes full Auto climate from manual fan-only operation) via Position, MQTT and Home Assistant discovery, mirroring the existing `is_climate_on` wiring (#4157)
+
 ### Improvements and bug fixes
 
 - fix(vehicle): cancel an update with the logged update row instead of the API payload, which crashed the vehicle process and left the update open forever (#5664 - @JakobLichterfeld)

--- a/lib/teslamate/log/position.ex
+++ b/lib/teslamate/log/position.ex
@@ -27,6 +27,7 @@ defmodule TeslaMate.Log.Position do
     field :driver_temp_setting, :decimal, read_after_writes: true
     field :passenger_temp_setting, :decimal, read_after_writes: true
     field :is_climate_on, :boolean
+    field :is_auto_conditioning_on, :boolean
     field :is_rear_defroster_on, :boolean
     field :is_front_defroster_on, :boolean
     field :tpms_pressure_fl, :decimal
@@ -64,6 +65,7 @@ defmodule TeslaMate.Log.Position do
       :driver_temp_setting,
       :passenger_temp_setting,
       :is_climate_on,
+      :is_auto_conditioning_on,
       :is_rear_defroster_on,
       :is_front_defroster_on,
       :tpms_pressure_fl,

--- a/lib/teslamate/mqtt/pubsub/home_assistant.ex
+++ b/lib/teslamate/mqtt/pubsub/home_assistant.ex
@@ -72,6 +72,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
     {"binary_sensor", "frunk_open"},
     {"binary_sensor", "is_user_present"},
     {"binary_sensor", "is_climate_on"},
+    {"binary_sensor", "is_auto_conditioning_on"},
     {"binary_sensor", "is_preconditioning"},
     {"binary_sensor", "plugged_in"},
     {"binary_sensor", "charge_port_door_open"},
@@ -1075,6 +1076,13 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistant do
          name: "Climate",
          device_class: "running",
          icon: "mdi:air-conditioner"
+       })},
+      {"binary_sensor", "is_auto_conditioning_on",
+       Map.merge(true_false, %{
+         state_topic_key: :is_auto_conditioning_on,
+         name: "Auto Conditioning",
+         device_class: "running",
+         icon: "mdi:fan-auto"
        })},
       {"binary_sensor", "is_preconditioning",
        Map.merge(true_false, %{

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -287,7 +287,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
   @simple_values ~w(
     display_name state since healthy latitude longitude heading battery_level charging_state usable_battery_level
     ideal_battery_range_km est_battery_range_km rated_battery_range_km charge_energy_added
-    speed outside_temp inside_temp is_climate_on is_preconditioning locked sentry_mode
+    speed outside_temp inside_temp is_climate_on is_auto_conditioning_on is_preconditioning locked sentry_mode
     plugged_in scheduled_charging_start_time charge_limit_soc charger_power windows_open
     driver_front_window_open driver_rear_window_open passenger_front_window_open passenger_rear_window_open
     doors_open driver_front_door_open driver_rear_door_open passenger_front_door_open passenger_rear_door_open

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1701,6 +1701,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
       rated_battery_range_km: Convert.miles_to_km(vehicle.charge_state.battery_range, 2),
       fan_status: vehicle.climate_state.fan_status,
       is_climate_on: vehicle.climate_state.is_climate_on,
+      is_auto_conditioning_on: vehicle.climate_state.is_auto_conditioning_on,
       driver_temp_setting: vehicle.climate_state.driver_temp_setting,
       passenger_temp_setting: vehicle.climate_state.passenger_temp_setting,
       is_rear_defroster_on: vehicle.climate_state.is_rear_defroster_on,

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -25,6 +25,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
           outside_temp: float() | nil,
           inside_temp: float() | nil,
           is_climate_on: boolean() | nil,
+          is_auto_conditioning_on: boolean() | nil,
           is_preconditioning: boolean() | nil,
           locked: boolean() | nil,
           sentry_mode: boolean() | nil,
@@ -86,7 +87,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
   defstruct ~w(
     car display_name state since healthy latitude longitude heading battery_level charging_state usable_battery_level
     ideal_battery_range_km est_battery_range_km rated_battery_range_km charge_energy_added
-    speed outside_temp inside_temp is_climate_on is_preconditioning locked sentry_mode
+    speed outside_temp inside_temp is_climate_on is_auto_conditioning_on is_preconditioning locked sentry_mode
     plugged_in scheduled_charging_start_time charge_limit_soc charger_power windows_open
     driver_front_window_open driver_rear_window_open passenger_front_window_open passenger_rear_window_open
     doors_open driver_front_door_open driver_rear_door_open passenger_front_door_open passenger_rear_door_open
@@ -199,6 +200,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
 
       # Climate State
       is_climate_on: get_in_struct(vehicle, [:climate_state, :is_climate_on]),
+      is_auto_conditioning_on: get_in_struct(vehicle, [:climate_state, :is_auto_conditioning_on]),
       is_preconditioning: get_in_struct(vehicle, [:climate_state, :is_preconditioning]),
       climate_keeper_mode: get_in_struct(vehicle, [:climate_state, :climate_keeper_mode]),
       outside_temp: get_in_struct(vehicle, [:climate_state, :outside_temp]),

--- a/priv/repo/migrations/20260912000000_add_is_auto_conditioning_on.exs
+++ b/priv/repo/migrations/20260912000000_add_is_auto_conditioning_on.exs
@@ -1,0 +1,9 @@
+defmodule TeslaMate.Repo.Migrations.AddIsAutoConditioningOn do
+  use Ecto.Migration
+
+  def change do
+    alter table(:positions) do
+      add(:is_auto_conditioning_on, :boolean)
+    end
+  end
+end

--- a/test/fixtures/characterization/goldens/charging_api_error.json
+++ b/test/fixtures/characterization/goldens/charging_api_error.json
@@ -202,6 +202,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -234,6 +235,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -266,6 +268,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -298,6 +301,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -364,27 +368,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -397,58 +434,148 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60", "61", "62"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60",
+      "61",
+      "62"
+    ],
     "teslamate/cars/$car/charge_energy_added": [
       "0.0",
       "0.1",
@@ -456,12 +583,36 @@
       "0.3",
       "0.0"
     ],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["false", "true", "false"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16", "0", ""],
-    "teslamate/cars/$car/charger_phases": ["", "3", ""],
-    "teslamate/cars/$car/charger_power": ["", "11", "0", ""],
-    "teslamate/cars/$car/charger_voltage": ["", "230", ""],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16",
+      "0",
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3",
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0",
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230",
+      ""
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Charging",
@@ -469,17 +620,41 @@
       "Unplugged",
       "Disconnected"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["305.78"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.5152"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "305.78"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.5152"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -490,29 +665,73 @@
         "longitude": 13.351
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.351"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true", "false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["313.82"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.351"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "313.82"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:40.000Z",
       "2024-01-01T00:01:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "charging", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59", "60", "61"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "charging",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59",
+      "60",
+      "61"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/charging_connection_loss.json
+++ b/test/fixtures/characterization/goldens/charging_connection_loss.json
@@ -202,6 +202,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -234,6 +235,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -266,6 +268,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -298,6 +301,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -364,27 +368,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -397,58 +434,148 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60", "61", "62"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60",
+      "61",
+      "62"
+    ],
     "teslamate/cars/$car/charge_energy_added": [
       "0.0",
       "0.1",
@@ -456,12 +583,36 @@
       "0.3",
       "0.0"
     ],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["false", "true", "false"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16", "0", ""],
-    "teslamate/cars/$car/charger_phases": ["", "3", ""],
-    "teslamate/cars/$car/charger_power": ["", "11", "0", ""],
-    "teslamate/cars/$car/charger_voltage": ["", "230", ""],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16",
+      "0",
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3",
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0",
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230",
+      ""
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Charging",
@@ -469,17 +620,41 @@
       "Unplugged",
       "Disconnected"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["305.78"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.5152"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "305.78"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.5152"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -490,29 +665,73 @@
         "longitude": 13.351
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.351"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true", "false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["313.82"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.351"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "313.82"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:40.000Z",
       "2024-01-01T00:01:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "charging", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59", "60", "61"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "charging",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59",
+      "60",
+      "61"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/charging_direct_transition.json
+++ b/test/fixtures/characterization/goldens/charging_direct_transition.json
@@ -154,6 +154,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -186,6 +187,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "386.24",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -218,6 +220,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "387.85",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -250,6 +253,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "387.85",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -316,27 +320,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -349,115 +386,294 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60", "75", "76"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0", "22.0"],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["false", "true"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16", "0"],
-    "teslamate/cars/$car/charger_phases": ["", "3"],
-    "teslamate/cars/$car/charger_power": ["", "11", "0"],
-    "teslamate/cars/$car/charger_voltage": ["", "230"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60",
+      "75",
+      "76"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0",
+      "22.0"
+    ],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16",
+      "0"
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3"
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0"
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230"
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Charging",
       "Complete",
       "Unplugged"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["305.78", "370.15", "371.76"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "305.78",
+      "370.15",
+      "371.76"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
     "teslamate/cars/$car/ideal_battery_range_km": [
       "321.87",
       "386.24",
       "387.85"
     ],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["313.82", "378.2", "379.81"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "313.82",
+      "378.2",
+      "379.81"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:00.000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:20.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "charging", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59", "74", "75"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "charging",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59",
+      "74",
+      "75"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/charging_full_cycle.json
+++ b/test/fixtures/characterization/goldens/charging_full_cycle.json
@@ -202,6 +202,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -234,6 +235,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -266,6 +268,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "325.09",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -298,6 +301,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "325.09",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -364,27 +368,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -397,58 +434,148 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60", "61", "62"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60",
+      "61",
+      "62"
+    ],
     "teslamate/cars/$car/charge_energy_added": [
       "0.0",
       "0.1",
@@ -457,12 +584,36 @@
       "0.4",
       "0.0"
     ],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["false", "true", "false"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16", "0", ""],
-    "teslamate/cars/$car/charger_phases": ["", "3", ""],
-    "teslamate/cars/$car/charger_power": ["", "11", "0", ""],
-    "teslamate/cars/$car/charger_voltage": ["", "230", ""],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16",
+      "0",
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3",
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0",
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230",
+      ""
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Starting",
@@ -471,7 +622,9 @@
       "Unplugged",
       "Disconnected"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
     "teslamate/cars/$car/est_battery_range_km": [
       "305.78",
       "306.58",
@@ -479,10 +632,19 @@
       "308.19",
       "308.99"
     ],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
     "teslamate/cars/$car/ideal_battery_range_km": [
       "321.87",
       "322.67",
@@ -490,10 +652,19 @@
       "324.28",
       "325.09"
     ],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.5152"],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.5152"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -504,13 +675,30 @@
         "longitude": 13.351
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.351"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true", "false"],
-    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.351"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
     "teslamate/cars/$car/rated_battery_range_km": [
       "313.82",
       "314.63",
@@ -518,21 +706,46 @@
       "316.24",
       "317.04"
     ],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:40.000Z",
       "2024-01-01T00:01:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "charging", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59", "60", "61"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "charging",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59",
+      "60",
+      "61"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/charging_into_asleep.json
+++ b/test/fixtures/characterization/goldens/charging_into_asleep.json
@@ -154,6 +154,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -186,6 +187,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -244,27 +246,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -277,105 +312,281 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60", "61"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0", "0.1", "0.2"],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["false", "true"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16"],
-    "teslamate/cars/$car/charger_phases": ["", "3"],
-    "teslamate/cars/$car/charger_power": ["", "11"],
-    "teslamate/cars/$car/charger_voltage": ["", "230"],
-    "teslamate/cars/$car/charging_state": ["Disconnected", "Charging"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["305.78"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60",
+      "61"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0",
+      "0.1",
+      "0.2"
+    ],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16"
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3"
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11"
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230"
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected",
+      "Charging"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "305.78"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["313.82"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "313.82"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:20.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "charging", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59", "60"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "charging",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59",
+      "60"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/charging_invalid_charge_data.json
+++ b/test/fixtures/characterization/goldens/charging_invalid_charge_data.json
@@ -178,6 +178,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -210,6 +211,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -242,6 +244,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -274,6 +277,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -315,27 +319,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -348,82 +385,225 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60", "61", "62"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0", "0.1", "0.3", "0.0"],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["false", "true", "false"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16", "0", ""],
-    "teslamate/cars/$car/charger_phases": ["", "3", ""],
-    "teslamate/cars/$car/charger_power": ["", "11", "0", ""],
-    "teslamate/cars/$car/charger_voltage": ["", "230", ""],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60",
+      "61",
+      "62"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0",
+      "0.1",
+      "0.3",
+      "0.0"
+    ],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16",
+      "0",
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3",
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0",
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230",
+      ""
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Charging",
       "Complete",
       "Disconnected"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["305.78"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.5152"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "305.78"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.5152"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -434,28 +614,71 @@
         "longitude": 13.351
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.351"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true", "false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["313.82"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.351"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "313.82"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:50.000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "charging", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59", "60", "61"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "charging",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59",
+      "60",
+      "61"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/charging_range_nil.json
+++ b/test/fixtures/characterization/goldens/charging_range_nil.json
@@ -154,6 +154,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -186,6 +187,7 @@
         "id": "position_2",
         "ideal_battery_range_km": null,
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -218,6 +220,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "329.92",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -250,6 +253,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "329.92",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -316,27 +320,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -349,111 +386,290 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60", "61"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0", "0.1", "0.2"],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["false", "true"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16", "0"],
-    "teslamate/cars/$car/charger_phases": ["", "3"],
-    "teslamate/cars/$car/charger_power": ["", "11", "0"],
-    "teslamate/cars/$car/charger_voltage": ["", "230"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60",
+      "61"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0",
+      "0.1",
+      "0.2"
+    ],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16",
+      "0"
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3"
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0"
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230"
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Charging",
       "Complete",
       "Unplugged"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["305.78", "313.82"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87", "329.92"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "305.78",
+      "313.82"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87",
+      "329.92"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["313.82", "321.87"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "313.82",
+      "321.87"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:40.000Z",
       "2024-01-01T00:00:50.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "charging", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59", "60"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "charging",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59",
+      "60"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/charging_settings_streaming_off.json
+++ b/test/fixtures/characterization/goldens/charging_settings_streaming_off.json
@@ -207,6 +207,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -239,6 +240,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -271,6 +273,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "325.09",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -303,6 +306,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "325.09",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -361,27 +365,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -394,58 +431,148 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60", "61", "62"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60",
+      "61",
+      "62"
+    ],
     "teslamate/cars/$car/charge_energy_added": [
       "0.0",
       "0.1",
@@ -454,12 +581,36 @@
       "0.4",
       "0.0"
     ],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["false", "true", "false"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16", "0", ""],
-    "teslamate/cars/$car/charger_phases": ["", "3", ""],
-    "teslamate/cars/$car/charger_power": ["", "11", "0", ""],
-    "teslamate/cars/$car/charger_voltage": ["", "230", ""],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16",
+      "0",
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3",
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0",
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230",
+      ""
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Starting",
@@ -468,7 +619,9 @@
       "Unplugged",
       "Disconnected"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
     "teslamate/cars/$car/est_battery_range_km": [
       "305.78",
       "306.58",
@@ -476,10 +629,19 @@
       "308.19",
       "308.99"
     ],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
     "teslamate/cars/$car/ideal_battery_range_km": [
       "321.87",
       "322.67",
@@ -487,10 +649,19 @@
       "324.28",
       "325.09"
     ],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.5152"],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.5152"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -501,13 +672,30 @@
         "longitude": 13.351
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.351"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true", "false"],
-    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.351"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
     "teslamate/cars/$car/rated_battery_range_km": [
       "313.82",
       "314.63",
@@ -515,21 +703,46 @@
       "316.24",
       "317.04"
     ],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:40.000Z",
       "2024-01-01T00:01:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "charging", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59", "60", "61"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "charging",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59",
+      "60",
+      "61"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/charging_without_charger_power.json
+++ b/test/fixtures/characterization/goldens/charging_without_charger_power.json
@@ -202,6 +202,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -234,6 +235,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -266,6 +268,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "325.09",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -298,6 +301,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "325.09",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -364,27 +368,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -397,58 +434,148 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60", "62", "60"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60",
+      "62",
+      "60"
+    ],
     "teslamate/cars/$car/charge_energy_added": [
       "0.0",
       "0.1",
@@ -457,12 +584,38 @@
       "0.4",
       "0.0"
     ],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["false", "true", "false"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16", "0", ""],
-    "teslamate/cars/$car/charger_phases": ["", "3", ""],
-    "teslamate/cars/$car/charger_power": ["", "11", "", "11", "0", ""],
-    "teslamate/cars/$car/charger_voltage": ["", "230", ""],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16",
+      "0",
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3",
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "",
+      "11",
+      "0",
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230",
+      ""
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Starting",
@@ -471,61 +624,121 @@
       "Unplugged",
       "Disconnected"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
     "teslamate/cars/$car/est_battery_range_km": [
       "305.78",
       "306.58",
       "308.99",
       "305.78"
     ],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
     "teslamate/cars/$car/ideal_battery_range_km": [
       "321.87",
       "322.67",
       "325.09",
       "321.87"
     ],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true", "false"],
-    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
     "teslamate/cars/$car/rated_battery_range_km": [
       "313.82",
       "314.63",
       "317.04",
       "313.82"
     ],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:40.000Z",
       "2024-01-01T00:01:00.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "charging", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59", "61", "59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "charging",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59",
+      "61",
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_api_error.json
+++ b/test/fixtures/characterization/goldens/driving_api_error.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -240,6 +244,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -272,6 +277,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -313,27 +319,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -346,74 +385,199 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false", "true", "false"],
-    "teslamate/cars/$car/is_user_present": ["false", "true", "false"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false",
+      "true",
+      "false"
+    ],
     "teslamate/cars/$car/latitude": [
       "52.514521",
       "52.516",
@@ -443,7 +607,11 @@
         "longitude": 13.3567
       }
     ],
-    "teslamate/cars/$car/locked": ["true", "false", "true"],
+    "teslamate/cars/$car/locked": [
+      "true",
+      "false",
+      "true"
+    ],
     "teslamate/cars/$car/longitude": [
       "13.350144",
       "13.3525",
@@ -451,7 +619,9 @@
       "13.3565",
       "13.3567"
     ],
-    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
     "teslamate/cars/$car/odometer": [
       "16093.44",
       "16093.6",
@@ -459,25 +629,63 @@
       "16094.0",
       "16094.02"
     ],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", ""],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:05.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:40.000Z"
     ],
-    "teslamate/cars/$car/speed": ["80", "89", "64"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "80",
+      "89",
+      "64"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_connection_loss.json
+++ b/test/fixtures/characterization/goldens/driving_connection_loss.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -240,6 +244,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -272,6 +277,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -313,27 +319,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -346,74 +385,199 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false", "true", "false"],
-    "teslamate/cars/$car/is_user_present": ["false", "true", "false"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false",
+      "true",
+      "false"
+    ],
     "teslamate/cars/$car/latitude": [
       "52.514521",
       "52.516",
@@ -443,7 +607,11 @@
         "longitude": 13.3567
       }
     ],
-    "teslamate/cars/$car/locked": ["true", "false", "true"],
+    "teslamate/cars/$car/locked": [
+      "true",
+      "false",
+      "true"
+    ],
     "teslamate/cars/$car/longitude": [
       "13.350144",
       "13.3525",
@@ -451,7 +619,9 @@
       "13.3565",
       "13.3567"
     ],
-    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
     "teslamate/cars/$car/odometer": [
       "16093.44",
       "16093.6",
@@ -459,25 +629,63 @@
       "16094.0",
       "16094.02"
     ],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", ""],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:05.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:40.000Z"
     ],
-    "teslamate/cars/$car/speed": ["80", "89", "64"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "80",
+      "89",
+      "64"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_direct_transition.json
+++ b/test/fixtures/characterization/goldens/driving_direct_transition.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -249,27 +253,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -282,75 +319,201 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["true", "false"],
-    "teslamate/cars/$car/is_user_present": ["true", "false"],
-    "teslamate/cars/$car/latitude": ["52.516", "52.5161"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.516",
+      "52.5161"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.516,
@@ -361,29 +524,74 @@
         "longitude": 13.3526
       }
     ],
-    "teslamate/cars/$car/locked": ["false", "true"],
-    "teslamate/cars/$car/longitude": ["13.3525", "13.3526"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.47", "16093.49"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["N", ""],
+    "teslamate/cars/$car/locked": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.3525",
+      "13.3526"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.47",
+      "16093.49"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "N",
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:20.000Z"
     ],
-    "teslamate/cars/$car/speed": ["0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_direct_transition_repeat.json
+++ b/test/fixtures/characterization/goldens/driving_direct_transition_repeat.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -240,6 +244,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -272,6 +277,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -313,27 +319,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -346,75 +385,201 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["true", "false"],
-    "teslamate/cars/$car/is_user_present": ["true", "false"],
-    "teslamate/cars/$car/latitude": ["52.516", "52.5161"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.516",
+      "52.5161"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.516,
@@ -425,29 +590,74 @@
         "longitude": 13.3526
       }
     ],
-    "teslamate/cars/$car/locked": ["false", "true"],
-    "teslamate/cars/$car/longitude": ["13.3525", "13.3526"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.47", "16093.49"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["N", ""],
+    "teslamate/cars/$car/locked": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.3525",
+      "13.3526"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.47",
+      "16093.49"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "N",
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:20.000Z"
     ],
-    "teslamate/cars/$car/speed": ["0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_empty_drive_state.json
+++ b/test/fixtures/characterization/goldens/driving_empty_drive_state.json
@@ -81,6 +81,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -113,6 +114,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -145,6 +147,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -186,27 +189,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -219,75 +255,199 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["true"],
-    "teslamate/cars/$car/is_user_present": ["true"],
-    "teslamate/cars/$car/latitude": ["52.516", "52.5165"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "true"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "true"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.516",
+      "52.5165"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.516,
@@ -298,28 +458,70 @@
         "longitude": 13.353
       }
     ],
-    "teslamate/cars/$car/locked": ["false"],
-    "teslamate/cars/$car/longitude": ["13.3525", "13.353"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.46", "16093.6"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["15"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["D"],
+    "teslamate/cars/$car/locked": [
+      "false"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.3525",
+      "13.353"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.46",
+      "16093.6"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "15"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "D"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:10.000Z"
     ],
-    "teslamate/cars/$car/speed": ["8", "80"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "8",
+      "80"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_full_drive.json
+++ b/test/fixtures/characterization/goldens/driving_full_drive.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -240,6 +244,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -272,6 +277,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -313,27 +319,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -346,75 +385,203 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["true", "false"],
-    "teslamate/cars/$car/is_user_present": ["true", "false"],
-    "teslamate/cars/$car/latitude": ["52.516", "52.5185", "52.519", "52.5192"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.516",
+      "52.5185",
+      "52.519",
+      "52.5192"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.516,
@@ -433,39 +600,82 @@
         "longitude": 13.3567
       }
     ],
-    "teslamate/cars/$car/locked": ["false", "true"],
+    "teslamate/cars/$car/locked": [
+      "false",
+      "true"
+    ],
     "teslamate/cars/$car/longitude": [
       "13.3525",
       "13.356",
       "13.3565",
       "13.3567"
     ],
-    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
     "teslamate/cars/$car/odometer": [
       "16093.71",
       "16093.91",
       "16093.92",
       "16093.94"
     ],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["D", "N", "R", ""],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "D",
+      "N",
+      "R",
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:40.000Z"
     ],
-    "teslamate/cars/$car/speed": ["97", "48", "-8"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "97",
+      "48",
+      "-8"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_geofence.json
+++ b/test/fixtures/characterization/goldens/driving_geofence.json
@@ -125,6 +125,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -157,6 +158,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -189,6 +191,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -221,6 +224,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -253,6 +257,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -285,6 +290,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -326,27 +332,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -359,74 +398,199 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": ["Tiergarten", "", "Tiergarten"],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["true", "false"],
-    "teslamate/cars/$car/is_user_present": ["true", "false"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      "Tiergarten",
+      "",
+      "Tiergarten"
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "true",
+      "false"
+    ],
     "teslamate/cars/$car/latitude": [
       "52.51455",
       "52.5185",
@@ -451,39 +615,81 @@
         "longitude": 13.35012
       }
     ],
-    "teslamate/cars/$car/locked": ["false", "true"],
+    "teslamate/cars/$car/locked": [
+      "false",
+      "true"
+    ],
     "teslamate/cars/$car/longitude": [
       "13.35018",
       "13.356",
       "13.353",
       "13.35012"
     ],
-    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
     "teslamate/cars/$car/odometer": [
       "16093.46",
       "16093.76",
       "16094.0",
       "16094.24"
     ],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["D", "P"],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "D",
+      "P"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:40.000Z"
     ],
-    "teslamate/cars/$car/speed": ["48", "72", "48", "0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "48",
+      "72",
+      "48",
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_offline_15min_new_drive.json
+++ b/test/fixtures/characterization/goldens/driving_offline_15min_new_drive.json
@@ -139,6 +139,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -171,6 +172,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -203,6 +205,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -235,6 +238,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -267,6 +271,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -299,6 +304,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -331,6 +337,7 @@
         "id": "position_7",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -397,27 +404,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -430,74 +470,202 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["20", "19"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["289.68", "273.59"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87", "305.78"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false", "true", "false"],
-    "teslamate/cars/$car/is_user_present": ["false", "true", "false"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "20",
+      "19"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "289.68",
+      "273.59"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87",
+      "305.78"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false",
+      "true",
+      "false"
+    ],
     "teslamate/cars/$car/latitude": [
       "52.514521",
       "52.516",
@@ -527,7 +695,11 @@
         "longitude": 13.371
       }
     ],
-    "teslamate/cars/$car/locked": ["true", "false", "true"],
+    "teslamate/cars/$car/locked": [
+      "true",
+      "false",
+      "true"
+    ],
     "teslamate/cars/$car/longitude": [
       "13.350144",
       "13.3525",
@@ -535,7 +707,9 @@
       "13.37",
       "13.371"
     ],
-    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
     "teslamate/cars/$car/odometer": [
       "16093.44",
       "16093.52",
@@ -543,13 +717,32 @@
       "16093.58",
       "16093.6"
     ],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["305.78", "289.68"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", ""],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "305.78",
+      "289.68"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
@@ -557,8 +750,13 @@
       "2024-01-01T00:16:11.001Z",
       "2024-01-01T00:16:11.003000Z"
     ],
-    "teslamate/cars/$car/speed": ["48", "32"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/speed": [
+      "48",
+      "32"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
     "teslamate/cars/$car/state": [
       "online",
       "driving",
@@ -568,10 +766,21 @@
       "online",
       "asleep"
     ],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["19", "18"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "19",
+      "18"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_offline_4min_continue.json
+++ b/test/fixtures/characterization/goldens/driving_offline_4min_continue.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -240,6 +244,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -272,6 +277,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -313,27 +319,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -346,75 +385,206 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["20", "19"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["289.68", "273.59"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87", "305.78"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["true", "false"],
-    "teslamate/cars/$car/is_user_present": ["true", "false"],
-    "teslamate/cars/$car/latitude": ["52.516", "52.5162", "52.53", "52.531"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "20",
+      "19"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "289.68",
+      "273.59"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87",
+      "305.78"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.516",
+      "52.5162",
+      "52.53",
+      "52.531"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.516,
@@ -433,34 +603,81 @@
         "longitude": 13.371
       }
     ],
-    "teslamate/cars/$car/locked": ["false", "true"],
-    "teslamate/cars/$car/longitude": ["13.3525", "13.3527", "13.37", "13.371"],
-    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/locked": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.3525",
+      "13.3527",
+      "13.37",
+      "13.371"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
     "teslamate/cars/$car/odometer": [
       "16093.52",
       "16093.55",
       "16093.58",
       "16093.6"
     ],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["305.78", "289.68"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["D", ""],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "305.78",
+      "289.68"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "D",
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:04:11.000Z"
     ],
-    "teslamate/cars/$car/speed": ["48", "32"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["19", "18"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "48",
+      "32"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "19",
+      "18"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_offline_sleep_timeout.json
+++ b/test/fixtures/characterization/goldens/driving_offline_sleep_timeout.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -224,27 +227,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -257,75 +293,199 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["20"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["289.68"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["true"],
-    "teslamate/cars/$car/is_user_present": ["true"],
-    "teslamate/cars/$car/latitude": ["52.516", "52.5162"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "20"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "289.68"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "true"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "true"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.516",
+      "52.5162"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.516,
@@ -336,29 +496,71 @@
         "longitude": 13.3527
       }
     ],
-    "teslamate/cars/$car/locked": ["false"],
-    "teslamate/cars/$car/longitude": ["13.3525", "13.3527"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.52", "16093.55"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["15"],
-    "teslamate/cars/$car/rated_battery_range_km": ["305.78"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["D"],
+    "teslamate/cars/$car/locked": [
+      "false"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.3525",
+      "13.3527"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.52",
+      "16093.55"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "15"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "305.78"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "D"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:10.003000Z"
     ],
-    "teslamate/cars/$car/speed": ["48"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["19"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "48"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "19"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_offline_soc_gain_charge.json
+++ b/test/fixtures/characterization/goldens/driving_offline_soc_gain_charge.json
@@ -209,6 +209,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -241,6 +242,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -273,6 +275,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -305,6 +308,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -337,6 +341,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "482.80",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -369,6 +374,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "482.80",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -401,6 +407,7 @@
         "id": "position_7",
         "ideal_battery_range_km": "482.80",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -433,6 +440,7 @@
         "id": "position_8",
         "ideal_battery_range_km": "482.80",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -474,27 +482,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -507,75 +548,208 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["20", "80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0", "45.0", "0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["289.68", "450.62"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87", "482.8"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["true", "false"],
-    "teslamate/cars/$car/is_user_present": ["true", "false"],
-    "teslamate/cars/$car/latitude": ["52.516", "52.5162", "52.53", "52.531"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "20",
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0",
+      "45.0",
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "289.68",
+      "450.62"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87",
+      "482.8"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.516",
+      "52.5162",
+      "52.53",
+      "52.531"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.516,
@@ -594,30 +768,62 @@
         "longitude": 13.371
       }
     ],
-    "teslamate/cars/$car/locked": ["false", "true"],
-    "teslamate/cars/$car/longitude": ["13.3525", "13.3527", "13.37", "13.371"],
-    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/locked": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.3525",
+      "13.3527",
+      "13.37",
+      "13.371"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
     "teslamate/cars/$car/odometer": [
       "16093.52",
       "16093.55",
       "16093.58",
       "16093.6"
     ],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["305.78", "466.71"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["D", ""],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "305.78",
+      "466.71"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "D",
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:05:10.001Z",
       "2024-01-01T00:05:11.001Z"
     ],
-    "teslamate/cars/$car/speed": ["48", "32"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/speed": [
+      "48",
+      "32"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
     "teslamate/cars/$car/state": [
       "online",
       "driving",
@@ -626,10 +832,21 @@
       "driving",
       "online"
     ],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["19", "79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "19",
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_offline_soc_gain_charge_plugged.json
+++ b/test/fixtures/characterization/goldens/driving_offline_soc_gain_charge_plugged.json
@@ -250,6 +250,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -282,6 +283,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -314,6 +316,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -346,6 +349,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -378,6 +382,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "482.80",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -410,6 +415,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "482.80",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -442,6 +448,7 @@
         "id": "position_7",
         "ideal_battery_range_km": "482.80",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -474,6 +481,7 @@
         "id": "position_8",
         "ideal_battery_range_km": "482.80",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -522,27 +530,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -555,82 +596,219 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["20", "80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0", "", "45.0"],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["true"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16"],
-    "teslamate/cars/$car/charger_phases": ["", "3"],
-    "teslamate/cars/$car/charger_power": ["", "11", "0"],
-    "teslamate/cars/$car/charger_voltage": ["", "230"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "20",
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0",
+      "",
+      "45.0"
+    ],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "true"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16"
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3"
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0"
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230"
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Charging",
       "Complete",
       "Unplugged"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["289.68", "450.62"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87", "482.8"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["true"],
-    "teslamate/cars/$car/is_user_present": ["true"],
-    "teslamate/cars/$car/latitude": ["52.516", "52.5162", "52.53"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "289.68",
+      "450.62"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87",
+      "482.8"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "true"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "true"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.516",
+      "52.5162",
+      "52.53"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.516,
@@ -645,17 +823,47 @@
         "longitude": 13.37
       }
     ],
-    "teslamate/cars/$car/locked": ["false"],
-    "teslamate/cars/$car/longitude": ["13.3525", "13.3527", "13.37"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.52", "16093.55", "16093.58"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true"],
-    "teslamate/cars/$car/power": ["15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["305.78", "466.71"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["D", ""],
+    "teslamate/cars/$car/locked": [
+      "false"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.3525",
+      "13.3527",
+      "13.37"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.52",
+      "16093.55",
+      "16093.58"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/power": [
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "305.78",
+      "466.71"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "D",
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:10.000Z",
@@ -663,8 +871,12 @@
       "2024-01-01T00:05:20.001Z",
       "2024-01-01T00:05:30.003000Z"
     ],
-    "teslamate/cars/$car/speed": ["48"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/speed": [
+      "48"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
     "teslamate/cars/$car/state": [
       "online",
       "driving",
@@ -674,10 +886,21 @@
       "online",
       "asleep"
     ],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["19", "79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "19",
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_offline_timeout.json
+++ b/test/fixtures/characterization/goldens/driving_offline_timeout.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -224,27 +227,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -257,75 +293,199 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["20"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["289.68"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["true"],
-    "teslamate/cars/$car/is_user_present": ["true"],
-    "teslamate/cars/$car/latitude": ["52.516", "52.5162"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "20"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "289.68"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "true"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "true"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.516",
+      "52.5162"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.516,
@@ -336,29 +496,71 @@
         "longitude": 13.3527
       }
     ],
-    "teslamate/cars/$car/locked": ["false"],
-    "teslamate/cars/$car/longitude": ["13.3525", "13.3527"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.52", "16093.55"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["15"],
-    "teslamate/cars/$car/rated_battery_range_km": ["305.78"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["D"],
+    "teslamate/cars/$car/locked": [
+      "false"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.3525",
+      "13.3527"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.52",
+      "16093.55"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "15"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "305.78"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "D"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:16:10.020000Z"
     ],
-    "teslamate/cars/$car/speed": ["48"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "offline"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["19"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "48"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "offline"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "19"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_shift_p_ends_drive.json
+++ b/test/fixtures/characterization/goldens/driving_shift_p_ends_drive.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -240,6 +244,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -281,27 +286,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -314,75 +352,202 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["true", "false"],
-    "teslamate/cars/$car/is_user_present": ["true", "false"],
-    "teslamate/cars/$car/latitude": ["52.516", "52.5165", "52.5166"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.516",
+      "52.5165",
+      "52.5166"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.516,
@@ -397,29 +562,78 @@
         "longitude": 13.3531
       }
     ],
-    "teslamate/cars/$car/locked": ["false", "true"],
-    "teslamate/cars/$car/longitude": ["13.3525", "13.353", "13.3531"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.47", "16093.57", "16093.58"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["D", "P"],
+    "teslamate/cars/$car/locked": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.3525",
+      "13.353",
+      "13.3531"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.47",
+      "16093.57",
+      "16093.58"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "D",
+      "P"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:30.000Z"
     ],
-    "teslamate/cars/$car/speed": ["8", "24", "0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "8",
+      "24",
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_shift_p_no_drive.json
+++ b/test/fixtures/characterization/goldens/driving_shift_p_no_drive.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,100 +161,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["P"],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:10.000000Z"],
-    "teslamate/cars/$car/speed": ["0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "P"
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:10.000000Z"
+    ],
+    "teslamate/cars/$car/speed": [
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_stream_reconnect_offline.json
+++ b/test/fixtures/characterization/goldens/driving_stream_reconnect_offline.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -240,6 +244,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -272,6 +277,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -338,27 +344,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -371,74 +410,202 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["20", "19"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["289.68", "273.59"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87", "305.78"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false", "true", "false"],
-    "teslamate/cars/$car/is_user_present": ["false", "true", "false"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "20",
+      "19"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "289.68",
+      "273.59"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87",
+      "305.78"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false",
+      "true",
+      "false"
+    ],
     "teslamate/cars/$car/latitude": [
       "52.514521",
       "52.516",
@@ -468,7 +635,11 @@
         "longitude": 13.371
       }
     ],
-    "teslamate/cars/$car/locked": ["true", "false", "true"],
+    "teslamate/cars/$car/locked": [
+      "true",
+      "false",
+      "true"
+    ],
     "teslamate/cars/$car/longitude": [
       "13.350144",
       "13.3525",
@@ -476,7 +647,9 @@
       "13.37",
       "13.371"
     ],
-    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
     "teslamate/cars/$car/odometer": [
       "16093.44",
       "16093.52",
@@ -484,21 +657,45 @@
       "16093.58",
       "16093.6"
     ],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["305.78", "289.68"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", ""],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "305.78",
+      "289.68"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:04:11.001Z",
       "2024-01-01T00:04:11.003000Z"
     ],
-    "teslamate/cars/$car/speed": ["48", "32"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/speed": [
+      "48",
+      "32"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
     "teslamate/cars/$car/state": [
       "online",
       "driving",
@@ -507,10 +704,21 @@
       "online",
       "asleep"
     ],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["19", "18"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "19",
+      "18"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_stream_reconnect_unavailable.json
+++ b/test/fixtures/characterization/goldens/driving_stream_reconnect_unavailable.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -240,6 +244,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -272,6 +277,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -338,27 +344,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -371,74 +410,202 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["20", "19"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["289.68", "273.59"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87", "305.78"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false", "true", "false"],
-    "teslamate/cars/$car/is_user_present": ["false", "true", "false"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "20",
+      "19"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "289.68",
+      "273.59"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87",
+      "305.78"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false",
+      "true",
+      "false"
+    ],
     "teslamate/cars/$car/latitude": [
       "52.514521",
       "52.516",
@@ -468,7 +635,11 @@
         "longitude": 13.371
       }
     ],
-    "teslamate/cars/$car/locked": ["true", "false", "true"],
+    "teslamate/cars/$car/locked": [
+      "true",
+      "false",
+      "true"
+    ],
     "teslamate/cars/$car/longitude": [
       "13.350144",
       "13.3525",
@@ -476,7 +647,9 @@
       "13.37",
       "13.371"
     ],
-    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
     "teslamate/cars/$car/odometer": [
       "16093.44",
       "16093.52",
@@ -484,26 +657,66 @@
       "16093.58",
       "16093.6"
     ],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["305.78", "289.68"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", ""],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "305.78",
+      "289.68"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:04:11.000Z",
       "2024-01-01T00:04:11.002000Z"
     ],
-    "teslamate/cars/$car/speed": ["48", "32"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["19", "18"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "48",
+      "32"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "19",
+      "18"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/driving_without_odometer.json
+++ b/test/fixtures/characterization/goldens/driving_without_odometer.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -117,6 +119,7 @@
         "id": "position_3",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -149,6 +152,7 @@
         "id": "position_4",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -181,6 +185,7 @@
         "id": "position_5",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -213,6 +218,7 @@
         "id": "position_6",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -254,27 +260,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -287,65 +326,169 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/latitude": ["0.1", "0.2"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "0.1",
+      "0.2"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 0.1,
@@ -356,20 +499,48 @@
         "longitude": 0.2
       }
     ],
-    "teslamate/cars/$car/longitude": ["0.1", "0.2"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/plugged_in": ["true"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/shift_state": ["D", "N", "R", ""],
+    "teslamate/cars/$car/longitude": [
+      "0.1",
+      "0.2"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "true"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "D",
+      "N",
+      "R",
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.001000Z",
       "2024-01-01T00:00:00.001Z",
       "2024-01-01T00:00:00.004Z"
     ],
-    "teslamate/cars/$car/speed": ["97", "48", "-8"],
-    "teslamate/cars/$car/state": ["online", "driving", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""],
-    "teslamate/cars/$car/version": [""]
+    "teslamate/cars/$car/speed": [
+      "97",
+      "48",
+      "-8"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      ""
+    ],
+    "teslamate/cars/$car/version": [
+      ""
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_car_type_nil.json
+++ b/test/fixtures/characterization/goldens/identity_car_type_nil.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,98 +161,257 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["100D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "100D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_cybertruck.json
+++ b/test/fixtures/characterization/goldens/identity_cybertruck.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["Cybertruck"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["AWD"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "Cybertruck"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "AWD"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_lychee_100d.json
+++ b/test/fixtures/characterization/goldens/identity_lychee_100d.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["S"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["100D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "S"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "100D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_lychee_p100d.json
+++ b/test/fixtures/characterization/goldens/identity_lychee_p100d.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["S"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["P100D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "S"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "P100D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_model3_50_invalid_vin.json
+++ b/test/fixtures/characterization/goldens/identity_model3_50_invalid_vin.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["50"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "50"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_model3_50_my2019.json
+++ b/test/fixtures/characterization/goldens/identity_model3_50_my2019.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["50"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "50"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_model3_50_my2022.json
+++ b/test/fixtures/characterization/goldens/identity_model3_50_my2022.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["50"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "50"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_model3_62.json
+++ b/test/fixtures/characterization/goldens/identity_model3_62.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["62"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "62"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_model3_74.json
+++ b/test/fixtures/characterization/goldens/identity_model3_74.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_model3_p74d.json
+++ b/test/fixtures/characterization/goldens/identity_model3_p74d.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["P74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "P74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_models2_100d.json
+++ b/test/fixtures/characterization/goldens/identity_models2_100d.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["S"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["100D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "S"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "100D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_models_100d.json
+++ b/test/fixtures/characterization/goldens/identity_models_100d.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["S"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["100D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "S"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "100D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_modelx_100d.json
+++ b/test/fixtures/characterization/goldens/identity_modelx_100d.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["X"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["100D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "X"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "100D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_modely_50.json
+++ b/test/fixtures/characterization/goldens/identity_modely_50.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["Y"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["50"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "Y"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "50"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_modely_74.json
+++ b/test/fixtures/characterization/goldens/identity_modely_74.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["Y"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "Y"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_modely_74d.json
+++ b/test/fixtures/characterization/goldens/identity_modely_74d.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["Y"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "Y"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_modely_p74d.json
+++ b/test/fixtures/characterization/goldens/identity_modely_p74d.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["Y"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["P74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "Y"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "P74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_tamarind_100d.json
+++ b/test/fixtures/characterization/goldens/identity_tamarind_100d.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["X"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["100D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "X"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "100D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_tamarind_p100d.json
+++ b/test/fixtures/characterization/goldens/identity_tamarind_p100d.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["X"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["P100D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "X"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "P100D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_trim_nil.json
+++ b/test/fixtures/characterization/goldens/identity_trim_nil.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      ""
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/identity_unknown_car_type.json
+++ b/test/fixtures/characterization/goldens/identity_unknown_car_type.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,98 +161,257 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.15"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.15"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["100D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "100D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/pre_online_fake.json
+++ b/test/fixtures/characterization/goldens/pre_online_fake.json
@@ -59,27 +59,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -92,70 +125,185 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.001000Z"],
-    "teslamate/cars/$car/state": ["asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""]
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.001000Z"
+    ],
+    "teslamate/cars/$car/state": [
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      ""
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/pre_online_idle_then_fake_frame.json
+++ b/test/fixtures/characterization/goldens/pre_online_idle_then_fake_frame.json
@@ -59,27 +59,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -92,70 +125,185 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.001000Z"],
-    "teslamate/cars/$car/state": ["asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""]
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.001000Z"
+    ],
+    "teslamate/cars/$car/state": [
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      ""
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/pre_online_idle_then_real_frame.json
+++ b/test/fixtures/characterization/goldens/pre_online_idle_then_real_frame.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -107,27 +108,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -140,102 +174,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:40.001000Z",
       "2024-01-01T00:00:40.003Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["asleep", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["", "74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "asleep",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "",
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/pre_online_inactive.json
+++ b/test/fixtures/characterization/goldens/pre_online_inactive.json
@@ -59,27 +59,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -92,70 +125,185 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.001000Z"],
-    "teslamate/cars/$car/state": ["asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""]
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.001000Z"
+    ],
+    "teslamate/cars/$car/state": [
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      ""
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/pre_online_no_frame.json
+++ b/test/fixtures/characterization/goldens/pre_online_no_frame.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -107,27 +108,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -140,102 +174,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:40.001000Z",
       "2024-01-01T00:00:40.004Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["asleep", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["", "74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "asleep",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "",
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/pre_online_real.json
+++ b/test/fixtures/characterization/goldens/pre_online_real.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -107,27 +108,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -140,102 +174,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:40.001000Z",
       "2024-01-01T00:00:40.003Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["asleep", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["", "74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "asleep",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "",
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/pre_online_startup_restore.json
+++ b/test/fixtures/characterization/goldens/pre_online_startup_restore.json
@@ -40,6 +40,7 @@
         "ideal_battery_range_km": 315.06,
         "inside_temp": "20.1",
         "install_perc": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_preconditioning": null,
         "is_user_present": null,
@@ -142,6 +143,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "315.06",
         "inside_temp": "20.1",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": false,
         "is_rear_defroster_on": false,
@@ -174,6 +176,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -221,27 +224,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -254,99 +290,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:40.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:40.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/stale_timestamp_offline_resume.json
+++ b/test/fixtures/characterization/goldens/stale_timestamp_offline_resume.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -108,27 +109,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -141,103 +175,265 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.001000Z",
       "2024-01-01T00:00:00.002Z",
       "2024-01-01T00:00:20.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["offline", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["", "74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "offline",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "",
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/stream_frame_after_timestampless_payload.json
+++ b/test/fixtures/characterization/goldens/stream_frame_after_timestampless_payload.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -240,6 +244,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -298,27 +303,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -331,76 +369,206 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80", "60", "80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/elevation": ["1", "2"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.52", "52.53"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80",
+      "60",
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/elevation": [
+      "1",
+      "2"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.52",
+      "52.53"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -415,30 +583,81 @@
         "longitude": 13.37
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.36", "13.37"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44", "16093.6", "16093.92"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "5", "10", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", "P"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.36",
+      "13.37"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44",
+      "16093.6",
+      "16093.92"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "5",
+      "10",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      "P"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:20.000Z",
       "2024-01-01T00:00:50.000Z",
       "2024-01-01T00:00:50.002000Z"
     ],
-    "teslamate/cars/$car/speed": ["16", "24"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "16",
+      "24"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/stream_stale_after_usage.json
+++ b/test/fixtures/characterization/goldens/stream_stale_after_usage.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -90,6 +91,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -137,27 +139,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -170,102 +205,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/streaming_charge_detect.json
+++ b/test/fixtures/characterization/goldens/streaming_charge_detect.json
@@ -178,6 +178,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -210,6 +211,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -242,6 +244,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "324.28",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -274,6 +277,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "324.28",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -340,27 +344,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -373,118 +410,291 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": ["", "0.1", "0.2"],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["true"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16", ""],
-    "teslamate/cars/$car/charger_phases": ["", "3", ""],
-    "teslamate/cars/$car/charger_power": ["", "11", "0"],
-    "teslamate/cars/$car/charger_voltage": ["", "230", ""],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "",
+      "0.1",
+      "0.2"
+    ],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "true"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16",
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3",
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0"
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230",
+      ""
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Charging",
       "Stopped"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95", "306.58", "308.19"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95",
+      "306.58",
+      "308.19"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
     "teslamate/cars/$car/ideal_battery_range_km": [
       "402.34",
       "322.67",
       "324.28"
     ],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true"],
-    "teslamate/cars/$car/power": ["0"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
     "teslamate/cars/$car/rated_battery_range_km": [
       "386.24",
       "314.63",
       "316.24"
     ],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:20.000Z",
       "2024-01-01T00:00:40.000Z",
       "2024-01-01T00:00:40.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "charging", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "charging",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/streaming_drive.json
+++ b/test/fixtures/characterization/goldens/streaming_drive.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -240,6 +244,7 @@
         "id": "position_5",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -272,6 +277,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -304,6 +310,7 @@
         "id": "position_7",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -362,27 +369,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -395,75 +435,201 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/elevation": ["1", "2", "3", "4"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/elevation": [
+      "1",
+      "2",
+      "3",
+      "4"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
     "teslamate/cars/$car/latitude": [
       "52.514521",
       "52.52",
@@ -493,7 +659,9 @@
         "longitude": 13.385
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
     "teslamate/cars/$car/longitude": [
       "13.350144",
       "13.36",
@@ -501,7 +669,9 @@
       "13.38",
       "13.385"
     ],
-    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
     "teslamate/cars/$car/odometer": [
       "16093.44",
       "16093.6",
@@ -509,26 +679,72 @@
       "16094.24",
       "16094.41"
     ],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "5", "10", "2", "1", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", "N", "R", "P"],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "5",
+      "10",
+      "2",
+      "1",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      "N",
+      "R",
+      "P"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:20.000Z",
       "2024-01-01T00:01:10.000Z",
       "2024-01-01T00:01:10.002000Z"
     ],
-    "teslamate/cars/$car/speed": ["16", "24", "32", "5", "0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "16",
+      "24",
+      "32",
+      "5",
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/streaming_geofence.json
+++ b/test/fixtures/characterization/goldens/streaming_geofence.json
@@ -137,6 +137,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -169,6 +170,7 @@
         "id": "position_2",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -201,6 +203,7 @@
         "id": "position_3",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -233,6 +236,7 @@
         "id": "position_4",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -265,6 +269,7 @@
         "id": "position_5",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -297,6 +302,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -329,6 +335,7 @@
         "id": "position_7",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -387,27 +394,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -420,76 +460,204 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/elevation": ["10"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": ["Zone A", "Zone B", "", "Zone A"],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.52"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/elevation": [
+      "10"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      "Zone A",
+      "Zone B",
+      "",
+      "Zone A"
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.52"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.52,
@@ -508,9 +676,18 @@
         "longitude": 13.4
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.4", "13.406", "13.43", "13.4"],
-    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.4",
+      "13.406",
+      "13.43",
+      "13.4"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
     "teslamate/cars/$car/odometer": [
       "16093.44",
       "16093.6",
@@ -518,26 +695,64 @@
       "16095.69",
       "16097.3"
     ],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "5", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", "P"],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "5",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      "P"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:50.000Z",
       "2024-01-01T00:00:50.002000Z"
     ],
-    "teslamate/cars/$car/speed": ["16", "0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "16",
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/streaming_stale_fetch.json
+++ b/test/fixtures/characterization/goldens/streaming_stale_fetch.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -240,6 +244,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -298,27 +303,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -331,76 +369,203 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/elevation": ["10"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.52", "52.53"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/elevation": [
+      "10"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.52",
+      "52.53"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -415,30 +580,82 @@
         "longitude": 13.37
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.36", "13.37"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44", "16093.6", "16093.92"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "5", "6", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", "P"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.36",
+      "13.37"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44",
+      "16093.6",
+      "16093.92"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "5",
+      "6",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      "P"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:40.000Z",
       "2024-01-01T00:00:40.002000Z"
     ],
-    "teslamate/cars/$car/speed": ["16", "19", "0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "16",
+      "19",
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/streaming_stale_frame.json
+++ b/test/fixtures/characterization/goldens/streaming_stale_frame.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -111,27 +112,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -144,102 +178,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/streaming_suspend_inactive.json
+++ b/test/fixtures/characterization/goldens/streaming_suspend_inactive.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -90,6 +91,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -148,27 +150,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -181,103 +216,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/streaming_suspend_resume_charge.json
+++ b/test/fixtures/characterization/goldens/streaming_suspend_resume_charge.json
@@ -159,6 +159,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -191,6 +192,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -223,6 +225,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -255,6 +258,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -287,6 +291,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -353,27 +358,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -386,98 +424,258 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": ["", "0.1"],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["true"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16", ""],
-    "teslamate/cars/$car/charger_phases": ["", "3", ""],
-    "teslamate/cars/$car/charger_power": ["", "11", "0"],
-    "teslamate/cars/$car/charger_voltage": ["", "230", ""],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "",
+      "0.1"
+    ],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "true"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16",
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3",
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0"
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230",
+      ""
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Charging",
       "Stopped"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95", "306.58"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34", "322.67"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95",
+      "306.58"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34",
+      "322.67"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24", "314.63"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24",
+      "314.63"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
@@ -485,7 +683,9 @@
       "2024-01-01T00:00:40.000Z",
       "2024-01-01T00:00:40.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
     "teslamate/cars/$car/state": [
       "online",
       "suspended",
@@ -493,10 +693,20 @@
       "online",
       "asleep"
     ],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/streaming_suspend_resume_drive.json
+++ b/test/fixtures/characterization/goldens/streaming_suspend_resume_drive.json
@@ -117,6 +117,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -149,6 +150,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -181,6 +183,7 @@
         "id": "position_3",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -213,6 +216,7 @@
         "id": "position_4",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -245,6 +249,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -277,6 +282,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -335,27 +341,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -368,76 +407,203 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/elevation": ["50"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.52", "52.53"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/elevation": [
+      "50"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.52",
+      "52.53"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -452,17 +618,47 @@
         "longitude": 13.37
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.36", "13.37"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44", "16093.76", "16094.24"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "5", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", "P"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.36",
+      "13.37"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44",
+      "16093.76",
+      "16094.24"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "5",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      "P"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
@@ -470,8 +666,13 @@
       "2024-01-01T00:00:50.000Z",
       "2024-01-01T00:00:50.002000Z"
     ],
-    "teslamate/cars/$car/speed": ["80", "0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/speed": [
+      "80",
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
     "teslamate/cars/$car/state": [
       "online",
       "suspended",
@@ -479,10 +680,20 @@
       "online",
       "asleep"
     ],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/streaming_suspend_stale_frame.json
+++ b/test/fixtures/characterization/goldens/streaming_suspend_stale_frame.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -90,6 +91,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -148,27 +150,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -181,103 +216,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:10.001000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/streaming_update_disconnect.json
+++ b/test/fixtures/characterization/goldens/streaming_update_disconnect.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -158,27 +160,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -191,92 +226,237 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
@@ -289,13 +469,35 @@
         "latest_version": "2019.8.5"
       }
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "updating", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["true", "false"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1", "2019.8.4", "2019.8.5"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "updating",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1",
+      "2019.8.4",
+      "2019.8.5"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/streaming_vehicle_offline.json
+++ b/test/fixtures/characterization/goldens/streaming_vehicle_offline.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -111,27 +112,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -144,102 +178,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:00.003000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "offline"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "offline"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/summary_download_perc.json
+++ b/test/fixtures/characterization/goldens/summary_download_perc.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,108 +161,275 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/download_perc": ["100"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/download_perc": [
+      "100"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
     "teslamate/cars/$car/software_update": [
       {
         "installed_version": "2026.20.1",
         "latest_version": "2026.24.1"
       }
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["true"],
-    "teslamate/cars/$car/update_version": ["2026.24.1"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "true"
+    ],
+    "teslamate/cars/$car/update_version": [
+      "2026.24.1"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/summary_no_software_update.json
+++ b/test/fixtures/characterization/goldens/summary_no_software_update.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/summary_update_available.json
+++ b/test/fixtures/characterization/goldens/summary_update_available.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,107 +161,272 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
     "teslamate/cars/$car/software_update": [
       {
         "installed_version": "2026.20.1",
         "latest_version": "2026.24.1"
       }
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["true"],
-    "teslamate/cars/$car/update_version": ["2026.24.1"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "true"
+    ],
+    "teslamate/cars/$car/update_version": [
+      "2026.24.1"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/summary_update_downloading.json
+++ b/test/fixtures/characterization/goldens/summary_update_downloading.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,107 +161,272 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
     "teslamate/cars/$car/software_update": [
       {
         "installed_version": "2026.20.1",
         "latest_version": "2026.24.1"
       }
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["true"],
-    "teslamate/cars/$car/update_version": ["2026.24.1"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "true"
+    ],
+    "teslamate/cars/$car/update_version": [
+      "2026.24.1"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/summary_update_downloading_wifi_wait.json
+++ b/test/fixtures/characterization/goldens/summary_update_downloading_wifi_wait.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,107 +161,272 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
     "teslamate/cars/$car/software_update": [
       {
         "installed_version": "2026.20.1",
         "latest_version": "2026.24.1"
       }
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["true"],
-    "teslamate/cars/$car/update_version": ["2026.24.1"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "true"
+    ],
+    "teslamate/cars/$car/update_version": [
+      "2026.24.1"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/summary_update_empty_status.json
+++ b/test/fixtures/characterization/goldens/summary_update_empty_status.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,106 +161,269 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
     "teslamate/cars/$car/software_update": [
       {
         "installed_version": "2026.20.1",
         "latest_version": "2026.20.1"
       }
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["false"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "false"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/summary_update_installing.json
+++ b/test/fixtures/characterization/goldens/summary_update_installing.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -101,27 +102,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -134,94 +168,243 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/download_perc": ["100"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/install_perc": ["42"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/download_perc": [
+      "100"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/install_perc": [
+      "42"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z"
@@ -232,14 +415,33 @@
         "latest_version": "2026.24.1"
       }
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "updating"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["true"],
-    "teslamate/cars/$car/update_version": ["2026.24.1"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "updating"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "true"
+    ],
+    "teslamate/cars/$car/update_version": [
+      "2026.24.1"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/summary_update_scheduled.json
+++ b/test/fixtures/characterization/goldens/summary_update_scheduled.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,107 +161,272 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
     "teslamate/cars/$car/software_update": [
       {
         "installed_version": "2026.20.1",
         "latest_version": "2026.24.1"
       }
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["true"],
-    "teslamate/cars/$car/update_version": ["2026.24.1"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "true"
+    ],
+    "teslamate/cars/$car/update_version": [
+      "2026.24.1"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/summary_update_version_nil.json
+++ b/test/fixtures/characterization/goldens/summary_update_version_nil.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,100 +161,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["true"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "true"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_after_charging_complete.json
+++ b/test/fixtures/characterization/goldens/suspend_after_charging_complete.json
@@ -154,6 +154,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -186,6 +187,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -218,6 +220,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -250,6 +253,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -282,6 +286,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -348,27 +353,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -381,98 +419,256 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80", "60"],
-    "teslamate/cars/$car/charge_energy_added": ["", "1.5"],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["true"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16"],
-    "teslamate/cars/$car/charger_phases": ["", "3"],
-    "teslamate/cars/$car/charger_power": ["", "11", "0"],
-    "teslamate/cars/$car/charger_voltage": ["", "230"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80",
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "",
+      "1.5"
+    ],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "true"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16"
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3"
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0"
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230"
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Charging",
       "Complete"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95", "306.58"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34", "322.67"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95",
+      "306.58"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34",
+      "322.67"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24", "314.63"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24",
+      "314.63"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
@@ -480,7 +676,9 @@
       "2024-01-01T00:03:40.000Z",
       "2024-01-01T00:03:40.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
     "teslamate/cars/$car/state": [
       "online",
       "charging",
@@ -488,10 +686,21 @@
       "suspended",
       "asleep"
     ],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79", "59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79",
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_after_charging_complete_recharge.json
+++ b/test/fixtures/characterization/goldens/suspend_after_charging_complete_recharge.json
@@ -246,6 +246,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -278,6 +279,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -310,6 +312,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -342,6 +345,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -374,6 +378,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -406,6 +411,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -438,6 +444,7 @@
         "id": "position_7",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -470,6 +477,7 @@
         "id": "position_8",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -533,27 +541,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -566,65 +607,178 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80", "60"],
-    "teslamate/cars/$car/charge_energy_added": ["", "1.5", "2.0", "2.5"],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["true"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16"],
-    "teslamate/cars/$car/charger_phases": ["", "3"],
-    "teslamate/cars/$car/charger_power": ["", "11", "0", "11", "0"],
-    "teslamate/cars/$car/charger_voltage": ["", "230"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80",
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "",
+      "1.5",
+      "2.0",
+      "2.5"
+    ],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "true"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16"
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3"
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0",
+      "11",
+      "0"
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230"
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Charging",
@@ -632,34 +786,83 @@
       "Charging",
       "Complete"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95", "306.58"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34", "322.67"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95",
+      "306.58"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34",
+      "322.67"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24", "314.63"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24",
+      "314.63"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
@@ -668,7 +871,9 @@
       "2024-01-01T00:03:50.000Z",
       "2024-01-01T00:04:10.000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
     "teslamate/cars/$car/state": [
       "online",
       "charging",
@@ -677,10 +882,21 @@
       "charging",
       "online"
     ],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79", "59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79",
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_broadcast_locked.json
+++ b/test/fixtures/characterization/goldens/suspend_broadcast_locked.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true", "false", "true", "false", "true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true",
+      "false",
+      "true",
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_broadcast_sentry_mode.json
+++ b/test/fixtures/characterization/goldens/suspend_broadcast_sentry_mode.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,90 +161,231 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
     "teslamate/cars/$car/sentry_mode": [
       "false",
       "true",
@@ -218,14 +393,32 @@
       "true",
       "false"
     ],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle.json
+++ b/test/fixtures/characterization/goldens/suspend_idle.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -133,27 +135,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -166,103 +201,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:16:00.000Z",
       "2024-01-01T00:16:00.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_dog_mode.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_dog_mode.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -101,27 +102,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -134,103 +168,265 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/climate_keeper_mode": ["dog"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/climate_keeper_mode": [
+      "dog"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:16:00.003000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_doors_open.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_doors_open.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -101,27 +102,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -134,107 +168,277 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/doors_open": ["true"],
-    "teslamate/cars/$car/driver_front_door_open": ["false"],
-    "teslamate/cars/$car/driver_rear_door_open": ["false"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/doors_open": [
+      "true"
+    ],
+    "teslamate/cars/$car/driver_front_door_open": [
+      "false"
+    ],
+    "teslamate/cars/$car/driver_rear_door_open": [
+      "false"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/passenger_front_door_open": ["true"],
-    "teslamate/cars/$car/passenger_rear_door_open": ["false"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/passenger_front_door_open": [
+      "true"
+    ],
+    "teslamate/cars/$car/passenger_rear_door_open": [
+      "false"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:16:00.003000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_downloading_update.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_downloading_update.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -101,27 +102,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -134,93 +168,240 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/download_perc": ["10"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/download_perc": [
+      "10"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:16:00.003000Z"
@@ -231,14 +412,33 @@
         "latest_version": "2026.24.1"
       }
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["true"],
-    "teslamate/cars/$car/update_version": ["2026.24.1"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "true"
+    ],
+    "teslamate/cars/$car/update_version": [
+      "2026.24.1"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_power_usage.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_power_usage.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -101,27 +102,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -134,102 +168,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "5"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "5"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:16:00.003000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_preconditioning.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_preconditioning.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -101,27 +102,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -134,103 +168,265 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_preconditioning": ["true"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_preconditioning": [
+      "true"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:16:00.003000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_sentry_mode.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_sentry_mode.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -101,27 +102,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -134,102 +168,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false", "true"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:16:00.003000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_service_mode.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_service_mode.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -117,6 +119,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -165,27 +168,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -198,104 +234,269 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/service_mode": ["false", "true", "false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/service_mode": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:16:00.000Z",
       "2024-01-01T00:16:10.001000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_streaming.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_streaming.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -143,27 +145,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -176,103 +211,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:03:20.000Z",
       "2024-01-01T00:03:20.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_trunk_open.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_trunk_open.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -101,27 +102,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -134,104 +168,268 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/frunk_open": ["true"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/frunk_open": [
+      "true"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:16:00.003000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/trunk_open": ["false"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/trunk_open": [
+      "false"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_unlocked_required.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_unlocked_required.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -101,27 +102,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -134,102 +168,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true", "false"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:16:00.003000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_unlocked_required_service_mode.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_unlocked_required_service_mode.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -101,27 +102,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -134,103 +168,266 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true", "false"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/service_mode": ["true"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/service_mode": [
+      "true"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:16:00.003000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_unlocked_streaming.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_unlocked_streaming.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -117,6 +119,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -149,6 +152,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -207,27 +211,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -240,103 +277,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["false"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "false"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:03:20.000Z",
       "2024-01-01T00:03:40.001000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_user_present.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_user_present.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -101,27 +102,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -134,102 +168,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false", "true"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:16:00.003000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_idle_while_suspended_polls.json
+++ b/test/fixtures/characterization/goldens/suspend_idle_while_suspended_polls.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -117,6 +119,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -149,6 +152,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -181,6 +185,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -239,27 +244,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -272,85 +310,216 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
     "teslamate/cars/$car/outside_temp": [
       "10.0",
       "10.1",
@@ -359,23 +528,51 @@
       "10.8",
       "10.9"
     ],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:03:20.000Z",
       "2024-01-01T00:03:50.001000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_after_charging_complete.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_after_charging_complete.json
@@ -159,6 +159,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -191,6 +192,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -223,6 +225,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -255,6 +258,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -287,6 +291,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -353,27 +358,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -386,98 +424,255 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": ["", "1.5"],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["true"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16"],
-    "teslamate/cars/$car/charger_phases": ["", "3"],
-    "teslamate/cars/$car/charger_power": ["", "11", "0"],
-    "teslamate/cars/$car/charger_voltage": ["", "230"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "",
+      "1.5"
+    ],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "true"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16"
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3"
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0"
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230"
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Charging",
       "Complete"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95", "306.58"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34", "322.67"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95",
+      "306.58"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34",
+      "322.67"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24", "314.63"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24",
+      "314.63"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
@@ -485,7 +680,9 @@
       "2024-01-01T00:00:40.000Z",
       "2024-01-01T00:00:40.001000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
     "teslamate/cars/$car/state": [
       "online",
       "charging",
@@ -493,10 +690,20 @@
       "suspended",
       "asleep"
     ],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_already_suspended.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_already_suspended.json
@@ -61,6 +61,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -93,6 +94,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -151,27 +153,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -184,103 +219,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:10.001000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_api_error.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_api_error.json
@@ -60,6 +60,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -101,27 +102,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -134,99 +168,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_asleep.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_asleep.json
@@ -58,27 +58,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -91,70 +124,185 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.001000Z"],
-    "teslamate/cars/$car/state": ["asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""]
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.001000Z"
+    ],
+    "teslamate/cars/$car/state": [
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      ""
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_detects_locking.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_detects_locking.json
@@ -63,6 +63,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -95,6 +96,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -143,27 +145,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -176,103 +211,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:20.000Z",
       "2024-01-01T00:00:20.001000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_doors_open.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_doors_open.json
@@ -60,6 +60,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -118,27 +119,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -151,102 +185,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_downloading_update.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_downloading_update.json
@@ -60,6 +60,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -118,27 +119,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -151,102 +185,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_idle.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_idle.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -90,6 +91,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -148,27 +150,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -181,103 +216,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:10.001000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_incomplete_data.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_incomplete_data.json
@@ -60,6 +60,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -108,27 +109,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -141,102 +175,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:00.004000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_offline.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_offline.json
@@ -58,27 +58,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -91,70 +124,185 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.001000Z"],
-    "teslamate/cars/$car/state": ["offline"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""]
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.001000Z"
+    ],
+    "teslamate/cars/$car/state": [
+      "offline"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      ""
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_preconditioning.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_preconditioning.json
@@ -60,6 +60,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -118,27 +119,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -151,102 +185,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_sentry_mode.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_sentry_mode.json
@@ -60,6 +60,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -118,27 +119,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -151,102 +185,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_shift_d.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_shift_d.json
@@ -119,6 +119,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -151,6 +152,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -183,6 +185,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -215,6 +218,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -247,6 +251,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -305,27 +310,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -338,75 +376,200 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.52", "52.53"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.52",
+      "52.53"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -421,30 +584,79 @@
         "longitude": 13.36
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.36"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44", "16093.76", "16094.24"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "10", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", "P"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.36"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44",
+      "16093.76",
+      "16094.24"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "10",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      "P"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:30.000Z",
       "2024-01-01T00:00:30.002000Z"
     ],
-    "teslamate/cars/$car/speed": ["32", "0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "32",
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_shift_n.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_shift_n.json
@@ -119,6 +119,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -151,6 +152,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -183,6 +185,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -215,6 +218,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -247,6 +251,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -305,27 +310,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -338,75 +376,200 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.52", "52.53"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.52",
+      "52.53"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -421,30 +584,79 @@
         "longitude": 13.36
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.36"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44", "16093.76", "16094.24"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "10", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "N", "P"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.36"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44",
+      "16093.76",
+      "16094.24"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "10",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "N",
+      "P"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:30.000Z",
       "2024-01-01T00:00:30.002000Z"
     ],
-    "teslamate/cars/$car/speed": ["32", "0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "32",
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_shift_r.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_shift_r.json
@@ -119,6 +119,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -151,6 +152,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -183,6 +185,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -215,6 +218,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -247,6 +251,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -305,27 +310,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -338,75 +376,200 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.52", "52.53"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.52",
+      "52.53"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -421,30 +584,79 @@
         "longitude": 13.36
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.36"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44", "16093.76", "16094.24"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "10", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "R", "P"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.36"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44",
+      "16093.76",
+      "16094.24"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "10",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "R",
+      "P"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:30.000Z",
       "2024-01-01T00:00:30.002000Z"
     ],
-    "teslamate/cars/$car/speed": ["32", "0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "32",
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_trunk_open.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_trunk_open.json
@@ -60,6 +60,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -118,27 +119,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -151,102 +185,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_unlocked.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_unlocked.json
@@ -60,6 +60,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -118,27 +119,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -151,102 +185,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_user_present.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_user_present.json
@@ -60,6 +60,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -118,27 +119,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -151,102 +185,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_while_charging.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_while_charging.json
@@ -161,6 +161,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -193,6 +194,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -225,6 +227,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -257,6 +260,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "322.67",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -323,27 +327,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -356,110 +393,284 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": ["", "0.1"],
-    "teslamate/cars/$car/charge_limit_soc": ["90"],
-    "teslamate/cars/$car/charge_port_door_open": ["true"],
-    "teslamate/cars/$car/charger_actual_current": ["", "16"],
-    "teslamate/cars/$car/charger_phases": ["", "3"],
-    "teslamate/cars/$car/charger_power": ["", "11", "0"],
-    "teslamate/cars/$car/charger_voltage": ["", "230"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "",
+      "0.1"
+    ],
+    "teslamate/cars/$car/charge_limit_soc": [
+      "90"
+    ],
+    "teslamate/cars/$car/charge_port_door_open": [
+      "true"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      "",
+      "16"
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      "",
+      "3"
+    ],
+    "teslamate/cars/$car/charger_power": [
+      "",
+      "11",
+      "0"
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      "",
+      "230"
+    ],
     "teslamate/cars/$car/charging_state": [
       "Disconnected",
       "Charging",
       "Stopped"
     ],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95", "306.58"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34", "322.67"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95",
+      "306.58"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34",
+      "322.67"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false", "true"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24", "314.63"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24",
+      "314.63"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:20.000Z",
       "2024-01-01T00:00:20.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "charging", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "charging",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_while_driving.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_while_driving.json
@@ -119,6 +119,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -151,6 +152,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -183,6 +185,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -215,6 +218,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -247,6 +251,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -305,27 +310,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -338,75 +376,200 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.52", "52.53"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.52",
+      "52.53"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -421,30 +584,79 @@
         "longitude": 13.36
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.36"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44", "16093.76", "16094.24"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "10", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", "P"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.36"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44",
+      "16093.76",
+      "16094.24"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "10",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      "P"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:30.000Z",
       "2024-01-01T00:00:30.002000Z"
     ],
-    "teslamate/cars/$car/speed": ["32", "0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "32",
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspend_logging_while_updating.json
+++ b/test/fixtures/characterization/goldens/suspend_logging_while_updating.json
@@ -60,6 +60,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -92,6 +93,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -165,27 +167,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -198,92 +233,237 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
@@ -296,13 +476,35 @@
         "latest_version": "2019.8.5"
       }
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "updating", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["true", "false"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1", "2019.8.4", "2019.8.5"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "updating",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1",
+      "2019.8.4",
+      "2019.8.5"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspended_inactive_online.json
+++ b/test/fixtures/characterization/goldens/suspended_inactive_online.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -90,6 +91,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -148,27 +150,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -181,103 +216,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:30.001000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspended_resume_logging.json
+++ b/test/fixtures/characterization/goldens/suspended_resume_logging.json
@@ -61,6 +61,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -93,6 +94,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -140,27 +142,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -173,102 +208,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/suspended_stream_usage.json
+++ b/test/fixtures/characterization/goldens/suspended_stream_usage.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -90,6 +91,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -137,27 +139,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -170,102 +205,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/updating_cancel.json
+++ b/test/fixtures/characterization/goldens/updating_cancel.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -126,27 +128,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -159,92 +194,237 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["305.78"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "305.78"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["313.82"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "313.82"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:10.000Z",
@@ -256,14 +436,34 @@
         "latest_version": "2019.8.5"
       }
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "updating", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["true"],
-    "teslamate/cars/$car/update_version": ["2019.8.5"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2019.8.4"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "updating",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "true"
+    ],
+    "teslamate/cars/$car/update_version": [
+      "2019.8.5"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2019.8.4"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/updating_full_cycle.json
+++ b/test/fixtures/characterization/goldens/updating_full_cycle.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -126,27 +128,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -159,92 +194,237 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["305.78"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "305.78"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["313.82"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "313.82"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
@@ -260,14 +440,36 @@
         "latest_version": "2019.8.5"
       }
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "updating", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["true", "false"],
-    "teslamate/cars/$car/update_version": ["2019.8.5"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2019.8.4", "2019.8.5"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "updating",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/update_version": [
+      "2019.8.5"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2019.8.4",
+      "2019.8.5"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/updating_nonempty_status.json
+++ b/test/fixtures/characterization/goldens/updating_nonempty_status.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -126,27 +128,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -159,92 +194,237 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["305.78"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "305.78"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["313.82"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "313.82"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:20.000Z",
@@ -260,14 +440,36 @@
         "latest_version": "2019.8.5"
       }
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "updating", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/update_available": ["true", "false"],
-    "teslamate/cars/$car/update_version": ["2019.8.5"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2019.8.4", "2019.8.5"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "updating",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/update_available": [
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/update_version": [
+      "2019.8.5"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2019.8.4",
+      "2019.8.5"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_asleep_to_offline.json
+++ b/test/fixtures/characterization/goldens/vehicle_asleep_to_offline.json
@@ -60,27 +60,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -93,73 +126,187 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.001000Z",
       "2024-01-01T00:00:00.003000Z"
     ],
-    "teslamate/cars/$car/state": ["asleep", "offline"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""]
+    "teslamate/cars/$car/state": [
+      "asleep",
+      "offline"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      ""
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_eid_changed_restart.json
+++ b/test/fixtures/characterization/goldens/vehicle_eid_changed_restart.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -151,27 +153,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -184,102 +219,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true", "false", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true",
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:20.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_health_api_errors.json
+++ b/test/fixtures/characterization/goldens/vehicle_health_api_errors.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -100,27 +101,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -133,99 +167,261 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true", "false"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_import_complete.json
+++ b/test/fixtures/characterization/goldens/vehicle_import_complete.json
@@ -45,27 +45,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -78,49 +111,131 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
-    "teslamate/cars/$car/healthy": [""]
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      ""
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_in_service_ends_drive.json
+++ b/test/fixtures/characterization/goldens/vehicle_in_service_ends_drive.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -238,27 +241,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -271,75 +307,201 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120", "42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.516", "52.52"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120",
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.516",
+      "52.52"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -354,29 +516,78 @@
         "longitude": 13.36
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.3525", "13.36"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44", "16093.71", "16095.08"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "15", "20"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.3525",
+      "13.36"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44",
+      "16093.71",
+      "16095.08"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "15",
+      "20"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:20.002000Z"
     ],
-    "teslamate/cars/$car/speed": ["13", "129"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "start", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "13",
+      "129"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "start",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_in_service_online.json
+++ b/test/fixtures/characterization/goldens/vehicle_in_service_online.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_offline_to_asleep.json
+++ b/test/fixtures/characterization/goldens/vehicle_offline_to_asleep.json
@@ -60,27 +60,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -93,73 +126,187 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.001000Z",
       "2024-01-01T00:00:00.003000Z"
     ],
-    "teslamate/cars/$car/state": ["offline", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""]
+    "teslamate/cars/$car/state": [
+      "offline",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      ""
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_restore_last_known_values.json
+++ b/test/fixtures/characterization/goldens/vehicle_restore_last_known_values.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "315.06",
         "inside_temp": "20.1",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": false,
         "is_rear_defroster_on": false,
@@ -86,27 +87,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -119,79 +153,200 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["64"],
-    "teslamate/cars/$car/display_name": ["bar"],
-    "teslamate/cars/$car/est_battery_range_km": ["268.07"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["315.06"],
-    "teslamate/cars/$car/inside_temp": ["20.1"],
-    "teslamate/cars/$car/latitude": ["37.889544"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "64"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "bar"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "268.07"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "315.06"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "20.1"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "37.889544"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 37.889544,
         "longitude": 41.128817
       }
     ],
-    "teslamate/cars/$car/longitude": ["41.128817"],
-    "teslamate/cars/$car/model": ["S"],
-    "teslamate/cars/$car/odometer": ["91887.73"],
-    "teslamate/cars/$car/outside_temp": ["16.5"],
-    "teslamate/cars/$car/rated_battery_range_km": ["315.06"],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.001000Z"],
-    "teslamate/cars/$car/state": ["asleep"],
-    "teslamate/cars/$car/trim_badging": ["P100D"],
-    "teslamate/cars/$car/usable_battery_level": ["64"]
+    "teslamate/cars/$car/longitude": [
+      "41.128817"
+    ],
+    "teslamate/cars/$car/model": [
+      "S"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "91887.73"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "16.5"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "315.06"
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.001000Z"
+    ],
+    "teslamate/cars/$car/state": [
+      "asleep"
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "P100D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "64"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_resume_asleep.json
+++ b/test/fixtures/characterization/goldens/vehicle_resume_asleep.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -112,27 +113,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -145,102 +179,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.001000Z",
       "2024-01-01T00:00:00.002Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["asleep", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["", "74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "asleep",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "",
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_resume_asleep_stays_asleep.json
+++ b/test/fixtures/characterization/goldens/vehicle_resume_asleep_stays_asleep.json
@@ -58,27 +58,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -91,70 +124,185 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.001000Z"],
-    "teslamate/cars/$car/state": ["asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""]
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.001000Z"
+    ],
+    "teslamate/cars/$car/state": [
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      ""
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_resume_offline.json
+++ b/test/fixtures/characterization/goldens/vehicle_resume_offline.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -112,27 +113,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -145,102 +179,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.001000Z",
       "2024-01-01T00:00:00.002Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["offline", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["", "74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "offline",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "",
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_resume_online.json
+++ b/test/fixtures/characterization/goldens/vehicle_resume_online.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -105,27 +106,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -138,99 +172,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_settings_change.json
+++ b/test/fixtures/characterization/goldens/vehicle_settings_change.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -90,6 +91,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -138,27 +140,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -171,103 +206,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:01:30.000Z",
       "2024-01-01T00:01:30.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_settings_req_not_unlocked_streaming.json
+++ b/test/fixtures/characterization/goldens/vehicle_settings_req_not_unlocked_streaming.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -105,27 +106,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -138,99 +172,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["false"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "false"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_settings_streaming_off.json
+++ b/test/fixtures/characterization/goldens/vehicle_settings_streaming_off.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -109,27 +110,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -142,99 +176,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_settings_streaming_on.json
+++ b/test/fixtures/characterization/goldens/vehicle_settings_streaming_on.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -105,27 +106,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -138,99 +172,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_signed_out_halt.json
+++ b/test/fixtures/characterization/goldens/vehicle_signed_out_halt.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -100,27 +101,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -133,99 +167,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true", "false"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "start"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "start"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_start_asleep.json
+++ b/test/fixtures/characterization/goldens/vehicle_start_asleep.json
@@ -53,27 +53,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -86,70 +119,185 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.001000Z"],
-    "teslamate/cars/$car/state": ["asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""]
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.001000Z"
+    ],
+    "teslamate/cars/$car/state": [
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      ""
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_start_offline.json
+++ b/test/fixtures/characterization/goldens/vehicle_start_offline.json
@@ -53,27 +53,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -86,70 +119,185 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.001000Z"],
-    "teslamate/cars/$car/state": ["offline"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""]
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.001000Z"
+    ],
+    "teslamate/cars/$car/state": [
+      "offline"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      ""
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_start_online.json
+++ b/test/fixtures/characterization/goldens/vehicle_start_online.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -100,27 +101,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -133,99 +167,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_summary_before_first_response.json
+++ b/test/fixtures/characterization/goldens/vehicle_summary_before_first_response.json
@@ -40,6 +40,7 @@
         "ideal_battery_range_km": null,
         "inside_temp": null,
         "install_perc": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_preconditioning": null,
         "is_user_present": null,
@@ -142,6 +143,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -189,27 +191,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -222,99 +257,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_summary_while_fetching.json
+++ b/test/fixtures/characterization/goldens/vehicle_summary_while_fetching.json
@@ -40,6 +40,7 @@
         "ideal_battery_range_km": 402.34,
         "inside_temp": 18.0,
         "install_perc": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_preconditioning": null,
         "is_user_present": false,
@@ -142,6 +143,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -189,27 +191,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -222,99 +257,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_timeout_errors.json
+++ b/test/fixtures/characterization/goldens/vehicle_timeout_errors.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -100,27 +101,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -133,99 +167,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_unavailable_fallback_asleep.json
+++ b/test/fixtures/characterization/goldens/vehicle_unavailable_fallback_asleep.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -111,27 +112,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -144,102 +178,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:00.004000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_unknown_state_errors.json
+++ b/test/fixtures/characterization/goldens/vehicle_unknown_state_errors.json
@@ -45,27 +45,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -78,69 +111,183 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true", "false"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/state": ["unavailable"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": [""]
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/state": [
+      "unavailable"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      ""
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_version_first_startup.json
+++ b/test/fixtures/characterization/goldens/vehicle_version_first_startup.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -100,27 +101,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -133,99 +167,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["42.42.42.0"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "42.42.42.0"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_version_missed_update.json
+++ b/test/fixtures/characterization/goldens/vehicle_version_missed_update.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -147,27 +149,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -180,103 +215,265 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:00.003000Z",
       "2024-01-01T00:00:20.000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2020.12.5", "2020.12.10"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2020.12.5",
+      "2020.12.10"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_version_nil.json
+++ b/test/fixtures/characterization/goldens/vehicle_version_nil.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -92,27 +93,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -125,98 +159,257 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/goldens/vehicle_version_not_newer.json
+++ b/test/fixtures/characterization/goldens/vehicle_version_not_newer.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -117,6 +119,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -149,6 +152,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -239,27 +243,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -272,92 +309,237 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:00.003000Z",
@@ -368,7 +550,9 @@
       "2024-01-01T00:01:00.000Z",
       "2024-01-01T00:01:00.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
     "teslamate/cars/$car/state": [
       "online",
       "asleep",
@@ -379,15 +563,23 @@
       "online",
       "asleep"
     ],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
     "teslamate/cars/$car/version": [
       "2019.40.10.7",
       "2019.40.10.6",
       "2019.40.2.6",
       "2019.40.9"
     ],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/await.json
+++ b/test/fixtures/characterization/selftest/goldens/await.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -101,27 +102,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -134,102 +168,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:10.000000Z",
       "2024-01-01T00:00:10.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/calls.json
+++ b/test/fixtures/characterization/selftest/goldens/calls.json
@@ -43,6 +43,7 @@
         "ideal_battery_range_km": null,
         "inside_temp": null,
         "install_perc": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_preconditioning": null,
         "is_user_present": null,
@@ -145,6 +146,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -199,27 +201,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -232,102 +267,263 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.001000Z",
       "2024-01-01T00:00:00.002Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["asleep", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["", "74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "asleep",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "",
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/clock.json
+++ b/test/fixtures/characterization/selftest/goldens/clock.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -143,27 +145,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -176,103 +211,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:03:20.000Z",
       "2024-01-01T00:03:20.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/error_event.json
+++ b/test/fixtures/characterization/selftest/goldens/error_event.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:20.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["unavailable", "online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["", "74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:20.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "unavailable",
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "",
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/geofence.json
+++ b/test/fixtures/characterization/selftest/goldens/geofence.json
@@ -66,6 +66,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -107,27 +108,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -140,99 +174,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": ["Selftest Home"],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      "Selftest Home"
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:10.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:10.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/halt.json
+++ b/test/fixtures/characterization/selftest/goldens/halt.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -100,27 +101,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -133,99 +167,262 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true", "false"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "start"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "start"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/interactions.json
+++ b/test/fixtures/characterization/selftest/goldens/interactions.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": "321.87",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": true,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -240,6 +244,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -272,6 +277,7 @@
         "id": "position_6",
         "ideal_battery_range_km": "305.78",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -338,27 +344,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -371,74 +410,202 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["20", "19"],
-    "teslamate/cars/$car/charge_energy_added": ["0.0"],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["289.68", "273.59"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["42"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["321.87", "305.78"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false", "true", "false"],
-    "teslamate/cars/$car/is_user_present": ["false", "true", "false"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "20",
+      "19"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      "0.0"
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "289.68",
+      "273.59"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "42"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "321.87",
+      "305.78"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false",
+      "true",
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false",
+      "true",
+      "false"
+    ],
     "teslamate/cars/$car/latitude": [
       "52.514521",
       "52.516",
@@ -468,7 +635,11 @@
         "longitude": 13.371
       }
     ],
-    "teslamate/cars/$car/locked": ["true", "false", "true"],
+    "teslamate/cars/$car/locked": [
+      "true",
+      "false",
+      "true"
+    ],
     "teslamate/cars/$car/longitude": [
       "13.350144",
       "13.3525",
@@ -476,7 +647,9 @@
       "13.37",
       "13.371"
     ],
-    "teslamate/cars/$car/model": ["3"],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
     "teslamate/cars/$car/odometer": [
       "16093.44",
       "16093.52",
@@ -484,21 +657,45 @@
       "16093.58",
       "16093.6"
     ],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "15", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["305.78", "289.68"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", ""],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "15",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "305.78",
+      "289.68"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:04:11.001Z",
       "2024-01-01T00:04:11.003000Z"
     ],
-    "teslamate/cars/$car/speed": ["48", "32"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
+    "teslamate/cars/$car/speed": [
+      "48",
+      "32"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
     "teslamate/cars/$car/state": [
       "online",
       "driving",
@@ -507,10 +704,21 @@
       "online",
       "asleep"
     ],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["19", "18"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "19",
+      "18"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/kill.json
+++ b/test/fixtures/characterization/selftest/goldens/kill.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -85,6 +86,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -151,27 +153,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -184,102 +219,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true", "false", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true",
+      "false",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:20.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/pipeline.json
+++ b/test/fixtures/characterization/selftest/goldens/pipeline.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,99 +161,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:10.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:10.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/seed.json
+++ b/test/fixtures/characterization/selftest/goldens/seed.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "315.06",
         "inside_temp": "20.1",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": false,
         "is_rear_defroster_on": false,
@@ -86,27 +87,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -119,79 +153,200 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["64"],
-    "teslamate/cars/$car/display_name": ["bar"],
-    "teslamate/cars/$car/est_battery_range_km": ["268.07"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["315.06"],
-    "teslamate/cars/$car/inside_temp": ["20.1"],
-    "teslamate/cars/$car/latitude": ["37.889544"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "64"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "bar"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "268.07"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "315.06"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "20.1"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "37.889544"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 37.889544,
         "longitude": 41.128817
       }
     ],
-    "teslamate/cars/$car/longitude": ["41.128817"],
-    "teslamate/cars/$car/model": ["S"],
-    "teslamate/cars/$car/odometer": ["91887.73"],
-    "teslamate/cars/$car/outside_temp": ["16.5"],
-    "teslamate/cars/$car/rated_battery_range_km": ["315.06"],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.001000Z"],
-    "teslamate/cars/$car/state": ["asleep"],
-    "teslamate/cars/$car/trim_badging": ["P100D"],
-    "teslamate/cars/$car/usable_battery_level": ["64"]
+    "teslamate/cars/$car/longitude": [
+      "41.128817"
+    ],
+    "teslamate/cars/$car/model": [
+      "S"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "91887.73"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "16.5"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "315.06"
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.001000Z"
+    ],
+    "teslamate/cars/$car/state": [
+      "asleep"
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "P100D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "64"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/settings.json
+++ b/test/fixtures/characterization/selftest/goldens/settings.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -90,6 +91,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -138,27 +140,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -171,103 +206,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:01:30.000Z",
       "2024-01-01T00:01:30.002000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/snapshot.json
+++ b/test/fixtures/characterization/selftest/goldens/snapshot.json
@@ -53,6 +53,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -94,27 +95,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -127,75 +161,199 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.6", "52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.6",
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.6,
@@ -206,24 +364,63 @@
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.4", "13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.4",
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/stream.json
+++ b/test/fixtures/characterization/selftest/goldens/stream.json
@@ -112,6 +112,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -144,6 +145,7 @@
         "id": "position_2",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -176,6 +178,7 @@
         "id": "position_3",
         "ideal_battery_range_km": null,
         "inside_temp": null,
+        "is_auto_conditioning_on": null,
         "is_climate_on": null,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -208,6 +211,7 @@
         "id": "position_4",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -240,6 +244,7 @@
         "id": "position_5",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -298,27 +303,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -331,76 +369,204 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/elevation": ["10", "12"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521", "52.6", "52.61"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/elevation": [
+      "10",
+      "12"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521",
+      "52.6",
+      "52.61"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
@@ -415,30 +581,82 @@
         "longitude": 13.41
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144", "13.4", "13.41"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44", "16093.6", "16093.92"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0", "5", "8", "0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": ["", "D", "P"],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144",
+      "13.4",
+      "13.41"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44",
+      "16093.6",
+      "16093.92"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0",
+      "5",
+      "8",
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      "",
+      "D",
+      "P"
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:30.000Z",
       "2024-01-01T00:00:30.002000Z"
     ],
-    "teslamate/cars/$car/speed": ["16", "19", "0"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "driving", "online", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/speed": [
+      "16",
+      "19",
+      "0"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "driving",
+      "online",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/stream_toggle.json
+++ b/test/fixtures/characterization/selftest/goldens/stream_toggle.json
@@ -61,6 +61,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -112,27 +113,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -145,99 +179,260 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["80"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "80"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
-    "teslamate/cars/$car/since": ["2024-01-01T00:00:00.000000Z"],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["79"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
+    "teslamate/cars/$car/since": [
+      "2024-01-01T00:00:00.000000Z"
+    ],
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "79"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/fixtures/characterization/selftest/goldens/suspend.json
+++ b/test/fixtures/characterization/selftest/goldens/suspend.json
@@ -58,6 +58,7 @@
         "id": "position_1",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -90,6 +91,7 @@
         "id": "position_2",
         "ideal_battery_range_km": "402.34",
         "inside_temp": "18.0",
+        "is_auto_conditioning_on": null,
         "is_climate_on": false,
         "is_front_defroster_on": null,
         "is_rear_defroster_on": null,
@@ -148,27 +150,60 @@
     "homeassistant/binary_sensor/teslamate_$car/charge_port_door_open/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/doors_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/frunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/healthy/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_auto_conditioning_on/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/is_climate_on/config": [
+      ""
+    ],
     "homeassistant/binary_sensor/teslamate_$car/is_preconditioning/config": [
       ""
     ],
-    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/locked/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [""],
-    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [""],
-    "homeassistant/device/teslamate_$car/config": [""],
+    "homeassistant/binary_sensor/teslamate_$car/is_user_present/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/locked/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/park_brake/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/plugged_in/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/sentry_mode/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/trunk_open/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/update_available/config": [
+      ""
+    ],
+    "homeassistant/binary_sensor/teslamate_$car/windows_open/config": [
+      ""
+    ],
+    "homeassistant/device/teslamate_$car/config": [
+      ""
+    ],
     "homeassistant/device_tracker/teslamate_$car/active_route_location/config": [
       ""
     ],
-    "homeassistant/device_tracker/teslamate_$car/location/config": [""],
-    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [""],
+    "homeassistant/device_tracker/teslamate_$car/location/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/active_route_destination/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/active_route_distance_to_arrival/config": [
       ""
     ],
@@ -181,103 +216,264 @@
     "homeassistant/sensor/teslamate_$car/active_route_traffic_minutes_delay/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [""],
-    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_phases/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_power/config": [""],
-    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [""],
-    "homeassistant/sensor/teslamate_$car/charging_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/display_name/config": [""],
-    "homeassistant/sensor/teslamate_$car/elevation/config": [""],
-    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/exterior_color/config": [""],
-    "homeassistant/sensor/teslamate_$car/geofence/config": [""],
-    "homeassistant/sensor/teslamate_$car/heading/config": [""],
-    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [""],
-    "homeassistant/sensor/teslamate_$car/inside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/model/config": [""],
-    "homeassistant/sensor/teslamate_$car/odometer/config": [""],
-    "homeassistant/sensor/teslamate_$car/outside_temp/config": [""],
-    "homeassistant/sensor/teslamate_$car/power/config": [""],
-    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [""],
+    "homeassistant/sensor/teslamate_$car/battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_energy_added/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charge_limit_soc/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_actual_current/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_phases/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charger_voltage/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/charging_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/display_name/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/elevation/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/est_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/exterior_color/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/geofence/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/heading/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/ideal_battery_range/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/inside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/model/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/odometer/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/outside_temp/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/power/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/rated_battery_range/config": [
+      ""
+    ],
     "homeassistant/sensor/teslamate_$car/scheduled_charging_start_time/config": [
       ""
     ],
-    "homeassistant/sensor/teslamate_$car/shift_state/config": [""],
-    "homeassistant/sensor/teslamate_$car/since/config": [""],
-    "homeassistant/sensor/teslamate_$car/speed/config": [""],
-    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [""],
-    "homeassistant/sensor/teslamate_$car/state/config": [""],
-    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [""],
-    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [""],
-    "homeassistant/sensor/teslamate_$car/trim_badging/config": [""],
-    "homeassistant/sensor/teslamate_$car/update_version/config": [""],
-    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [""],
-    "homeassistant/sensor/teslamate_$car/version/config": [""],
-    "homeassistant/sensor/teslamate_$car/wheel_type/config": [""],
+    "homeassistant/sensor/teslamate_$car/shift_state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/since/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/speed/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/spoiler_type/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/state/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/time_to_full_charge/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_fr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rl_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/tpms_pressure_rr_psi/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/trim_badging/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/update_version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/usable_battery_level/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/version/config": [
+      ""
+    ],
+    "homeassistant/sensor/teslamate_$car/wheel_type/config": [
+      ""
+    ],
     "teslamate/cars/$car/active_route": [
       {
         "error": "No active route available"
       }
     ],
-    "teslamate/cars/$car/active_route_destination": ["nil"],
-    "teslamate/cars/$car/active_route_latitude": ["nil"],
-    "teslamate/cars/$car/active_route_longitude": ["nil"],
-    "teslamate/cars/$car/battery_level": ["60"],
-    "teslamate/cars/$car/charge_energy_added": [""],
-    "teslamate/cars/$car/charger_actual_current": [""],
-    "teslamate/cars/$car/charger_phases": [""],
-    "teslamate/cars/$car/charger_power": [""],
-    "teslamate/cars/$car/charger_voltage": [""],
-    "teslamate/cars/$car/charging_state": ["Disconnected"],
-    "teslamate/cars/$car/display_name": ["blue"],
-    "teslamate/cars/$car/est_battery_range_km": ["370.95"],
-    "teslamate/cars/$car/exterior_color": ["DeepBlue"],
-    "teslamate/cars/$car/geofence": [""],
-    "teslamate/cars/$car/heading": ["120"],
-    "teslamate/cars/$car/healthy": ["", "true"],
-    "teslamate/cars/$car/ideal_battery_range_km": ["402.34"],
-    "teslamate/cars/$car/inside_temp": ["18.0"],
-    "teslamate/cars/$car/is_climate_on": ["false"],
-    "teslamate/cars/$car/is_user_present": ["false"],
-    "teslamate/cars/$car/latitude": ["52.514521"],
+    "teslamate/cars/$car/active_route_destination": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_latitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/active_route_longitude": [
+      "nil"
+    ],
+    "teslamate/cars/$car/battery_level": [
+      "60"
+    ],
+    "teslamate/cars/$car/charge_energy_added": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_actual_current": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_phases": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_power": [
+      ""
+    ],
+    "teslamate/cars/$car/charger_voltage": [
+      ""
+    ],
+    "teslamate/cars/$car/charging_state": [
+      "Disconnected"
+    ],
+    "teslamate/cars/$car/display_name": [
+      "blue"
+    ],
+    "teslamate/cars/$car/est_battery_range_km": [
+      "370.95"
+    ],
+    "teslamate/cars/$car/exterior_color": [
+      "DeepBlue"
+    ],
+    "teslamate/cars/$car/geofence": [
+      ""
+    ],
+    "teslamate/cars/$car/heading": [
+      "120"
+    ],
+    "teslamate/cars/$car/healthy": [
+      "",
+      "true"
+    ],
+    "teslamate/cars/$car/ideal_battery_range_km": [
+      "402.34"
+    ],
+    "teslamate/cars/$car/inside_temp": [
+      "18.0"
+    ],
+    "teslamate/cars/$car/is_climate_on": [
+      "false"
+    ],
+    "teslamate/cars/$car/is_user_present": [
+      "false"
+    ],
+    "teslamate/cars/$car/latitude": [
+      "52.514521"
+    ],
     "teslamate/cars/$car/location": [
       {
         "latitude": 52.514521,
         "longitude": 13.350144
       }
     ],
-    "teslamate/cars/$car/locked": ["true"],
-    "teslamate/cars/$car/longitude": ["13.350144"],
-    "teslamate/cars/$car/model": ["3"],
-    "teslamate/cars/$car/odometer": ["16093.44"],
-    "teslamate/cars/$car/outside_temp": ["12.5"],
-    "teslamate/cars/$car/plugged_in": ["false"],
-    "teslamate/cars/$car/power": ["0"],
-    "teslamate/cars/$car/rated_battery_range_km": ["386.24"],
-    "teslamate/cars/$car/scheduled_charging_start_time": [""],
-    "teslamate/cars/$car/sentry_mode": ["false"],
-    "teslamate/cars/$car/shift_state": [""],
+    "teslamate/cars/$car/locked": [
+      "true"
+    ],
+    "teslamate/cars/$car/longitude": [
+      "13.350144"
+    ],
+    "teslamate/cars/$car/model": [
+      "3"
+    ],
+    "teslamate/cars/$car/odometer": [
+      "16093.44"
+    ],
+    "teslamate/cars/$car/outside_temp": [
+      "12.5"
+    ],
+    "teslamate/cars/$car/plugged_in": [
+      "false"
+    ],
+    "teslamate/cars/$car/power": [
+      "0"
+    ],
+    "teslamate/cars/$car/rated_battery_range_km": [
+      "386.24"
+    ],
+    "teslamate/cars/$car/scheduled_charging_start_time": [
+      ""
+    ],
+    "teslamate/cars/$car/sentry_mode": [
+      "false"
+    ],
+    "teslamate/cars/$car/shift_state": [
+      ""
+    ],
     "teslamate/cars/$car/since": [
       "2024-01-01T00:00:00.000000Z",
       "2024-01-01T00:00:10.000Z",
       "2024-01-01T00:00:10.001000Z"
     ],
-    "teslamate/cars/$car/spoiler_type": ["None"],
-    "teslamate/cars/$car/state": ["online", "suspended", "asleep"],
-    "teslamate/cars/$car/time_to_full_charge": [""],
-    "teslamate/cars/$car/trim_badging": ["74D"],
-    "teslamate/cars/$car/usable_battery_level": ["59"],
-    "teslamate/cars/$car/version": ["2026.20.1"],
-    "teslamate/cars/$car/wheel_type": ["Pinwheel18"]
+    "teslamate/cars/$car/spoiler_type": [
+      "None"
+    ],
+    "teslamate/cars/$car/state": [
+      "online",
+      "suspended",
+      "asleep"
+    ],
+    "teslamate/cars/$car/time_to_full_charge": [
+      ""
+    ],
+    "teslamate/cars/$car/trim_badging": [
+      "74D"
+    ],
+    "teslamate/cars/$car/usable_battery_level": [
+      "59"
+    ],
+    "teslamate/cars/$car/version": [
+      "2026.20.1"
+    ],
+    "teslamate/cars/$car/wheel_type": [
+      "Pinwheel18"
+    ]
   }
 }

--- a/test/teslamate/mqtt/pubsub/home_assistant_test.exs
+++ b/test/teslamate/mqtt/pubsub/home_assistant_test.exs
@@ -48,8 +48,8 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     assert publish_opts == [retain: true, qos: 1]
     cleanup_topics = Enum.map(cleanup, &elem(&1, 0))
 
-    assert length(cleanup_topics) == 62
-    assert MapSet.size(MapSet.new(cleanup_topics)) == 62
+    assert length(cleanup_topics) == 63
+    assert MapSet.size(MapSet.new(cleanup_topics)) == 63
     assert Enum.all?(cleanup, &match?({_topic, "", [retain: true, qos: 1]}, &1))
 
     removed_update_available_topic =
@@ -120,7 +120,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     :ok = HomeAssistant.migrate(@summary, opts, publisher)
     :ok = HomeAssistant.migrate(@summary, opts, publisher)
 
-    [first, second] = receive_configs() |> Enum.chunk_every(63)
+    [first, second] = receive_configs() |> Enum.chunk_every(64)
 
     assert {"homeassistant/device/teslamate_0/config", first_payload, [retain: true, qos: 1]} =
              List.last(first)
@@ -587,6 +587,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
       {"frunk_open", "Frunk", "door", "mdi:car"},
       {"trunk_open", "Trunk", "door", "mdi:car"},
       {"is_climate_on", "Climate", "running", "mdi:air-conditioner"},
+      {"is_auto_conditioning_on", "Auto Conditioning", "running", "mdi:fan-auto"},
       {"is_preconditioning", "Preconditioning", "running", "mdi:air-conditioner"},
       {"is_user_present", "User", "presence", "mdi:human-greeting"},
       {"plugged_in", "Plug", "plug", "mdi:ev-station"},
@@ -1032,8 +1033,8 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
 
     assert device_topic == "homeassistant/device/teslamate_0/config"
     assert publish_opts == [retain: true, qos: 1]
-    assert length(legacy_cleanup) == 62
-    assert legacy_cleanup |> Enum.map(&elem(&1, 0)) |> MapSet.new() |> MapSet.size() == 62
+    assert length(legacy_cleanup) == 63
+    assert legacy_cleanup |> Enum.map(&elem(&1, 0)) |> MapSet.new() |> MapSet.size() == 63
     assert Enum.all?(legacy_cleanup, &match?({_topic, "", [retain: true, qos: 1]}, &1))
 
     assert Enum.any?(legacy_cleanup, fn {topic, _, _} ->
@@ -1086,7 +1087,7 @@ defmodule TeslaMate.Mqtt.PubSub.HomeAssistantTest do
     messages = receive_configs()
     {cleanup, [{^device_topic, payload, [retain: true, qos: 1]}]} = Enum.split(messages, -1)
 
-    assert length(cleanup) == 62
+    assert length(cleanup) == 63
     assert Enum.all?(cleanup, &match?({_topic, "", [retain: true, qos: 1]}, &1))
 
     assert Jason.decode!(payload)["components"]["display_name"]["enabled_by_default"] ==


### PR DESCRIPTION
## Summary

Tesla's `vehicle_data` already returns `is_auto_conditioning_on` under `climate_state`, and `TeslaApi.Vehicle.State.Climate` already parses it — but it was never wired further into `Position`, the MQTT publisher, or Home Assistant discovery, so it has stayed inert since the field was added to the struct. Requested in #4157 (Aug 2024), no follow-up since.

This distinguishes full **Auto** climate (compressor/heat pump actively regulating) from **manual fan-only** operation, which isn't observable today: the existing `is_climate_on` flag is `true` in both cases, so any automation built on it (e.g. "turn climate off when a window opens to save energy") can't tell a compressor-driven session from someone just running the fan manually to save power — and can't avoid overriding a deliberate manual choice back into Auto.

## Changes

- `TeslaMate.Log.Position`: new `is_auto_conditioning_on` column + changeset field
- `TeslaMate.Vehicles.Vehicle`: populate it from `climate_state` on every position write, same as `is_climate_on`
- `TeslaMate.Vehicles.Vehicle.Summary`: new field, populated the same way
- MQTT: published as a simple value (`teslamate/cars/<id>/is_auto_conditioning_on`)
- Home Assistant: new `binary_sensor` discovery entry, mirroring `is_climate_on`'s icon/device_class conventions
- Migration adds the column (`alter table positions`)

## Testing

- `mix compile --warnings-as-errors`: clean
- `mix test` against a real Postgres (migration included): 243 tests, 0 failures
- Characterization goldens re-recorded (`CHARACTERIZATION_RECORD=all`); diffed every changed fixture by hand — the only content change across all 153 fixtures is the new field (always `null`, since no existing scenario input sets it) and the new discovery topic entry, plus incidental JSON pretty-printer re-wrapping of unrelated array literals once the containing object grew a key. No other behavioral drift.
- Bumped the three hardcoded discovery-entity-count assertions in `home_assistant_test.exs` (62→63, chunk_every(63)→64) to account for the one new entity, and added the new sensor to the "aligns vehicle status binary sensors" expectation list.

Happy to adjust naming/icon/device_class or split the HA discovery entry into a follow-up if preferred.

Closes #4157